### PR TITLE
v0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,7 +2219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "volta"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volta"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["David Herman <david.herman@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/volta-cli/volta"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,8 @@
+# Version 0.5.1
+
+- Add per-project hooks configuration in `<PROJECT_ROOT>/.volta/hooks.json` (#411)
+- Support backwards compatibility with `toolchain` key in `package.json` (#434)
+
 # Version 0.5.0
 
 - Rename to Volta: The JavaScript Launcher ⚡️


### PR DESCRIPTION
Decided against calling this a breaking change, since the hooks configuration wasn't documented as part of our public API (but will be with the new format).