### PR TITLE
v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,7 +2298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "volta"
-version = "0.5.7"
+version = "0.6.0"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volta"
-version = "0.5.7"
+version = "0.6.0"
 authors = ["David Herman <david.herman@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/volta-cli/volta"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+# Version 0.6.0
+
+- Allow installing 3rd-party binaries from private registries (#469)
+
 # Version 0.5.7
 
 - Prevent corrupting local cache by downloading tools to temp directory (#498)

--- a/dev/rpm/volta.spec
+++ b/dev/rpm/volta.spec
@@ -1,5 +1,5 @@
 Name:           volta
-Version:        0.5.7
+Version:        0.6.0
 Release:        1%{?dist}
 Summary:        The JavaScript Launcher ⚡
 


### PR DESCRIPTION
Weekly release! Breaking change since the package install behavior changed (now requires Node to be available), but no changes to the file layout so no changes needed to the installer.