### PR TITLE
Separate bin manifest parse from regular manifest

### DIFF
--- a/crates/volta-core/src/manifest/mod.rs
+++ b/crates/volta-core/src/manifest/mod.rs
@@ -128,12 +128,10 @@ impl BinManifest {
             file: package_file.to_path_buf(),
         })?;
 
-        let serial: serial::RawBinManifest =
-            serde_json::de::from_reader(file).with_context(|_| {
-                ErrorDetails::PackageParseError {
-                    file: package_file.to_path_buf(),
-                }
-            })?;
-        Ok(serial.into_bin_manifest())
+        serde_json::de::from_reader::<File, serial::RawBinManifest>(file)
+            .with_context(|_| ErrorDetails::PackageParseError {
+                file: package_file.to_path_buf(),
+            })
+            .map(BinManifest::from)
     }
 }

--- a/crates/volta-core/src/manifest/mod.rs
+++ b/crates/volta-core/src/manifest/mod.rs
@@ -23,10 +23,6 @@ pub struct Manifest {
     pub dependencies: HashMap<String, String>,
     /// The `devDependencies` section.
     pub dev_dependencies: HashMap<String, String>,
-    /// The `bin` section, containing a map of binary names to locations.
-    pub bin: HashMap<String, String>,
-    /// The `engines` section, containing a spec of the Node versions that the package works on.
-    pub engines: Option<String>,
 }
 
 impl Manifest {
@@ -48,11 +44,6 @@ impl Manifest {
     /// Returns a reference to the platform image specified by manifest, if any.
     pub fn platform(&self) -> Option<Rc<PlatformSpec>> {
         self.platform.as_ref().map(|p| p.clone())
-    }
-
-    /// Returns a copy of the "engines" specification from the manifest, if any.
-    pub fn engines(&self) -> Option<String> {
-        self.engines.as_ref().map(|e| e.clone())
     }
 
     /// Gets the names of all the direct dependencies in the manifest.
@@ -123,7 +114,26 @@ impl Manifest {
     }
 }
 
-// unit tests
+pub struct BinManifest {
+    /// The `bin` section, containing a map of binary names to locations.
+    pub bin: HashMap<String, String>,
+    /// The `engines` section, containing a spec of the Node versions that the package works on.
+    pub engine: Option<String>,
+}
 
-#[cfg(test)]
-pub mod tests;
+impl BinManifest {
+    pub fn for_dir(project_root: &Path) -> Fallible<Self> {
+        let package_file = project_root.join("package.json");
+        let file = File::open(&package_file).with_context(|_| ErrorDetails::PackageReadError {
+            file: package_file.to_path_buf(),
+        })?;
+
+        let serial: serial::RawBinManifest =
+            serde_json::de::from_reader(file).with_context(|_| {
+                ErrorDetails::PackageParseError {
+                    file: package_file.to_path_buf(),
+                }
+            })?;
+        Ok(serial.into_bin_manifest())
+    }
+}

--- a/crates/volta-core/src/manifest/serial.rs
+++ b/crates/volta-core/src/manifest/serial.rs
@@ -168,15 +168,15 @@ impl Manifest {
     }
 }
 
-impl RawBinManifest {
-    pub fn into_bin_manifest(self) -> super::BinManifest {
+impl From<RawBinManifest> for super::BinManifest {
+    fn from(raw: RawBinManifest) -> Self {
         let mut map = HashMap::new();
-        if let Some(ref bin) = self.bin {
+        if let Some(ref bin) = raw.bin {
             for (name, path) in bin.iter() {
                 // handle case where only the path was given and binary name was unknown
                 if name == "" {
                     // npm uses the package name for the binary in this case
-                    map.insert(self.name.clone().unwrap(), path.clone());
+                    map.insert(raw.name.clone().unwrap(), path.clone());
                 } else {
                     map.insert(name.clone(), path.clone());
                 }
@@ -185,7 +185,7 @@ impl RawBinManifest {
 
         super::BinManifest {
             bin: map,
-            engine: self.engines.map(|e| e.node),
+            engine: raw.engines.map(|e| e.node),
         }
     }
 }


### PR DESCRIPTION
Closes #476 

Info
-----
* Currently the package install logic uses the full project Manifest parser to read the `package.json` and get the `bin` and `engines` information.
* This causes the package install to show a warning when the package being installed has a `toolchain` property.
* Additionally, we are parsing extra fields (`dependencies`, `volta`, etc.) that aren't needed in the package install context.

Changes
-----
* Split `Manifest` into two structs (`Manifest` for the project information and `BinManifest` for the specific information needed when doing a package install).
* Update the deserialization logic to reflect the split in behavior.
* Switch package install process to use the `BinManifest` instead of the `Manifest` object, which removes the code path that shows a warning about `toolchain` existing