### PR TITLE
Remove unknown() and is_user_friendly() from VoltaError

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -1382,8 +1382,4 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::YarnVersionNotFound { .. } => ExitCode::NoVersionMatch,
         }
     }
-
-    fn is_user_friendly(&self) -> bool {
-        true
-    }
 }

--- a/crates/volta-fail-derive/src/lib.rs
+++ b/crates/volta-fail-derive/src/lib.rs
@@ -17,7 +17,6 @@ pub fn volta_fail(token_stream: TokenStream) -> TokenStream {
 
     let mut code = Ident::new("UnknownError", Span::call_site());
     let mut code_set = false;
-    let mut is_friendly = Ident::new("true", Span::call_site());
 
     for meta in input.attrs.iter().filter_map(get_volta_fail_meta_items) {
         for item in meta {
@@ -34,15 +33,6 @@ pub fn volta_fail(token_stream: TokenStream) -> TokenStream {
                     if let Lit::Str(s) = &m.lit {
                         code = Ident::new(&s.value(), Span::call_site());
                         code_set = true;
-                    } else {
-                        // Defined, but not a string.
-                        panic!("#[volta_fail()]: 'code' must be a string.");
-                    }
-                }
-
-                Meta(NameValue(ref m)) if m.ident == "friendly" => {
-                    if let Lit::Str(s) = &m.lit {
-                        is_friendly = Ident::new(&s.value(), Span::call_site());
                     } else {
                         // Defined, but not a string.
                         panic!("#[volta_fail()]: 'code' must be a string.");
@@ -68,10 +58,6 @@ pub fn volta_fail(token_stream: TokenStream) -> TokenStream {
         impl VoltaFail for #name {
             fn exit_code(&self) -> ExitCode {
                 ExitCode::#code
-            }
-
-            fn is_user_friendly(&self) -> bool {
-                #is_friendly
             }
         }
     };


### PR DESCRIPTION
Closes #306 

Since the error rework, there is no longer a need to support the `VoltaError::unknown()` and `VoltaError::is_user_friendly()` errors. All errors are now user-friendly, and no unknown errors are used anywhere in the code base.

Additionally, we do still want to have separate crates, which will necessitate having separate error types, so we don't want to remove `volta-fail` entirely (as was originally suggested in #334)