### PR TITLE
Fix boot-install latest-version URL

### DIFF
--- a/dev/unix/boot-install.sh
+++ b/dev/unix/boot-install.sh
@@ -6,7 +6,7 @@
 # fetch and install the appropriate build of Volta.
 
 volta_get_latest_release() {
-  curl --silent https://www.volta.sh/latest-version
+  curl --silent https://volta.sh/latest-version
 }
 
 volta_eprintf() {


### PR DESCRIPTION
Remove `www.` from latest-version URL in installer.