### PR TITLE
Download archives to temp file to prevent corrupted state

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -290,6 +290,11 @@ pub enum ErrorDetails {
         tool_spec: String,
     },
 
+    /// Thrown when persisting an archive to the inventory fails
+    PersistInventoryError {
+        tool: String,
+    },
+
     /// Thrown when executing a project-local binary fails
     ProjectLocalBinaryExecError {
         command: String,
@@ -937,6 +942,13 @@ Please verify the requested package and version.",
 Please supply a spec in the format `<tool name>[@<version>]`.",
                 tool_spec
             ),
+            ErrorDetails::PersistInventoryError { tool } => write!(
+                f,
+                "Could not store {} archive in inventory cache
+
+{}",
+                tool, PERMISSIONS_CTA
+            ),
             ErrorDetails::ProjectLocalBinaryExecError { command } => write!(
                 f,
                 "Could not execute `{}`
@@ -1298,6 +1310,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::ParsePackageConfigError => ExitCode::UnknownError,
             ErrorDetails::ParsePackageMetadataError { .. } => ExitCode::UnknownError,
             ErrorDetails::ParsePlatformError => ExitCode::ConfigurationError,
+            ErrorDetails::PersistInventoryError { .. } => ExitCode::FileSystemError,
             ErrorDetails::ProjectLocalBinaryExecError { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::ProjectLocalBinaryNotFound { .. } => ExitCode::FileSystemError,
             ErrorDetails::PublishHookBothUrlAndBin => ExitCode::ConfigurationError,

--- a/tests/acceptance/corrupted_download.rs
+++ b/tests/acceptance/corrupted_download.rs
@@ -1,0 +1,107 @@
+use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, YarnFixture};
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+use volta_fail::ExitCode;
+
+const NODE_VERSION_INFO: &'static str = r#"[
+{"version":"v10.99.1040","npm":"6.2.26","lts": "Dubnium","files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]},
+{"version":"v0.0.1","npm":"0.0.2","lts": "Sure","files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]}
+]
+"#;
+
+const NODE_VERSION_FIXTURES: [DistroMetadata; 2] = [
+    DistroMetadata {
+        version: "0.0.1",
+        compressed_size: 10,
+        uncompressed_size: Some(0x00280000),
+    },
+    DistroMetadata {
+        version: "10.99.1040",
+        compressed_size: 273,
+        uncompressed_size: Some(0x00280000),
+    },
+];
+
+const YARN_VERSION_INFO: &'static str = r#"[
+{"tag_name":"v0.0.1","assets":[{"name":"yarn-v0.0.1.tar.gz"}]},
+{"tag_name":"v1.2.42","assets":[{"name":"yarn-v1.2.42.tar.gz"}]}
+]"#;
+
+const YARN_VERSION_FIXTURES: [DistroMetadata; 2] = [
+    DistroMetadata {
+        version: "0.0.1",
+        compressed_size: 10,
+        uncompressed_size: Some(0x00280000),
+    },
+    DistroMetadata {
+        version: "1.2.42",
+        compressed_size: 174,
+        uncompressed_size: Some(0x00280000),
+    },
+];
+
+#[test]
+fn install_corrupted_node_leaves_inventory_unchanged() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.volta("install node@0.0.1"),
+        execs().with_status(ExitCode::UnknownError as i32)
+    );
+
+    assert!(!s.node_inventory_archive_exists("0.0.1"));
+}
+
+#[test]
+fn install_valid_node_saves_to_inventory() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.volta("install node@10.99.1040"),
+        execs().with_status(ExitCode::Success as i32)
+    );
+
+    assert!(s.node_inventory_archive_exists("10.99.1040"));
+}
+
+#[test]
+fn install_corrupted_yarn_leaves_inventory_unchanged() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.volta("install yarn@0.0.1"),
+        execs().with_status(ExitCode::UnknownError as i32)
+    );
+
+    assert!(!s.yarn_inventory_archive_exists("0.0.1"));
+}
+
+#[test]
+fn install_valid_yarn_saves_to_inventory() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.volta("install yarn@1.2.42"),
+        execs().with_status(ExitCode::Success as i32)
+    );
+
+    assert!(s.yarn_inventory_archive_exists("1.2.42"));
+}

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -2,6 +2,7 @@ mod support;
 
 // test files
 
