### PR TITLE
Fall back to default Yarn if project Yarn is not set

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -768,7 +768,7 @@ Use `volta install` to select a default version of a tool."
             ),
             ErrorDetails::NoUserYarn => write!(
                 f,
-                "Could not determine Yarn version.
+                "Yarn is not available.
 
 Use `volta install yarn` to select a default version (see `volta help install for more info)."
             ),

--- a/crates/volta-core/src/platform/sourced.rs
+++ b/crates/volta-core/src/platform/sourced.rs
@@ -8,8 +8,14 @@ use semver::Version;
 use volta_fail::Fallible;
 
 pub enum Source {
+    /// Represents a Platform that came from the user default
     User,
+
+    /// Represents a Platform that came from a project manifest
     Project,
+
+    /// Represents a Platform that is the result of merging the User and Project platforms
+    ProjectNodeUserYarn,
 }
 
 pub struct SourcedPlatformSpec {
@@ -34,6 +40,13 @@ impl SourcedPlatformSpec {
         SourcedPlatformSpec {
             platform,
             source: Source::User,
+        }
+    }
+
+    pub fn merged(platform: Rc<PlatformSpec>) -> Self {
+        SourcedPlatformSpec {
+            platform,
+            source: Source::ProjectNodeUserYarn,
         }
     }
 

--- a/crates/volta-core/src/platform/sourced.rs
+++ b/crates/volta-core/src/platform/sourced.rs
@@ -9,13 +9,13 @@ use volta_fail::Fallible;
 
 pub enum Source {
     /// Represents a Platform that came from the user default
-    User,
+    Default,
 
     /// Represents a Platform that came from a project manifest
     Project,
 
-    /// Represents a Platform that is the result of merging the User and Project platforms
-    ProjectNodeUserYarn,
+    /// Represents a Platform that is the result of merging the Default and Project platforms
+    ProjectNodeDefaultYarn,
 }
 
 pub struct SourcedPlatformSpec {
@@ -36,17 +36,17 @@ impl SourcedPlatformSpec {
         }
     }
 
-    pub fn user(platform: Rc<PlatformSpec>) -> Self {
+    pub fn default(platform: Rc<PlatformSpec>) -> Self {
         SourcedPlatformSpec {
             platform,
-            source: Source::User,
+            source: Source::Default,
         }
     }
 
     pub fn merged(platform: Rc<PlatformSpec>) -> Self {
         SourcedPlatformSpec {
             platform,
-            source: Source::ProjectNodeUserYarn,
+            source: Source::ProjectNodeDefaultYarn,
         }
     }
 

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -110,7 +110,17 @@ impl Session {
 
     pub fn current_platform(&self) -> Fallible<Option<SourcedPlatformSpec>> {
         if let Some(platform) = self.project_platform()? {
-            Ok(Some(SourcedPlatformSpec::project(platform)))
+            if platform.yarn.is_some() {
+                Ok(Some(SourcedPlatformSpec::project(platform)))
+            } else {
+                let user_yarn = self.user_platform()?.and_then(|p| p.yarn.clone());
+                let merged = Rc::new(PlatformSpec {
+                    node_runtime: platform.node_runtime.clone(),
+                    npm: platform.npm.clone(),
+                    yarn: user_yarn,
+                });
+                Ok(Some(SourcedPlatformSpec::merged(merged)))
+            }
         } else if let Some(platform) = self.user_platform()? {
             Ok(Some(SourcedPlatformSpec::user(platform)))
         } else {

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -122,7 +122,7 @@ impl Session {
                 Ok(Some(SourcedPlatformSpec::merged(merged)))
             }
         } else if let Some(platform) = self.user_platform()? {
-            Ok(Some(SourcedPlatformSpec::user(platform)))
+            Ok(Some(SourcedPlatformSpec::default(platform)))
         } else {
             Ok(None)
         }

--- a/crates/volta-core/src/tool/binary.rs
+++ b/crates/volta-core/src/tool/binary.rs
@@ -38,10 +38,10 @@ where
 
             if let Some(platform) = session.current_platform()? {
                 match platform.source() {
-                    Source::Project | Source::ProjectNodeUserYarn => {
+                    Source::Project | Source::ProjectNodeDefaultYarn => {
                         debug!("Using node@{} from project configuration", platform.node())
                     }
-                    Source::User => {
+                    Source::Default => {
                         debug!("Using node@{} from default configuration", platform.node())
                     }
                 };

--- a/crates/volta-core/src/tool/binary.rs
+++ b/crates/volta-core/src/tool/binary.rs
@@ -38,7 +38,7 @@ where
 
             if let Some(platform) = session.current_platform()? {
                 match platform.source() {
-                    Source::Project => {
+                    Source::Project | Source::ProjectNodeUserYarn => {
                         debug!("Using node@{} from project configuration", platform.node())
                     }
                     Source::User => {

--- a/crates/volta-core/src/tool/node.rs
+++ b/crates/volta-core/src/tool/node.rs
@@ -18,8 +18,8 @@ where
     match session.current_platform()? {
         Some(platform) => {
             let source = match platform.source() {
-                Source::Project | Source::ProjectNodeUserYarn => "project",
-                Source::User => "default",
+                Source::Project | Source::ProjectNodeDefaultYarn => "project",
+                Source::Default => "default",
             };
             let version = tool_version("node", platform.node());
             debug!("Using {} from {} configuration", version, source);

--- a/crates/volta-core/src/tool/node.rs
+++ b/crates/volta-core/src/tool/node.rs
@@ -18,7 +18,7 @@ where
     match session.current_platform()? {
         Some(platform) => {
             let source = match platform.source() {
-                Source::Project => "project",
+                Source::Project | Source::ProjectNodeUserYarn => "project",
                 Source::User => "default",
             };
             let version = tool_version("node", platform.node());

--- a/crates/volta-core/src/tool/npm.rs
+++ b/crates/volta-core/src/tool/npm.rs
@@ -27,8 +27,8 @@ where
             let path = image.path()?;
 
             let source = match image.source() {
-                Source::Project | Source::ProjectNodeUserYarn => "project",
-                Source::User => "default",
+                Source::Project | Source::ProjectNodeDefaultYarn => "project",
+                Source::Default => "default",
             };
             let version = tool_version("npm", &image.node().npm);
             debug!("Using {} from {} configuration", version, source);

--- a/crates/volta-core/src/tool/npm.rs
+++ b/crates/volta-core/src/tool/npm.rs
@@ -27,7 +27,7 @@ where
             let path = image.path()?;
 
             let source = match image.source() {
-                Source::Project => "project",
+                Source::Project | Source::ProjectNodeUserYarn => "project",
                 Source::User => "default",
             };
             let version = tool_version("npm", &image.node().npm);

--- a/crates/volta-core/src/tool/npx.rs
+++ b/crates/volta-core/src/tool/npx.rs
@@ -25,8 +25,8 @@ where
             let required_npm = VersionSpec::parse_version("5.2.0")?;
             if image.node().npm >= required_npm {
                 let source = match image.source() {
-                    Source::Project | Source::ProjectNodeUserYarn => "project",
-                    Source::User => "default",
+                    Source::Project | Source::ProjectNodeDefaultYarn => "project",
+                    Source::Default => "default",
                 };
                 let version = tool_version("npx", &image.node().npm);
                 debug!("Using {} from {} configuration", version, source);

--- a/crates/volta-core/src/tool/npx.rs
+++ b/crates/volta-core/src/tool/npx.rs
@@ -25,7 +25,7 @@ where
             let required_npm = VersionSpec::parse_version("5.2.0")?;
             if image.node().npm >= required_npm {
                 let source = match image.source() {
-                    Source::Project => "project",
+                    Source::Project | Source::ProjectNodeUserYarn => "project",
                     Source::User => "default",
                 };
                 let version = tool_version("npx", &image.node().npm);

--- a/crates/volta-core/src/tool/yarn.rs
+++ b/crates/volta-core/src/tool/yarn.rs
@@ -27,7 +27,7 @@ where
             // Note: If we've gotten this far, we know there is a yarn version set
             let source = match platform.source() {
                 Source::Project => "project",
-                Source::User | Source::ProjectNodeUserYarn => "default",
+                Source::Default | Source::ProjectNodeDefaultYarn => "default",
             };
             let version = tool_version("yarn", platform.yarn().unwrap());
             debug!("Using {} from {} configuration", version, source);
@@ -49,10 +49,10 @@ fn get_yarn_platform(session: &mut Session) -> Fallible<Option<SourcedPlatformSp
         Some(platform) => match platform.yarn() {
             Some(_) => Ok(Some(platform)),
             None => match platform.source() {
-                Source::Project | Source::ProjectNodeUserYarn => {
+                Source::Project | Source::ProjectNodeDefaultYarn => {
                     Err(ErrorDetails::NoProjectYarn.into())
                 }
-                Source::User => Err(ErrorDetails::NoUserYarn.into()),
+                Source::Default => Err(ErrorDetails::NoUserYarn.into()),
             },
         },
         None => Ok(None),

--- a/crates/volta-core/src/tool/yarn.rs
+++ b/crates/volta-core/src/tool/yarn.rs
@@ -27,7 +27,7 @@ where
             // Note: If we've gotten this far, we know there is a yarn version set
             let source = match platform.source() {
                 Source::Project => "project",
-                Source::User => "default",
+                Source::User | Source::ProjectNodeUserYarn => "default",
             };
             let version = tool_version("yarn", platform.yarn().unwrap());
             debug!("Using {} from {} configuration", version, source);
@@ -49,7 +49,9 @@ fn get_yarn_platform(session: &mut Session) -> Fallible<Option<SourcedPlatformSp
         Some(platform) => match platform.yarn() {
             Some(_) => Ok(Some(platform)),
             None => match platform.source() {
-                Source::Project => Err(ErrorDetails::NoProjectYarn.into()),
+                Source::Project | Source::ProjectNodeUserYarn => {
+                    Err(ErrorDetails::NoProjectYarn.into())
+                }
                 Source::User => Err(ErrorDetails::NoUserYarn.into()),
             },
         },

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -3,6 +3,7 @@ mod support;
 // test files
 
 mod intercept_global_installs;
+mod merged_platform;
 mod verbose_errors;
 mod volta_current;
 mod volta_deactivate;

--- a/tests/acceptance/merged_platform.rs
+++ b/tests/acceptance/merged_platform.rs
@@ -1,0 +1,116 @@
+use crate::support::sandbox::sandbox;
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+use volta_fail::ExitCode;
+
+const PACKAGE_JSON_WITH_YARN: &'static str = r#"{
+    "name": "with-yarn",
+    "volta": {
+        "node": "10.22.123",
+        "yarn": "4.55.633"
+    }
+}"#;
+
+const PACKAGE_JSON_NO_YARN: &'static str = r#"{
+    "name": "without-yarn",
+    "volta": {
+        "node": "10.22.123"
+    }
+}"#;
+
+const PLATFORM_WITH_YARN: &'static str = r#"{
+    "node":{
+        "runtime":"9.11.2",
+        "npm":"5.6.0"
+    },
+    "yarn": "1.22.300"
+}"#;
+
+const PLATFORM_NO_YARN: &'static str = r#"{
+    "node":{
+        "runtime":"9.11.2",
+        "npm":"5.6.0"
+    }
+}"#;
+
+#[test]
+fn uses_project_yarn_if_available() {
+    let s = sandbox()
+        .platform(PLATFORM_WITH_YARN)
+        .package_json(PACKAGE_JSON_WITH_YARN)
+        .env("VOLTA_LOGLEVEL", "debug")
+        .build();
+
+    assert_that!(
+        s.yarn("--version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_does_not_contain("[..]Yarn is not available.")
+            .with_stderr_does_not_contain("[..]No Yarn version found in this project.")
+            .with_stdout_contains("[..]Using yarn@4.55.633 from project configuration")
+    );
+}
+
+#[test]
+fn uses_default_yarn_in_project_without_yarn() {
+    let s = sandbox()
+        .platform(PLATFORM_WITH_YARN)
+        .package_json(PACKAGE_JSON_NO_YARN)
+        .env("VOLTA_LOGLEVEL", "debug")
+        .build();
+
+    assert_that!(
+        s.yarn("--version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_does_not_contain("[..]Yarn is not available.")
+            .with_stderr_does_not_contain("[..]No Yarn version found in this project.")
+            .with_stdout_contains("[..]Using yarn@1.22.300 from default configuration")
+    );
+}
+
+#[test]
+fn uses_default_yarn_outside_project() {
+    let s = sandbox()
+        .platform(PLATFORM_WITH_YARN)
+        .env("VOLTA_LOGLEVEL", "debug")
+        .build();
+
+    assert_that!(
+        s.yarn("--version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_does_not_contain("[..]Yarn is not available.")
+            .with_stderr_does_not_contain("[..]No Yarn version found in this project.")
+            .with_stdout_contains("[..]Using yarn@1.22.300 from default configuration")
+    );
+}
+
+#[test]
+fn throws_project_error_in_project() {
+    let s = sandbox()
+        .platform(PLATFORM_NO_YARN)
+        .package_json(PACKAGE_JSON_NO_YARN)
+        .build();
+
+    assert_that!(
+        s.yarn("--version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]No Yarn version found in this project.")
+    );
+}
+
+#[test]
+fn throws_user_error_outside_project() {
+    let s = sandbox().platform(PLATFORM_NO_YARN).build();
+
+    assert_that!(
+        s.yarn("--version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]Yarn is not available.")
+    );
+}


### PR DESCRIPTION
Closes #436 

Info
-----
* Currently, if we have a default yarn set, but the user runs `yarn` within a project that _doesn't_ have yarn specified, then we throw an error and require the user to run `volta pin yarn` to continue.
* This is a poor UX, as the user has already run `volta install yarn`, so we do have a Yarn version available, we are just not using it.
* Additionally, with the command passthrough and other UX improvements, we have taken the approach of setting Volta up to _support_ doing things the "safe" way (e.g. if you use `yarn` in your project, you should specify it there), but not _require_ that they are done that way.
* To align with that goal, we should fall back to the default yarn, even in a project that doesn't have `yarn` specified.

Changes
-----
* Added an additional `platform::Source`: `ProjectNodeUserYarn`, that represents a merged platform.
* Implemented the fall-back logic in `session::current_platform`, so that the fallback is available to any tool (as running other tools could result in running `yarn`, e.g. `ember new --yarn`).
* Updated the tool implementations to account for the new source.

Tested
-----
* Added new acceptance tests to cover the new behavior.