### PR TITLE
Installer - fail fast on unsupported architectures

### DIFF
--- a/dev/unix/tests/install-script.bats
+++ b/dev/unix/tests/install-script.bats
@@ -212,5 +212,39 @@ END_BASH_STRING
   [ "$status" -eq 1 ]
 }
 
+@test "check_architecture" {
+  # Succeeds for local-release and supported arch
+  run check_architecture "local-release" "x86_64"
+  [ "$status" -eq 0 ]
+
+  # Succeeds for local-release and unsupported arch
+  run check_architecture "local-release" "i686"
+  [ "$status" -eq 0 ]
+
+  # Succeeds for local-dev and supported arch
+  run check_architecture "local-dev" "x86_64"
+  [ "$status" -eq 0 ]
+
+  # Succeeds for local-dev and unsupported arch
+  run check_architecture "local-dev" "i686"
+  [ "$status" -eq 0 ]
+
+  # Succeeds for latest and supported arch
+  run check_architecture "latest" "x86_64"
+  [ "$status" -eq 0 ]
+
+  # Fails for latest and unsupported arch
+  run check_architecture "latest" "i686"
+  [ "$status" -ne 0 ]
+
+  # Succeeds for version and supported arch
+  run check_architecture "0.5.0" "x86_64"
+  [ "$status" -eq 0 ]
+
+  # Fails for version and unsupported arch
+  run check_architecture "0.5.0" "i686"
+  [ "$status" -ne 0 ]
+}
+
 
 # TODO: test creating symlinks

--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -553,6 +553,18 @@ install_from_file() {
   tar -xzvf "$archive" -C "$extract_to"
 }
 
+check_architecture() {
+  local version="$1"
+  local arch="$2"
+
+  if [[ "$version" != "local"* ]]; then
+    if [ "$arch" != "x86_64" ]; then
+      error "Sorry! Volta currently only provides pre-built binaries for x86_64 architectures."
+      return 1
+    fi
+  fi
+}
+
 
 # return if sourced (for testing the functions above)
 return 0 2>/dev/null
@@ -593,5 +605,7 @@ do
       ;;
   esac
 done
+
+check_architecture "$version_to_install" "$(uname -m)" || exit 1
 
 install_version "$version_to_install" "$install_dir"


### PR DESCRIPTION
Partially addresses #519 

Info
-----
* We don't currently provide pre-built binaries for Architectures that aren't x86_64.
* The installer, however, only looks at the OS and doesn't consider the architecture, so it is happy to try to install a 64-bit binary on a 32-bit system.
* This binary fails, but it's only once the user attempts to run `volta` that they see the issue.
* We can detect early on that an install won't work, and fail fast with a message to the user.

Changes
-----
* Added a `check_architecture` function to the install script which verifies that the architecture the user is on is supported.
* The function will always succeed if the install is from a local build, since those binaries were built on the current architecture and should work.
* If it's not a local build, then the function will detect any architecture that isn't x86_64 and show an error message.

Tested
-----
* Manually tested the various use-cases to ensure that the error message is shown appropriately.
* Added bats tests for the `check_architecture` function to cover all combinations of successful and unsuccessful behaviors.