### PR TITLE
Support relative paths for Bin hooks

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -126,8 +126,13 @@ pub enum ErrorDetails {
         bin: String,
     },
 
-    /// Thrown when executing a hook command fails
+    /// Thrown when unable to execute a hook command
     ExecuteHookError {
+        command: String,
+    },
+
+    /// Thrown when a hook command returns a non-zero exit code
+    HookCommandFailed {
         command: String,
     },
 
@@ -136,6 +141,11 @@ pub enum ErrorDetails {
 
     /// Thrown when a hook doesn't contain any of the known fields (prefix, template, or bin)
     HookNoFieldsSpecified,
+
+    /// Thrown when determining the path to a hook fails
+    HookPathError {
+        command: String,
+    },
 
     InvalidHookCommand {
         command: String,
@@ -617,6 +627,13 @@ Please verify your internet connection and ensure the correct version is specifi
 Please ensure that the correct command is specified.",
                 command
             ),
+            ErrorDetails::HookCommandFailed { command } => write!(
+                f,
+                "Hook command '{}' indicated a failure.
+
+Please verify the requested tool and version.",
+                command
+            ),
             ErrorDetails::HookMultipleFieldsSpecified => write!(
                 f,
                 "Hook configuration includes multiple hook types.
@@ -628,6 +645,13 @@ Please include only one of 'bin', 'prefix', or 'template'"
                 "Hook configuration includes no hook types.
 
 Please include one of 'bin', 'prefix', or 'template'"
+            ),
+            ErrorDetails::HookPathError { command } => write!(
+                f,
+                "Could not determine path to hook command: '{}'
+
+Please ensure that the correct command is specified.",
+                command
             ),
             ErrorDetails::InvalidHookCommand { command } => write!(
                 f,
@@ -1234,8 +1258,10 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::ExecutablePathError { .. } => ExitCode::UnknownError,
             ErrorDetails::ExecutablePermissionsError { .. } => ExitCode::FileSystemError,
             ErrorDetails::ExecuteHookError { .. } => ExitCode::ExecutionFailure,
+            ErrorDetails::HookCommandFailed { .. } => ExitCode::ConfigurationError,
             ErrorDetails::HookMultipleFieldsSpecified => ExitCode::ConfigurationError,
             ErrorDetails::HookNoFieldsSpecified => ExitCode::ConfigurationError,
+            ErrorDetails::HookPathError { .. } => ExitCode::ConfigurationError,
             ErrorDetails::InvalidHookCommand { .. } => ExitCode::ExecutableNotFound,
             ErrorDetails::InvalidHookOutput { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::InvalidInvocation { .. } => ExitCode::InvalidArguments,

--- a/crates/volta-core/src/hook/mod.rs
+++ b/crates/volta-core/src/hook/mod.rs
@@ -155,7 +155,9 @@ impl HookConfig {
                 file: file_path.to_path_buf(),
             })?;
 
-        serial.into_hook_config().map(|hooks| Some(hooks))
+        let hooks_path = file_path.parent().unwrap_or(Path::new("/"));
+
+        serial.into_hook_config(hooks_path).map(|hooks| Some(hooks))
     }
 
     /// Returns the per-user hooks, loaded from the filesystem.
@@ -231,33 +233,45 @@ pub mod tests {
 
         assert_eq!(
             node.distro,
-            Some(tool::DistroHook::Bin(
-                "/some/bin/for/node/distro".to_string()
-            ))
+            Some(tool::DistroHook::Bin {
+                bin: "/some/bin/for/node/distro".to_string(),
+                base_path: fixture_dir.clone(),
+            })
         );
         assert_eq!(
             node.latest,
-            Some(tool::MetadataHook::Bin(
-                "/some/bin/for/node/latest".to_string()
-            ))
+            Some(tool::MetadataHook::Bin {
+                bin: "/some/bin/for/node/latest".to_string(),
+                base_path: fixture_dir.clone(),
+            })
         );
         assert_eq!(
             node.index,
-            Some(tool::MetadataHook::Bin(
-                "/some/bin/for/node/index".to_string()
-            ))
+            Some(tool::MetadataHook::Bin {
+                bin: "/some/bin/for/node/index".to_string(),
+                base_path: fixture_dir.clone(),
+            })
         );
         assert_eq!(
             yarn.distro,
-            Some(tool::DistroHook::Bin("/bin/to/yarn/distro".to_string()))
+            Some(tool::DistroHook::Bin {
+                bin: "/bin/to/yarn/distro".to_string(),
+                base_path: fixture_dir.clone(),
+            })
         );
         assert_eq!(
             yarn.latest,
-            Some(tool::MetadataHook::Bin("/bin/to/yarn/latest".to_string()))
+            Some(tool::MetadataHook::Bin {
+                bin: "/bin/to/yarn/latest".to_string(),
+                base_path: fixture_dir.clone(),
+            })
         );
         assert_eq!(
             yarn.index,
-            Some(tool::MetadataHook::Bin("/bin/to/yarn/index".to_string()))
+            Some(tool::MetadataHook::Bin {
+                bin: "/bin/to/yarn/index".to_string(),
+                base_path: fixture_dir.clone(),
+            })
         );
         assert_eq!(
             hooks.events.unwrap().publish,
@@ -359,6 +373,7 @@ pub mod tests {
     #[test]
     fn test_for_dir() {
         let project_dir = fixture_path("hooks/project");
+        let hooks_dir = project_dir.join(".volta");
         let hooks = HookConfig::for_dir(&project_dir)
             .expect("Could not read project hooks.json")
             .expect("Could not find project hooks.json");
@@ -366,21 +381,24 @@ pub mod tests {
 
         assert_eq!(
             node.distro,
-            Some(tool::DistroHook::Bin(
-                "/some/bin/for/node/distro".to_string()
-            ))
+            Some(tool::DistroHook::Bin {
+                bin: "/some/bin/for/node/distro".to_string(),
+                base_path: hooks_dir.clone(),
+            })
         );
         assert_eq!(
             node.latest,
-            Some(tool::MetadataHook::Bin(
-                "/some/bin/for/node/latest".to_string()
-            ))
+            Some(tool::MetadataHook::Bin {
+                bin: "/some/bin/for/node/latest".to_string(),
+                base_path: hooks_dir.clone(),
+            })
         );
         assert_eq!(
             node.index,
-            Some(tool::MetadataHook::Bin(
-                "/some/bin/for/node/index".to_string()
-            ))
+            Some(tool::MetadataHook::Bin {
+                bin: "/some/bin/for/node/index".to_string(),
+                base_path: hooks_dir.clone(),
+            })
         );
         assert_eq!(
             hooks.events.unwrap().publish,
@@ -395,6 +413,7 @@ pub mod tests {
             .unwrap()
             .unwrap();
         let project_dir = fixture_path("hooks/project");
+        let project_hooks_dir = project_dir.join(".volta");
         let project_hooks = HookConfig::for_dir(&project_dir)
             .expect("Could not read project hooks.json")
             .expect("Could not find project hooks.json");
@@ -404,21 +423,24 @@ pub mod tests {
 
         assert_eq!(
             node.distro,
-            Some(tool::DistroHook::Bin(
-                "/some/bin/for/node/distro".to_string()
-            ))
+            Some(tool::DistroHook::Bin {
+                bin: "/some/bin/for/node/distro".to_string(),
+                base_path: project_hooks_dir.clone(),
+            })
         );
         assert_eq!(
             node.latest,
-            Some(tool::MetadataHook::Bin(
-                "/some/bin/for/node/latest".to_string()
-            ))
+            Some(tool::MetadataHook::Bin {
+                bin: "/some/bin/for/node/latest".to_string(),
+                base_path: project_hooks_dir.clone(),
+            })
         );
         assert_eq!(
             node.index,
-            Some(tool::MetadataHook::Bin(
-                "/some/bin/for/node/index".to_string()
-            ))
+            Some(tool::MetadataHook::Bin {
+                bin: "/some/bin/for/node/index".to_string(),
+                base_path: project_hooks_dir.clone(),
+            })
         );
         assert_eq!(
             yarn.distro,

--- a/crates/volta-core/src/hook/tool.rs
+++ b/crates/volta-core/src/hook/tool.rs
@@ -1,6 +1,7 @@
 //! Types representing Volta Tool Hooks.
 
 use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use crate::command::create_command;
@@ -20,20 +21,22 @@ const VERSION_TEMPLATE: &'static str = "{{version}}";
 pub enum DistroHook {
     Prefix(String),
     Template(String),
-    Bin(String),
+    Bin { bin: String, base_path: PathBuf },
 }
 
 impl DistroHook {
     /// Performs resolution of the distro URL based on the given
     /// version and file name
     pub fn resolve(&self, version: &Version, filename: &str) -> Fallible<String> {
-        match self {
-            &DistroHook::Prefix(ref prefix) => Ok(format!("{}{}", prefix, filename)),
-            &DistroHook::Template(ref template) => Ok(template
+        match &self {
+            DistroHook::Prefix(prefix) => Ok(format!("{}{}", prefix, filename)),
+            DistroHook::Template(template) => Ok(template
                 .replace(ARCH_TEMPLATE, ARCH)
                 .replace(OS_TEMPLATE, OS)
                 .replace(VERSION_TEMPLATE, &version.to_string())),
-            &DistroHook::Bin(ref bin) => execute_binary(bin, Some(version.to_string())),
+            DistroHook::Bin { bin, base_path } => {
+                execute_binary(bin, base_path, Some(version.to_string()))
+            }
         }
     }
 }
@@ -43,35 +46,45 @@ impl DistroHook {
 pub enum MetadataHook {
     Prefix(String),
     Template(String),
-    Bin(String),
+    Bin { bin: String, base_path: PathBuf },
 }
 
 impl MetadataHook {
     /// Performs resolution of the metadata URL based on the given default file name
     pub fn resolve(&self, filename: &str) -> Fallible<String> {
-        match self {
-            &MetadataHook::Prefix(ref prefix) => Ok(format!("{}{}", prefix, filename)),
-            &MetadataHook::Template(ref template) => Ok(template
+        match &self {
+            MetadataHook::Prefix(prefix) => Ok(format!("{}{}", prefix, filename)),
+            MetadataHook::Template(template) => Ok(template
                 .replace(ARCH_TEMPLATE, ARCH)
                 .replace(OS_TEMPLATE, OS)),
-            &MetadataHook::Bin(ref bin) => execute_binary(bin, None),
+            MetadataHook::Bin { bin, base_path } => execute_binary(bin, base_path, None),
         }
     }
 }
 
 /// Execute a shell command and return the trimmed stdout from that command
-fn execute_binary(bin: &str, extra_arg: Option<String>) -> Fallible<String> {
+fn execute_binary(bin: &str, base_path: &Path, extra_arg: Option<String>) -> Fallible<String> {
     let mut trimmed = bin.trim().to_string();
     let mut words = trimmed.parse_cmdline_words();
-    let cmd = if let Some(word) = words.next() {
-        word
-    } else {
-        throw!(ErrorDetails::InvalidHookCommand {
-            command: String::from(bin.trim()),
-        })
+    let cmd = match words.next() {
+        Some(word) => {
+            // Treat any path that starts with a '.' as a relative path
+            if word.starts_with('.') {
+                base_path.join(word).canonicalize().with_context(|_| {
+                    ErrorDetails::HookPathError {
+                        command: String::from(word),
+                    }
+                })?
+            } else {
+                PathBuf::from(word)
+            }
+        }
+        None => throw!(ErrorDetails::InvalidHookCommand {
+            command: String::from(bin.trim())
+        }),
     };
-    let mut args: Vec<OsString> = words.map(OsString::from).collect();
 
+    let mut args: Vec<OsString> = words.map(OsString::from).collect();
     if let Some(arg) = extra_arg {
         args.push(OsString::from(arg));
     }
@@ -79,20 +92,27 @@ fn execute_binary(bin: &str, extra_arg: Option<String>) -> Fallible<String> {
     let mut command = create_command(cmd);
     command
         .args(&args)
+        .current_dir(base_path)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null());
+        .stderr(Stdio::inherit());
 
     debug!("Running hook command: {:?}", command);
     let output = command
         .output()
         .with_context(|_| ErrorDetails::ExecuteHookError {
-            command: cmd.to_string(),
+            command: String::from(bin.trim()),
         })?;
+
+    if !output.status.success() {
+        throw!(ErrorDetails::HookCommandFailed {
+            command: String::from(bin.trim()),
+        });
+    }
 
     let url =
         String::from_utf8(output.stdout).with_context(|_| ErrorDetails::InvalidHookOutput {
-            command: cmd.to_string(),
+            command: String::from(bin.trim()),
         })?;
 
     Ok(url.trim().to_string())


### PR DESCRIPTION
Closes #459 

Info
-----
* The Hooks configuration has an option `bin` that allows you to specify a command to run to resolve the hook.
* Currently, that command is run relative to the current directory, so if you specify a relative path in `hooks.json`, it will only work if you are in the correct directory.
* The easiest way to specify hooks will be with a relative path to the script, so we should support this use-case.

Changes
-----
* Updated the hooks deserialization to propagate the base directory that the `hooks.json` file is found in to any `Bin` hooks.
* If the command is detected as being a relative path (if it begins with `.`), then we execute it relative to the base directory found above.
* Added detection for non-zero exit codes, so that if the hook command returns a failure code, we throw a Volta error instead of continuing as if the command succeeded.
* Also updated `stderr` to inherit from the parent process, so that bin hooks can use it to show progress bars or waiting spinners, as well as report errors directly to the user.

Tested
-----
* Verified that a bin hook with a relative path correctly executes anywhere in a project, as opposed to only from a single directory.