+mod corrupted_download;
 mod intercept_global_installs;
 mod merged_platform;
 mod verbose_errors;

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -9,7 +9,9 @@ use reqwest::hyper_011::header::HttpDate;
 
 use test_support::{self, ok_or_panic, paths, paths::PathExt, process::ProcessBuilder};
 
-use volta_core::path::{archive_extension, create_file_symlink, ARCH, OS};
+use volta_core::path::{
+    archive_extension, create_file_symlink, node_distro_file_name, yarn_distro_file_name, ARCH, OS,
+};
 
 #[cfg(feature = "mock-network")]
 use mockito::{self, mock, Matcher};
@@ -606,6 +608,18 @@ impl Sandbox {
     }
 
     // check that files in the sandbox exist
+
+    pub fn node_inventory_archive_exists(&self, version: &str) -> bool {
+        node_inventory_dir()
+            .join(node_distro_file_name(version))
+            .exists()
+    }
+
+    pub fn yarn_inventory_archive_exists(&self, version: &str) -> bool {
+        yarn_inventory_dir()
+            .join(yarn_distro_file_name(version))
+            .exists()
+    }
 
     pub fn package_config_exists(name: &str) -> bool {
         package_config_file(name).exists()

--- a/tests/fixtures/node-v0.0.1-darwin-x64.tar.gz
+++ b/tests/fixtures/node-v0.0.1-darwin-x64.tar.gz
@@ -1,0 +1,1 @@
+CORRUPTED

--- a/tests/fixtures/node-v0.0.1-linux-x64.tar.gz
+++ b/tests/fixtures/node-v0.0.1-linux-x64.tar.gz
@@ -1,0 +1,1 @@
+CORRUPTED

--- a/tests/fixtures/node-v0.0.1-win-x64.zip
+++ b/tests/fixtures/node-v0.0.1-win-x64.zip
@@ -1,0 +1,1 @@
+CORRUPTED

--- a/tests/fixtures/node-v0.0.1-win-x86.zip
+++ b/tests/fixtures/node-v0.0.1-win-x86.zip
@@ -1,0 +1,1 @@
+CORRUPTED

--- a/tests/fixtures/yarn-v0.0.1.tar.gz
+++ b/tests/fixtures/yarn-v0.0.1.tar.gz
@@ -1,0 +1,1 @@
+CORRUPTED

--- a/tests/smoke/main.rs
+++ b/tests/smoke/main.rs
@@ -1,15 +1,15 @@
-/// Smoke tests for Volta, that will be run in CI.
-///
-/// To run these locally:
-/// (CAUTION: this will destroy the Volta installation on the system where this is run)
-///
-/// ```
-/// VOLTA_LOGLEVEL=debug cargo test --test smoke --features smoke-tests -- --test-threads 1
-/// ```
-///
-/// Also note that each test uses a different version of node and yarn. This is to prevent
-/// false positives if the tests are not cleaned up correctly. Any new tests should use
-/// different versions of node and yarn.
+// Smoke tests for Volta, that will be run in CI.
+//
+// To run these locally:
+// (CAUTION: this will destroy the Volta installation on the system where this is run)
+//
+// ```
+// VOLTA_LOGLEVEL=debug cargo test --test smoke --features smoke-tests -- --test-threads 1
+// ```
+//
+// Also note that each test uses a different version of node and yarn. This is to prevent
+// false positives if the tests are not cleaned up correctly. Any new tests should use
+// different versions of node and yarn.
 
 cfg_if::cfg_if! {
     if #[cfg(all(unix, feature = "smoke-tests"))] {


### PR DESCRIPTION
Closes #200 
Closes #275 

Info
-----
When downloading Node or Yarn, if the download is interrupted (by the user pressing Ctrl+C, for example) or if the download is corrupted in some way, the Volta internal state gets corrupted. We currently write the archive directly to the cache, so if it is invalid in some way, on subsequent attempts, we continue to try to use that invalid cache.

Changes
-----
* Updated `distro::node` and `distro::yarn` to download the archives into a temp file, and only move that temp file over to the cache location once the fetching and unpacking has completed successfully.

Tested
-----
* Manual testing to verify that interrupting the download of Node or Yarn no longer leaves an incomplete cache file in the inventory directory.
* Manually confirmed that after interrupting the download, a subsequent `volta install node` will succeed, and that `node` is correctly available.
* Added acceptance tests to ensure that if the archive is corrupted, it won't be written to the inventory directory.

Note: This PR doesn't attempt to tackle matching the downloads against the shasum, as that will require additional design to make sure we cover all cases. Opened #497 to cover that functionality.