### PR TITLE
Clean up a bug in the install script

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -20,7 +20,7 @@ download_release_from_repo() {
   local tmpdir="$3"
 
   local filename="volta-$version-$os_info.tar.gz"
-  local download_file="$download_dir/$filename"
+  local download_file="$tmpdir/$filename"
   local archive_url="$(release_url)/download/v$version/$filename"
 
   curl --progress-bar --show-error --location --fail "$archive_url" --output "$download_file" && echo "$download_file"


### PR DESCRIPTION
The install script is not broken, but the code should be fixed to be more explicit.

Currently, in the `download_release_from_repo()` function, the `$download_dir` variable is passed in, and captured locally in the `$tmpdir` variable. But then `$tmpdir` is never used, and instead `$download_dir` is used (probably a refactoring miss on my part).

It seems like this shouldn't work, because `$download_dir` is a local var in the parent function, BUT the scope of local variables in bash is limited to the function _and any of its children_ (see [here](https://www.tldp.org/LDP/abs/html/localvar.html#FTN.AEN18568)). So this still works, but it works explicitly, which is not great.

All that to say that I changed this to actually use `$tmpdir` inside the function.