### PR TITLE
Delegate Ctrl+C handling for shims

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "custom_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1071,6 +1080,18 @@ dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "nix"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2297,6 +2318,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "volta"
 version = "0.6.0"
 dependencies = [
@@ -2331,6 +2357,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmdline_words_parser 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "detect-indent 0.1.0 (git+https://github.com/stefanpenner/detect-indent-rs)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "envoy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2538,6 +2565,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum debug-builders 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0f5d8e3d14cabcb2a8a59d7147289173c6ada77a0bc526f6b85078f941c0cf12"
@@ -2609,6 +2637,7 @@ dependencies = [
 "checksum msdos_time 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "aad9dfe950c057b1bfe9c1f2aa51583a8468ef2a5baba2ebbe06d775efeb7729"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
+"checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "4703ad64153382334aa8db57c637364c322d3372e097840c72000dabdcf6156e"
 "checksum num-bigint 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)" = "e63899ad0da84ce718c14936262a41cee2c79c981fc0a0e7c7beb47d5a07e8c1"
@@ -2746,6 +2775,7 @@ dependencies = [
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum verbatim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bbad0679079b451226e954019b2efac46bafa8f7b1418b953861e864072a97c6"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -46,6 +46,7 @@ validate-npm-package-name = { path = "../validate-npm-package-name" }
 textwrap = "0.11.0"
 atty = "0.2"
 log = { version = "0.4", features = ["std"] }
+ctrlc = "3.1.3"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6.0"

--- a/crates/volta-core/src/lib.rs
+++ b/crates/volta-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod project;
 pub mod session;
 pub mod shell;
 pub mod shim;
+pub mod signal;
 pub mod style;
 pub mod tool;
 pub mod toolchain;

--- a/crates/volta-core/src/signal.rs
+++ b/crates/volta-core/src/signal.rs
@@ -1,0 +1,23 @@
+use std::process::exit;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use log::debug;
+
+static SHIM_HAS_CONTROL: AtomicBool = AtomicBool::new(false);
+const INTERRUPTED_EXIT_CODE: i32 = 130;
+
+pub fn pass_control_to_shim() {
+    SHIM_HAS_CONTROL.store(true, Ordering::SeqCst);
+}
+
+pub fn setup_signal_handler() {
+    let result = ctrlc::set_handler(|| {
+        if !SHIM_HAS_CONTROL.load(Ordering::SeqCst) {
+            exit(INTERRUPTED_EXIT_CODE);
+        }
+    });
+
+    if result.is_err() {
+        debug!("Unable to set Ctrl+C handler, SIGINT will not be handled correctly");
+    }
+}

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -20,6 +20,7 @@ use crate::error::ErrorDetails;
 use crate::path;
 use crate::platform::System;
 use crate::session::Session;
+use crate::signal::pass_control_to_shim;
 use crate::version::VersionSpec;
 
 mod binary;
@@ -296,6 +297,7 @@ impl ToolCommand {
     }
 
     fn exec(mut self) -> Fallible<ExitStatus> {
+        pass_control_to_shim();
         self.command.status().with_context(|_| self.error)
     }
 }

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -1,12 +1,14 @@
 use volta_core::error::report_error;
 use volta_core::log::{LogContext, LogVerbosity, Logger};
 use volta_core::session::{ActivityKind, Session};
+use volta_core::signal::setup_signal_handler;
 use volta_core::tool::execute_tool;
 use volta_fail::ExitCode;
 
 pub fn main() {
     Logger::init(LogContext::Shim, LogVerbosity::Default)
         .expect("Only a single Logger should be initialized");
+    setup_signal_handler();
 
     let mut session = Session::new();
 


### PR DESCRIPTION
Closes #500 

Info
-----
Currently the `Ctrl+C` SIGINT signal is being sent to both the Volta process and the shimmed child process simultaneously. This means that if a shim waits after receiving the SIGINT signal (as in the repro example in #500), Volta will still exit immediately and not wait for the shim.

Changes
-----
* Used the `ctrlc` crate to set a handler for Ctrl+C in the shim executable.
* Handler uses a flag to determine if control has been passed to the shim or not.
    * If it has, the handler does nothing and lets the child process control the flow of the application.
    * If it hasn't, then we are still doing Volta work (perhaps downloading a version of Node), so it exits immediately (the default behavior).
* Added a call to set the flag immediately before running the shim process.

Tested
-----
* Confirmed that the reproduction case in the issue is handled correctly, the process waits for Node to exit before returning control to the user.
* Verified that interrupting the automatic download of a tool still correctly interrupts immediately.
* Tested on both Mac & Windows to ensure that the behavior is accurate cross-platform.