### PR TITLE
Support `volta` and `toolchain` keys side by side.

### DIFF
--- a/crates/volta-core/src/manifest/mod.rs
+++ b/crates/volta-core/src/manifest/mod.rs
@@ -42,7 +42,7 @@ impl Manifest {
                 file: package_file.to_string_lossy().to_string(),
             }
         })?;
-        serial.into_manifest()
+        serial.into_manifest(&package_file)
     }
 
     /// Returns a reference to the platform image specified by manifest, if any.

--- a/crates/volta-core/src/manifest/serial.rs
+++ b/crates/volta-core/src/manifest/serial.rs
@@ -359,7 +359,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_package_toolchain() {
+    fn test_package_toolchain_with_volta_key() {
         let package_empty_toolchain = r#"{
             "volta": {
             }
@@ -416,6 +416,69 @@ pub mod tests {
             serde_json::de::from_str(package_node_and_yarn).expect("Could not deserialize string");
         let toolchain_node_and_yarn = manifest_node_and_yarn
             .volta
+            .expect("Did not parse toolchain correctly");
+        assert_eq!(toolchain_node_and_yarn.node, "0.10.5");
+        assert_eq!(toolchain_node_and_yarn.yarn.unwrap(), "1.2.1");
+    }
+
+    #[test]
+    fn test_package_toolchain_with_toolchain_key() {
+        let package_empty_toolchain = r#"{
+            "toolchain": {
+            }
+        }"#;
+        let manifest_empty_toolchain =
+            serde_json::de::from_str::<Manifest>(package_empty_toolchain);
+        assert!(
+            manifest_empty_toolchain.is_err(),
+            "Node must be defined under the 'toolchain' key"
+        );
+
+        let package_node_only = r#"{
+            "toolchain": {
+                "node": "0.11.4"
+            }
+        }"#;
+        let manifest_node_only: Manifest =
+            serde_json::de::from_str(package_node_only).expect("Could not deserialize string");
+        assert_eq!(manifest_node_only.toolchain.unwrap().node, "0.11.4");
+
+        let package_node_npm = r#"{
+            "toolchain": {
+                "node": "0.10.5",
+                "npm": "1.2.18"
+            }
+        }"#;
+        let manifest_node_npm: Manifest =
+            serde_json::de::from_str(package_node_npm).expect("Could not deserialize string");
+        let toolchain_node_npm = manifest_node_npm
+            .toolchain
+            .expect("Did not parse toolchain correctly");
+        assert_eq!(toolchain_node_npm.node, "0.10.5");
+        assert_eq!(toolchain_node_npm.npm.unwrap(), "1.2.18");
+
+        let package_yarn_only = r#"{
+            "toolchain": {
+                "yarn": "1.2.1"
+            }
+        }"#;
+        let manifest_yarn_only = serde_json::de::from_str::<Manifest>(package_yarn_only);
+        assert!(
+            manifest_yarn_only.is_err(),
+            "Node must be defined under the 'toolchain' key"
+        );
+
+        let package_node_and_yarn = r#"{
+            "toolchain": {
+                "node": "0.10.5",
+                "npm": "1.2.18",
+                "yarn": "1.2.1"
+            }
+        }"#;
+        let manifest_node_and_yarn: Manifest =
+            serde_json::de::from_str(package_node_and_yarn).expect("Could not deserialize string");
+        let toolchain_node_and_yarn = manifest_node_and_yarn
+            .toolchain
             .expect("Did not parse toolchain correctly");
         assert_eq!(toolchain_node_and_yarn.node, "0.10.5");
         assert_eq!(toolchain_node_and_yarn.yarn.unwrap(), "1.2.1");

--- a/crates/volta-core/src/manifest/serial.rs
+++ b/crates/volta-core/src/manifest/serial.rs
@@ -378,7 +378,7 @@ pub mod tests {
         }"#;
         let manifest_node_only: Manifest =
             serde_json::de::from_str(package_node_only).expect("Could not deserialize string");
-        assert_eq!(manifest_node_only.toolchain.unwrap().node, "0.11.4");
+        assert_eq!(manifest_node_only.volta.unwrap().node, "0.11.4");
 
         let package_node_npm = r#"{
             "volta": {
@@ -389,7 +389,7 @@ pub mod tests {
         let manifest_node_npm: Manifest =
             serde_json::de::from_str(package_node_npm).expect("Could not deserialize string");
         let toolchain_node_npm = manifest_node_npm
-            .toolchain
+            .volta
             .expect("Did not parse toolchain correctly");
         assert_eq!(toolchain_node_npm.node, "0.10.5");
         assert_eq!(toolchain_node_npm.npm.unwrap(), "1.2.18");
@@ -415,7 +415,7 @@ pub mod tests {
         let manifest_node_and_yarn: Manifest =
             serde_json::de::from_str(package_node_and_yarn).expect("Could not deserialize string");
         let toolchain_node_and_yarn = manifest_node_and_yarn
-            .toolchain
+            .volta
             .expect("Did not parse toolchain correctly");
         assert_eq!(toolchain_node_and_yarn.node, "0.10.5");
         assert_eq!(toolchain_node_and_yarn.yarn.unwrap(), "1.2.1");


### PR DESCRIPTION
- Fixes #432.
- Fixes #433.

<details><summary>deprecation output</summary>

```sh
$ yarn
Volta warning: the `toolchain` key is deprecated and will be removed in a future
               version. Please switch to `volta` instead.
yarn install v1.13.0
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.33s.

$ volta pin yarn@1.15.2
warning: the `toolchain` key is deprecated and will be removed in a future
         version. Please switch to `volta` instead.
success: pinned yarn@1.15.2 in package.json

$ volta pin yarn
warning: this project is configured with both the deprecated `toolchain` key and
         the `volta` key; using the versions specified in `volta`.
success: pinned yarn@1.16.0 in package.json

$ yarn
Volta warning: this project is configured with both the deprecated `toolchain`
               key and the `volta` key; using the versions specified in `volta`.
yarn install v1.16.0
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.28s.

# edit package.json to remove `toolchain`

$ yarn
yarn install v1.16.0
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.34s.
```

</details>

<details><summary>deprecation output screenshot</summary>

<img width="664" alt="actual-output" src="https://user-images.githubusercontent.com/2403023/57720344-e7c4e000-763e-11e9-94e7-44cb6ad56b30.png">

</details>