### PR TITLE
Prevent printing warnings if stdout is not a tty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2247,6 +2247,7 @@ name = "volta-core"
 version = "0.1.0"
 dependencies = [
  "archive 0.1.0",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmdline_words_parser 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -40,6 +40,7 @@ hex = "0.3.2"
 chrono = "0.4.6"
 validate-npm-package-name = { path = "../validate-npm-package-name" }
 textwrap = "0.11.0"
+atty = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6.0"

--- a/crates/volta-core/src/style.rs
+++ b/crates/volta-core/src/style.rs
@@ -1,5 +1,6 @@
 //! The view layer of Volta, with utilities for styling command-line output.
 use archive::Origin;
+use atty::Stream;
 use console::{style, StyledObject};
 use failure::Fail;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -34,6 +35,11 @@ fn styled_warning_prefix(prefix: &'static str) -> StyledObject<&'static str> {
 }
 
 pub(crate) fn write_warning(message: &str) -> Fallible<()> {
+    // If we're not in a tty, don't write warnings as they could mess up scripts
+    if atty::isnt(Stream::Stdout) {
+        return Ok(());
+    }
+
     // Determine whether we're in a shim context or a Volta context.
     let command = std::env::args_os()
         .next()


### PR DESCRIPTION
Closes #450 

Use the `atty` crate to detect if `stdout` is a TTY or not. If it isn't, then we short-circuit the `write_warning` method to prevent writing warnings when we're being called in a script.