### PR TITLE
Enforce nightly build even if rust is already installed

### DIFF
--- a/ci/build-api-docs.yml
+++ b/ci/build-api-docs.yml
@@ -3,7 +3,11 @@ steps:
       set -e
       curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
       echo "##vso[task.setvariable variable=PATH;]$PATH:$HOME/.cargo/bin"
-    displayName: Install nightly Rust for docs
+    displayName: Install Rust for docs
+
+  - script: |
+      rustup default nightly
+    displayName: Ensure nightly toolchain is the default
 
   - script: |
       cargo doc -p progress-read --no-deps

--- a/ci/install-rust.yml
+++ b/ci/install-rust.yml
@@ -19,6 +19,7 @@ steps:
 
   # All platforms.
   - script: |
+      rustup default stable
       rustc -Vv
       cargo -V
     displayName: Log Rust and Cargo versions


### PR DESCRIPTION
It appears that running `curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly` doesn't change the default toolchain if Rust is already installed. This is causing the docs build to fail because it needs Nightly to use the `#![feature]` attribute.

Added a new step that runs `rustup default nightly` to ensure that the nightly toolchain is always selected as the default.