### PR TITLE
Update how RPM install works, and auto-create shims along with the home dir layout

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -1119,8 +1119,12 @@ at {}
 {}"#,
                 name, PERMISSIONS_CTA
             ),
-            // TODO: fix this message
-            ErrorDetails::ShimExecutableNotFound => write!(f, "shim executable not found!"),
+            ErrorDetails::ShimExecutableNotFound => write!(
+                f,
+                "Volta shim executable not found!
+
+Please re-install Volta to create the shim file."
+            ),
             // This case does not have a CTA as there is no avenue to allow users to remove built-in shims
             ErrorDetails::ShimRemoveBuiltInError { name } => {
                 write!(f, r#"Cannot remove built-in shim for "{}""#, name)

--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -386,6 +386,9 @@ pub enum ErrorDetails {
         name: String,
     },
 
+    /// Thrown when Volta cannot find the shim executable
+    ShimExecutableNotFound,
+
     /// Thrown when trying to remove a built-in shim (`node`, `yarn`, etc.)
     ShimRemoveBuiltInError {
         name: String,
@@ -1116,6 +1119,8 @@ at {}
 {}"#,
                 name, PERMISSIONS_CTA
             ),
+            // TODO: fix this message
+            ErrorDetails::ShimExecutableNotFound => write!(f, "shim executable not found!"),
             // This case does not have a CTA as there is no avenue to allow users to remove built-in shims
             ErrorDetails::ShimRemoveBuiltInError { name } => {
                 write!(f, r#"Cannot remove built-in shim for "{}""#, name)
@@ -1359,6 +1364,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::RegistryFetchError { .. } => ExitCode::NetworkError,
             ErrorDetails::SetupToolImageError { .. } => ExitCode::FileSystemError,
             ErrorDetails::ShimCreateError { .. } => ExitCode::FileSystemError,
+            ErrorDetails::ShimExecutableNotFound => ExitCode::EnvironmentError,
             ErrorDetails::ShimRemoveBuiltInError { .. } => ExitCode::InvalidArguments,
             ErrorDetails::ShimRemoveError { .. } => ExitCode::FileSystemError,
             ErrorDetails::StringifyBinConfigError => ExitCode::UnknownError,

--- a/crates/volta-core/src/path/mod.rs
+++ b/crates/volta-core/src/path/mod.rs
@@ -46,10 +46,15 @@ pub fn ensure_volta_dirs_exist() -> Fallible<()> {
         ensure_dir_exists(tmp_dir()?)?;
         ensure_dir_exists(log_dir()?)?;
         // also ensure the basic shims exist
-        ensure_shim_exists("node")?;
-        ensure_shim_exists("yarn")?;
-        ensure_shim_exists("npm")?;
-        ensure_shim_exists("npx")?;
+        // this is only for unix until the update process is refactored
+        // (windows stores the location in the Registry, which is not available for the tests)
+        #[cfg(unix)]
+        {
+            ensure_shim_exists("node")?;
+            ensure_shim_exists("yarn")?;
+            ensure_shim_exists("npm")?;
+            ensure_shim_exists("npx")?;
+        }
     }
 
     Ok(())

--- a/crates/volta-core/src/path/mod.rs
+++ b/crates/volta-core/src/path/mod.rs
@@ -7,6 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::error::ErrorDetails;
+use crate::shim;
 use volta_fail::{Fallible, ResultExt};
 
 cfg_if::cfg_if! {
@@ -44,6 +45,10 @@ pub fn ensure_volta_dirs_exist() -> Fallible<()> {
         ensure_dir_exists(user_toolchain_dir()?)?;
         ensure_dir_exists(tmp_dir()?)?;
         ensure_dir_exists(log_dir()?)?;
+        // also ensure the basic shims exist
+        ensure_shim_exists("node")?;
+        ensure_shim_exists("yarn")?;
+        ensure_shim_exists("npm")?;
     }
 
     Ok(())
@@ -51,6 +56,10 @@ pub fn ensure_volta_dirs_exist() -> Fallible<()> {
 
 fn ensure_dir_exists(path: PathBuf) -> Fallible<()> {
     fs::create_dir_all(&path).with_context(|_| ErrorDetails::CreateDirError { dir: path })
+}
+
+fn ensure_shim_exists(shim_name: &str) -> Fallible<shim::ShimResult> {
+    shim::create(shim_name)
 }
 
 pub fn volta_home() -> Fallible<PathBuf> {

--- a/crates/volta-core/src/path/mod.rs
+++ b/crates/volta-core/src/path/mod.rs
@@ -49,6 +49,7 @@ pub fn ensure_volta_dirs_exist() -> Fallible<()> {
         ensure_shim_exists("node")?;
         ensure_shim_exists("yarn")?;
         ensure_shim_exists("npm")?;
+        ensure_shim_exists("npx")?;
     }
 
     Ok(())

--- a/crates/volta-core/src/path/unix.rs
+++ b/crates/volta-core/src/path/unix.rs
@@ -120,7 +120,7 @@ pub fn shim_executable() -> Fallible<PathBuf> {
     // if VOLTA_SHIM is set, try that first
     // (not documented yet, as it's currently only used for testing)
     if let Some(shim_location) = env::var_os("VOLTA_SHIM") {
-        return Ok(Path::new(&shim_location).to_path_buf());
+        return Ok(shim_location.into());
     }
 
     // default location for the shim executable

--- a/crates/volta-core/src/path/unix.rs
+++ b/crates/volta-core/src/path/unix.rs
@@ -114,27 +114,23 @@ pub fn volta_file() -> Fallible<PathBuf> {
     Ok(volta_home()?.join("volta"))
 }
 
+// check that it exists - if not, check some other locations
 pub fn shim_executable() -> Fallible<PathBuf> {
-    // default location for the shim executable (most user installs)
+    // prefer the default location for the shim executable
+    // (this will be the case for the majority of installs)
     let default_shim_executable = volta_home()?.join("shim");
-
-    // TODO: check that it exists - if not, check some other locations
-    // (like what volta_home() does, sorta)
-    //
-    // prefer the default location, if it exists
     if default_shim_executable.exists() {
         return Ok(default_shim_executable);
     }
 
-    // when an RPM is installed as root, the shim will be here (managed installs)
+    // when an RPM is installed as root, the shim will be here for non-root users
+    // (this will be the case for some managed installs)
     let rpm_shim_executable = Path::new("/usr/bin/volta-lib/shim").to_path_buf();
-
     if rpm_shim_executable.exists() {
         return Ok(rpm_shim_executable);
     }
 
-    // TODO: for now
-    Ok(rpm_shim_executable)
+    Err(ErrorDetails::ShimExecutableNotFound.into())
 }
 
 pub fn env_paths() -> Fallible<Vec<PathBuf>> {

--- a/crates/volta-core/src/path/unix.rs
+++ b/crates/volta-core/src/path/unix.rs
@@ -115,9 +115,26 @@ pub fn volta_file() -> Fallible<PathBuf> {
 }
 
 pub fn shim_executable() -> Fallible<PathBuf> {
+    // default location for the shim executable (most user installs)
+    let default_shim_executable = volta_home()?.join("shim");
+
     // TODO: check that it exists - if not, check some other locations
     // (like what volta_home() does, sorta)
-    Ok(volta_home()?.join("shim"))
+    //
+    // prefer the default location, if it exists
+    if default_shim_executable.exists() {
+        return Ok(default_shim_executable);
+    }
+
+    // when an RPM is installed as root, the shim will be here (managed installs)
+    let rpm_shim_executable = Path::new("/usr/bin/volta-lib/shim").to_path_buf();
+
+    if rpm_shim_executable.exists() {
+        return Ok(rpm_shim_executable);
+    }
+
+    // TODO: for now
+    Ok(rpm_shim_executable)
 }
 
 pub fn env_paths() -> Fallible<Vec<PathBuf>> {

--- a/crates/volta-core/src/path/unix.rs
+++ b/crates/volta-core/src/path/unix.rs
@@ -1,6 +1,7 @@
 //! Provides functions for determining the paths of files and directories
 //! in a standard Volta layout in Unix-based operating systems.
 
+use std::env;
 use std::io;
 use std::os::unix;
 use std::path::{Path, PathBuf};
@@ -116,7 +117,13 @@ pub fn volta_file() -> Fallible<PathBuf> {
 
 // check that it exists - if not, check some other locations
 pub fn shim_executable() -> Fallible<PathBuf> {
-    // prefer the default location for the shim executable
+    // if VOLTA_SHIM is set, try that first
+    // (not documented yet, as it's currently only used for testing)
+    if let Some(shim_location) = env::var_os("VOLTA_SHIM") {
+        return Ok(Path::new(&shim_location).to_path_buf());
+    }
+
+    // default location for the shim executable
     // (this will be the case for the majority of installs)
     let default_shim_executable = volta_home()?.join("shim");
     if default_shim_executable.exists() {

--- a/crates/volta-core/src/path/unix.rs
+++ b/crates/volta-core/src/path/unix.rs
@@ -132,7 +132,7 @@ pub fn shim_executable() -> Fallible<PathBuf> {
 
     // when an RPM is installed as root, the shim will be here for non-root users
     // (this will be the case for some managed installs)
-    let rpm_shim_executable = Path::new("/usr/bin/volta-lib/shim").to_path_buf();
+    let rpm_shim_executable = PathBuf::from("/usr/bin/volta-lib/shim");
     if rpm_shim_executable.exists() {
         return Ok(rpm_shim_executable);
     }

--- a/crates/volta-core/src/path/unix.rs
+++ b/crates/volta-core/src/path/unix.rs
@@ -109,11 +109,14 @@ pub fn shim_file(toolname: &str) -> Fallible<PathBuf> {
     Ok(shim_dir()?.join(toolname))
 }
 
+// this is not currently used by anything
 pub fn volta_file() -> Fallible<PathBuf> {
     Ok(volta_home()?.join("volta"))
 }
 
 pub fn shim_executable() -> Fallible<PathBuf> {
+    // TODO: check that it exists - if not, check some other locations
+    // (like what volta_home() does, sorta)
     Ok(volta_home()?.join("shim"))
 }
 

--- a/dev/rpm/build-rpm.sh
+++ b/dev/rpm/build-rpm.sh
@@ -21,7 +21,7 @@ rpmdev-setuptree
 # create a tarball of the repo for the specified version
 # using prefix because the rpmbuild process expects a 'volta-<version>' directory
 # (https://rpm-packaging-guide.github.io/#putting-source-code-into-tarball)
-git archive --format=tar.gz --output=$archive_filename --prefix="volta-${release_version}/" "v${release_version}"
+git archive --format=tar.gz --output=$archive_filename --prefix="volta-${release_version}/" HEAD
 
 # move the archive to the SOURCES dir, after cleaning it up
 # (https://rpm-packaging-guide.github.io/#working-with-spec-files)

--- a/dev/rpm/volta-postinstall.sh
+++ b/dev/rpm/volta-postinstall.sh
@@ -12,7 +12,7 @@ set -e
 # where Volta will be installed
 VOLTA_HOME="$HOME/.volta"
 # where the RPM installed the compiled binaries
-BIN_DIR="/usr/bin/volta"
+BIN_DIR="/usr/bin/volta-lib"
 
 
 # symlink bins in home dir to /usr/bin/volta/{volta,shim}
@@ -21,7 +21,7 @@ create_bin_symlinks() {
 
   info 'Creating' "symlinks to installed binaries"
 
-  local bin_shims=( shim volta )
+  local bin_shims=( shim )
 
   # remove these symlinks or binaries if they exist, and re-link them
   # (using -f so there is no error if the files don't exist)

--- a/dev/rpm/volta.spec
+++ b/dev/rpm/volta.spec
@@ -72,7 +72,7 @@ rm -rf %{_bindir}/%{name}
 %post
 printf '\033[1;32m%12s\033[0m %s\n' "Running" "Volta post-install setup..." 1>&2
 # run this as the user who invoked sudo (not as root, because we're writing to $HOME)
-/bin/su -c %{_bindir}/%{name}/volta-postinstall.sh - $SUDO_USER
+/bin/su -c %{volta_bin_dir}/volta-postinstall.sh - $SUDO_USER
 
 
 # this runs after uninstall

--- a/tests/acceptance/autocreate_home_dir.rs
+++ b/tests/acceptance/autocreate_home_dir.rs
@@ -1,0 +1,72 @@
+use crate::support::sandbox::{sandbox, shim_exe, Sandbox};
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+#[test]
+fn empty_volta_home_is_auto_created() {
+    let s = sandbox()
+        .env("VOLTA_SHIM", &shim_exe().to_string_lossy())
+        .build();
+
+    // clear out the .volta dir
+    s.remove_volta_home();
+
+    // VOLTA_HOME starts out non-existent, with no shims
+    assert!(!Sandbox::dir_exists(".volta"));
+    assert!(!Sandbox::shim_exists("node"));
+
+    // running volta triggers automatic creation
+    assert_that!(s.volta("--version"), execs().with_status(0));
+
+    // home directories should all be created
+    assert!(Sandbox::dir_exists(".volta"));
+    assert!(Sandbox::dir_exists(".volta/bin"));
+    assert!(Sandbox::dir_exists(".volta/cache/node"));
+    assert!(Sandbox::dir_exists(".volta/log"));
+    assert!(Sandbox::dir_exists(".volta/tmp"));
+    assert!(Sandbox::dir_exists(".volta/tools/image/node"));
+    assert!(Sandbox::dir_exists(".volta/tools/image/yarn"));
+    assert!(Sandbox::dir_exists(".volta/tools/inventory/node"));
+    assert!(Sandbox::dir_exists(".volta/tools/inventory/packages"));
+    assert!(Sandbox::dir_exists(".volta/tools/inventory/yarn"));
+    assert!(Sandbox::dir_exists(".volta/tools/user"));
+
+    // shims should all be created
+    assert!(Sandbox::shim_exists("node"));
+    assert!(Sandbox::shim_exists("npm"));
+    assert!(Sandbox::shim_exists("yarn"));
+}
+
+#[test]
+fn existing_volta_home_is_unchanged() {
+    let s = sandbox().build();
+
+    // directories that are already created by the test framework
+    assert!(Sandbox::dir_exists(".volta"));
+    assert!(Sandbox::dir_exists(".volta/cache/node"));
+    assert!(Sandbox::dir_exists(".volta/tmp"));
+    assert!(Sandbox::dir_exists(".volta/tools/inventory/node"));
+    assert!(Sandbox::dir_exists(".volta/tools/inventory/packages"));
+    assert!(Sandbox::dir_exists(".volta/tools/inventory/yarn"));
+
+    // shims do not exist
+    assert!(!Sandbox::shim_exists("node"));
+    assert!(!Sandbox::shim_exists("npm"));
+    assert!(!Sandbox::shim_exists("yarn"));
+
+    // running volta should not create anything else
+    assert_that!(s.volta("--version"), execs().with_status(0));
+
+    // everything should be the same as before running the command
+    assert!(Sandbox::dir_exists(".volta"));
+    assert!(Sandbox::dir_exists(".volta/cache/node"));
+    assert!(Sandbox::dir_exists(".volta/tmp"));
+    assert!(Sandbox::dir_exists(".volta/tools/inventory/node"));
+    assert!(Sandbox::dir_exists(".volta/tools/inventory/packages"));
+    assert!(Sandbox::dir_exists(".volta/tools/inventory/yarn"));
+
+    assert!(!Sandbox::shim_exists("node"));
+    assert!(!Sandbox::shim_exists("npm"));
+    assert!(!Sandbox::shim_exists("yarn"));
+}

--- a/tests/acceptance/autocreate_home_dir.rs
+++ b/tests/acceptance/autocreate_home_dir.rs
@@ -33,10 +33,15 @@ fn empty_volta_home_is_auto_created() {
     assert!(Sandbox::dir_exists(".volta/tools/user"));
 
     // shims should all be created
-    assert!(Sandbox::shim_exists("node"));
-    assert!(Sandbox::shim_exists("yarn"));
-    assert!(Sandbox::shim_exists("npm"));
-    assert!(Sandbox::shim_exists("npx"));
+    // NOTE: this doesn't work in Windows, because the shim directory
+    //       is stored in the Registry, and not accessible
+    #[cfg(unix)]
+    {
+        assert!(Sandbox::shim_exists("node"));
+        assert!(Sandbox::shim_exists("yarn"));
+        assert!(Sandbox::shim_exists("npm"));
+        assert!(Sandbox::shim_exists("npx"));
+    }
 }
 
 #[test]

--- a/tests/acceptance/autocreate_home_dir.rs
+++ b/tests/acceptance/autocreate_home_dir.rs
@@ -34,8 +34,9 @@ fn empty_volta_home_is_auto_created() {
 
     // shims should all be created
     assert!(Sandbox::shim_exists("node"));
-    assert!(Sandbox::shim_exists("npm"));
     assert!(Sandbox::shim_exists("yarn"));
+    assert!(Sandbox::shim_exists("npm"));
+    assert!(Sandbox::shim_exists("npx"));
 }
 
 #[test]
@@ -67,6 +68,7 @@ fn existing_volta_home_is_unchanged() {
     assert!(Sandbox::dir_exists(".volta/tools/inventory/yarn"));
 
     assert!(!Sandbox::shim_exists("node"));
-    assert!(!Sandbox::shim_exists("npm"));
     assert!(!Sandbox::shim_exists("yarn"));
+    assert!(!Sandbox::shim_exists("npm"));
+    assert!(!Sandbox::shim_exists("npx"));
 }

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -2,6 +2,7 @@ mod support;
 
 // test files
 
+mod autocreate_home_dir;
 mod corrupted_download;
 mod intercept_global_installs;
 mod merged_platform;

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -513,6 +513,10 @@ fn user_platform_file() -> PathBuf {
     user_dir().join("platform.json")
 }
 
+fn sandbox_dir(dir_path: &str) -> PathBuf {
+    home_dir().join(dir_path)
+}
+
 pub struct Sandbox {
     root: PathBuf,
     mocks: Vec<mockito::Mock>,
@@ -607,6 +611,10 @@ impl Sandbox {
         fs::read_dir(volta_log_dir()).ok()
     }
 
+    pub fn remove_volta_home(&self) -> () {
+        volta_home().rm_rf();
+    }
+
     // check that files in the sandbox exist
 
     pub fn node_inventory_archive_exists(&self, version: &str) -> bool {
@@ -629,6 +637,9 @@ impl Sandbox {
     }
     pub fn shim_exists(name: &str) -> bool {
         shim_file(name).exists()
+    }
+    pub fn dir_exists(dir_path: &str) -> bool {
+        sandbox_dir(dir_path).exists()
     }
     pub fn package_image_exists(name: &str, version: &str) -> bool {
         let package_img_dir = package_image_dir(name, version);
@@ -679,7 +690,7 @@ fn volta_exe() -> PathBuf {
     cargo_dir().join(format!("volta{}", env::consts::EXE_SUFFIX))
 }
 
-fn shim_exe() -> PathBuf {
+pub fn shim_exe() -> PathBuf {
     cargo_dir().join(format!("shim{}", env::consts::EXE_SUFFIX))
 }
 


### PR DESCRIPTION
## RPM install changes

The `volta` binary is now installed to `/usr/bin`, so it will be available on the PATH after install. For the user who ran the install, everything is still setup in their home dir.

## Shim auto-creation changes

If this was installed by `root` (which seems to be typical in managed environments), then other users will not have `~/.volta/` setup for them. We already had code to create the directory layout if it does not exist, and this adds one more step to also create the base shims (`node`, `npm`, `yarn`). This allows a non-root user to bootstrap `~/.volta` after this has been installed by root.

There are also some changes to where Volta looks for the `shim` executable. I added an option to look in the install location `/usr/bin/volta-lib/shim` for the RPM special case, so non-root users can still create shims that will symlink correctly.

Overall, this is an incremental change that will help us get this in CI, as well as move closer to working with the upcoming upgrade changes.