### PR TITLE
volta list: fix tool printing logic

### DIFF
--- a/src/command/list/toolchain.rs
+++ b/src/command/list/toolchain.rs
@@ -288,7 +288,7 @@ impl Toolchain {
                 .fold((false, false), |(packages, tools), (kind, ..)| {
                     (
                         packages || kind == &Kind::Package,
-                        tools || kind == &Kind::Package,
+                        tools || kind == &Kind::Tool,
                     )
                 });
 


### PR DESCRIPTION
When checking whether the list of all packages and tools includes tools, check the tools against `Kind::Tool` instead of `Kind::Package`. (Fixes a mistake introduced during the refactor made in 3eb57526.)