### PR TITLE
Improve error message when executing a project-local bin

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -27,6 +27,7 @@ pub enum ErrorDetails {
         new_package: String,
     },
 
+    /// Thrown when executing an external binary fails
     BinaryExecError,
 
     /// Thrown when a binary could not be found in the local inventory
@@ -84,9 +85,6 @@ pub enum ErrorDetails {
     DeleteFileError {
         file: String,
     },
-
-    /// Thrown when reading dependency package info fails
-    DepPackageReadError,
 
     DeprecatedCommandError {
         command: String,
@@ -263,6 +261,11 @@ pub enum ErrorDetails {
     /// Thrown when unable to parse a tool spec (`<tool>[@<version>]`)
     ParseToolSpecError {
         tool_spec: String,
+    },
+
+    /// Thrown when executing a project-local binary fails
+    ProjectLocalBinaryExecError {
+        command: String,
     },
 
     /// Thrown when a publish hook contains both the url and bin fields
@@ -547,12 +550,6 @@ at {}
 
 {}",
                 file, PERMISSIONS_CTA
-            ),
-            ErrorDetails::DepPackageReadError => write!(
-                f,
-                "Could not read package info for dependencies.
-
-Please ensure that all dependencies have been installed."
             ),
             ErrorDetails::DeprecatedCommandError { command, advice } => {
                 write!(f, "The subcommand `{}` is deprecated.\n{}", command, advice)
@@ -879,6 +876,13 @@ Please verify the requested package and version.",
 Please supply a spec in the format `<tool name>[@<version>]`.",
                 tool_spec
             ),
+            ErrorDetails::ProjectLocalBinaryExecError { command } => write!(
+                f,
+                "Could not execute command `{}`
+
+Please ensure that all project dependencies are installed.",
+                command
+            ),
             ErrorDetails::PublishHookBothUrlAndBin => write!(
                 f,
                 "Publish hook configuration includes both hook types.
@@ -1159,7 +1163,6 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::CurrentDirError => ExitCode::EnvironmentError,
             ErrorDetails::DeleteDirectoryError { .. } => ExitCode::FileSystemError,
             ErrorDetails::DeleteFileError { .. } => ExitCode::FileSystemError,
-            ErrorDetails::DepPackageReadError => ExitCode::FileSystemError,
             ErrorDetails::DeprecatedCommandError { .. } => ExitCode::InvalidArguments,
             ErrorDetails::DetermineBinaryLoaderError { .. } => ExitCode::FileSystemError,
             ErrorDetails::DownloadToolNetworkError { .. } => ExitCode::NetworkError,
@@ -1204,6 +1207,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::ParsePackageConfigError => ExitCode::UnknownError,
             ErrorDetails::ParsePackageMetadataError { .. } => ExitCode::UnknownError,
             ErrorDetails::ParsePlatformError => ExitCode::ConfigurationError,
+            ErrorDetails::ProjectLocalBinaryExecError { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::PublishHookBothUrlAndBin => ExitCode::ConfigurationError,
             ErrorDetails::PublishHookNeitherUrlNorBin => ExitCode::ConfigurationError,
             ErrorDetails::ReadBinConfigDirError { .. } => ExitCode::FileSystemError,

--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -268,6 +268,11 @@ pub enum ErrorDetails {
         command: String,
     },
 
+    /// Thrown when a project-local binary could not be found
+    ProjectLocalBinaryNotFound {
+        command: String,
+    },
+
     /// Thrown when a publish hook contains both the url and bin fields
     PublishHookBothUrlAndBin,
 
@@ -878,9 +883,16 @@ Please supply a spec in the format `<tool name>[@<version>]`.",
             ),
             ErrorDetails::ProjectLocalBinaryExecError { command } => write!(
                 f,
-                "Could not execute command `{}`
+                "Could not execute `{}`
 
-Please ensure that all project dependencies are installed.",
+Please ensure you have correct permissions to access the file.",
+                command
+            ),
+            ErrorDetails::ProjectLocalBinaryNotFound { command } => write!(
+                f,
+                "Could not execute `{}`, the file does not exist.
+
+Please ensure that all project dependencies are installed with `npm install` or `yarn install`",
                 command
             ),
             ErrorDetails::PublishHookBothUrlAndBin => write!(
@@ -1208,6 +1220,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::ParsePackageMetadataError { .. } => ExitCode::UnknownError,
             ErrorDetails::ParsePlatformError => ExitCode::ConfigurationError,
             ErrorDetails::ProjectLocalBinaryExecError { .. } => ExitCode::ExecutionFailure,
+            ErrorDetails::ProjectLocalBinaryNotFound { .. } => ExitCode::FileSystemError,
             ErrorDetails::PublishHookBothUrlAndBin => ExitCode::ConfigurationError,
             ErrorDetails::PublishHookNeitherUrlNorBin => ExitCode::ConfigurationError,
             ErrorDetails::ReadBinConfigDirError { .. } => ExitCode::FileSystemError,

--- a/crates/volta-core/src/tool/binary.rs
+++ b/crates/volta-core/src/tool/binary.rs
@@ -4,7 +4,7 @@ use super::ToolCommand;
 use crate::error::ErrorDetails;
 use crate::session::{ActivityKind, Session};
 
-use volta_fail::Fallible;
+use volta_fail::{throw, Fallible};
 
 pub(super) fn command<A>(exe: OsString, args: A, session: &mut Session) -> Fallible<ToolCommand>
 where
@@ -19,6 +19,13 @@ where
             // use the full path to the file
             let mut path_to_bin = project.local_bin_dir();
             path_to_bin.push(&exe);
+
+            if !path_to_bin.is_file() {
+                throw!(ErrorDetails::ProjectLocalBinaryNotFound {
+                    command: path_to_bin.to_string_lossy().to_string(),
+                });
+            }
+
             let path_to_bin = path_to_bin.as_os_str();
 
             // if we're in a pinned project, use the project's platform.

--- a/crates/volta-core/src/tool/binary.rs
+++ b/crates/volta-core/src/tool/binary.rs
@@ -25,14 +25,14 @@ where
             if let Some(ref platform) = project.platform() {
                 let image = platform.checkout(session)?;
                 let path = image.path()?;
-                return Ok(ToolCommand::direct(&path_to_bin, args, &path));
+                return Ok(ToolCommand::project_local(&path_to_bin, args, &path));
             }
 
             // otherwise use the user platform.
             if let Some(ref platform) = session.user_platform()? {
                 let image = platform.checkout(session)?;
                 let path = image.path()?;
-                return Ok(ToolCommand::direct(&path_to_bin, args, &path));
+                return Ok(ToolCommand::project_local(&path_to_bin, args, &path));
             }
 
             // if there's no user platform selected, pass through to existing PATH.


### PR DESCRIPTION
When attempting to execute a project-local tool (e.g. `ember`), if the binary doesn't exist (because, for example, the `node_modules` have not been installed), then the error message is misleading:

```
Could not execute command.

See `volta help install` and `volta help pin` for info about making tools available.
```

The problem, in this case, isn't that the tool hasn't been made available, but rather that executing it failed for some reason (most likely because the file doesn't exist). Update that to instead say:

```
Could not execute command `/path/to/project/node_modules/.bin/ember`

Please ensure that all project dependencies are installed.
```

Which gives information about what command was being run _and_ what the user can do to fix it.

Also removed the `DepPackageReadError`, as we no longer read the dependent package information, so it won't ever be thrown.