### PR TITLE
Ensure download directory exists for tarballs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs-utils 0.1.0",
  "headers-011 0.1.0",
  "progress-read 0.1.0",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -630,6 +631,13 @@ dependencies = [
 name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fs-utils"
+version = "0.1.0"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "fuchsia-cprng"
@@ -2375,6 +2383,7 @@ dependencies = [
  "envoy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fs-utils 0.1.0",
  "headers-011 0.1.0",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "indicatif 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -13,6 +13,7 @@ headers-011 = { path = "../headers-011" }
 tee = "0.1.0"
 failure = "0.1.1"
 failure_derive = "0.1.1"
+fs-utils = { path = "../fs-utils" }
 progress-read = { path = "../progress-read" }
 verbatim = "0.1"
 cfg-if = "0.1"

--- a/crates/archive/src/tarball.rs
+++ b/crates/archive/src/tarball.rs
@@ -1,12 +1,13 @@
 //! Provides types and functions for fetching and unpacking a Node installation
 //! tarball in Unix operating systems.
 
-use std::fs::{self, File};
+use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 
 use failure::{self, Fail};
 use flate2::read::GzDecoder;
+use fs_utils::ensure_containing_dir_exists;
 use headers_011::Headers011;
 use progress_read::ProgressRead;
 use reqwest;
@@ -28,40 +29,6 @@ pub struct Tarball {
     uncompressed_size: Option<u64>,
     data: Box<Read>,
     origin: Origin,
-}
-
-/// Thrown when the containing directory could not be determined
-#[derive(Fail, Debug)]
-#[fail(display = "Could not determine directory information for {}", path)]
-struct ContainingDirError {
-    path: String,
-}
-
-/// Thrown when the containing directory could not be determined
-#[derive(Fail, Debug)]
-#[fail(display = "Could not create directory {}", dir)]
-struct CreateDirError {
-    dir: String,
-}
-
-/// This creates the parent directory of the input path, assuming the input path is a file.
-pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> Result<(), failure::Error> {
-    path.as_ref()
-        .parent()
-        .ok_or(
-            ContainingDirError {
-                path: path.as_ref().to_string_lossy().to_string(),
-            }
-            .into(),
-        )
-        .and_then(|dir| {
-            fs::create_dir_all(dir).map_err(|_| {
-                CreateDirError {
-                    dir: dir.to_string_lossy().to_string(),
-                }
-                .into()
-            })
-        })
 }
 
 #[derive(Fail, Debug)]

--- a/crates/archive/src/tarball.rs
+++ b/crates/archive/src/tarball.rs
@@ -1,7 +1,7 @@
 //! Provides types and functions for fetching and unpacking a Node installation
 //! tarball in Unix operating systems.
 
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 
@@ -30,10 +30,40 @@ pub struct Tarball {
     origin: Origin,
 }
 
+/// Thrown when the containing directory could not be determined
+#[derive(Fail, Debug)]
+#[fail(display = "Could not determine directory information for {}", path)]
+struct ContainingDirError {
+    path: String,
+}
+
+/// Thrown when the containing directory could not be determined
+#[derive(Fail, Debug)]
+#[fail(display = "Could not create directory {}", dir)]
+struct CreateDirError {
+    dir: String,
+}
+
 #[derive(Fail, Debug)]
 #[fail(display = "HTTP header '{}' not found", header)]
 struct MissingHeaderError {
     header: String,
+}
+
+/// This creates the parent directory of the input path, assuming the input path is a file.
+pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> Result<(), failure::Error> {
+    // TODO: don't know WTF I'm doing with this
+    // path.as_ref()
+    //     .parent()
+    //     .ok_or(Err("some error"))
+    //     .and_then(|dir| fs::create_dir_all(dir))
+    //     .or(Err("another error"))
+    fs::create_dir_all(path.as_ref()).map_err(|_| {
+        CreateDirError {
+            dir: path.as_ref().to_string_lossy().to_string(),
+        }
+        .into()
+    })
 }
 
 /// Determines the length of an HTTP response's content in bytes, using
@@ -82,6 +112,7 @@ impl Tarball {
             false => None,
         };
 
+        ensure_containing_dir_exists(&cache_file)?;
         let file = File::create(cache_file)?;
         let data = Box::new(TeeReader::new(response, file));
 

--- a/crates/archive/src/tarball.rs
+++ b/crates/archive/src/tarball.rs
@@ -44,26 +44,30 @@ struct CreateDirError {
     dir: String,
 }
 
+/// This creates the parent directory of the input path, assuming the input path is a file.
+pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> Result<(), failure::Error> {
+    path.as_ref()
+        .parent()
+        .ok_or(
+            ContainingDirError {
+                path: path.as_ref().to_string_lossy().to_string(),
+            }
+            .into(),
+        )
+        .and_then(|dir| {
+            fs::create_dir_all(dir).map_err(|_| {
+                CreateDirError {
+                    dir: dir.to_string_lossy().to_string(),
+                }
+                .into()
+            })
+        })
+}
+
 #[derive(Fail, Debug)]
 #[fail(display = "HTTP header '{}' not found", header)]
 struct MissingHeaderError {
     header: String,
-}
-
-/// This creates the parent directory of the input path, assuming the input path is a file.
-pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> Result<(), failure::Error> {
-    // TODO: don't know WTF I'm doing with this
-    // path.as_ref()
-    //     .parent()
-    //     .ok_or(Err("some error"))
-    //     .and_then(|dir| fs::create_dir_all(dir))
-    //     .or(Err("another error"))
-    fs::create_dir_all(path.as_ref()).map_err(|_| {
-        CreateDirError {
-            dir: path.as_ref().to_string_lossy().to_string(),
-        }
-        .into()
-    })
 }
 
 /// Determines the length of an HTTP response's content in bytes, using

--- a/crates/fs-utils/Cargo.toml
+++ b/crates/fs-utils/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "fs-utils"
+version = "0.1.0"
+authors = ["Michael Stewart <mikrostew@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+failure = "0.1.1"

--- a/crates/fs-utils/Cargo.toml
+++ b/crates/fs-utils/Cargo.toml
@@ -5,4 +5,3 @@ authors = ["Michael Stewart <mikrostew@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-failure = "0.1.1"

--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -1,0 +1,40 @@
+//! This crate provides utilities for operating on the filesystem.
+
+use std::fs;
+use std::path::Path;
+
+use failure::{self, Fail};
+
+/// Thrown when the containing directory could not be determined
+#[derive(Fail, Debug)]
+#[fail(display = "Could not determine directory information for {}", path)]
+struct ContainingDirError {
+    path: String,
+}
+
+/// Thrown when the containing directory could not be determined
+#[derive(Fail, Debug)]
+#[fail(display = "Could not create directory {}", dir)]
+struct CreateDirError {
+    dir: String,
+}
+
+/// This creates the parent directory of the input path, assuming the input path is a file.
+pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> Result<(), failure::Error> {
+    path.as_ref()
+        .parent()
+        .ok_or(
+            ContainingDirError {
+                path: path.as_ref().to_string_lossy().to_string(),
+            }
+            .into(),
+        )
+        .and_then(|dir| {
+            fs::create_dir_all(dir).map_err(|_| {
+                CreateDirError {
+                    dir: dir.to_string_lossy().to_string(),
+                }
+                .into()
+            })
+        })
+}

--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -1,40 +1,21 @@
 //! This crate provides utilities for operating on the filesystem.
 
 use std::fs;
+use std::io;
 use std::path::Path;
 
-use failure::{self, Fail};
-
-/// Thrown when the containing directory could not be determined
-#[derive(Fail, Debug)]
-#[fail(display = "Could not determine directory information for {}", path)]
-struct ContainingDirError {
-    path: String,
-}
-
-/// Thrown when the containing directory could not be determined
-#[derive(Fail, Debug)]
-#[fail(display = "Could not create directory {}", dir)]
-struct CreateDirError {
-    dir: String,
-}
-
 /// This creates the parent directory of the input path, assuming the input path is a file.
-pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> Result<(), failure::Error> {
+pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> io::Result<()> {
     path.as_ref()
         .parent()
-        .ok_or(
-            ContainingDirError {
-                path: path.as_ref().to_string_lossy().to_string(),
-            }
-            .into(),
-        )
-        .and_then(|dir| {
-            fs::create_dir_all(dir).map_err(|_| {
-                CreateDirError {
-                    dir: dir.to_string_lossy().to_string(),
-                }
-                .into()
-            })
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!(
+                    "Could not determine directory information for {}",
+                    path.as_ref().display()
+                ),
+            )
         })
+        .and_then(|dir| fs::create_dir_all(dir))
 }

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -29,6 +29,7 @@ lazy_static = "1.3.0"
 semver = { git = "https://github.com/mikrostew/semver", branch = "new-parser" }
 cmdline_words_parser = "0.0.2"
 reqwest = { version = "0.9.9", features = ["hyper-011"] }
+fs-utils = { path = "../fs-utils" }
 headers-011 = { path = "../headers-011" }
 cfg-if = "0.1"
 winfolder = "0.1"

--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -534,8 +534,7 @@ Please remove the file or pass `-f` or `--force` to override.",
             ),
             ErrorDetails::ContainingDirError { path } => write!(
                 f,
-                "Could not determine directory information
-for {}
+                "Could not create the containing directory for {}
 
 {}",
                 path.display(),

--- a/crates/volta-core/src/error/reporter.rs
+++ b/crates/volta-core/src/error/reporter.rs
@@ -4,11 +4,11 @@ use std::fs::File;
 use std::io::Write as IoWrite;
 use std::path::PathBuf;
 
-use crate::fs::ensure_containing_dir_exists;
 use crate::path::log_dir;
 use crate::style::format_error_cause;
 use chrono::Local;
 use failure::Error;
+use fs_utils::ensure_containing_dir_exists;
 use log::{debug, error};
 use volta_fail::VoltaError;
 

--- a/crates/volta-core/src/fs.rs
+++ b/crates/volta-core/src/fs.rs
@@ -20,23 +20,6 @@ pub fn touch(path: &Path) -> io::Result<File> {
     File::open(path)
 }
 
-/// This creates the parent directory of the input path, assuming the input path is a file.
-pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> Fallible<()> {
-    path.as_ref()
-        .parent()
-        .ok_or(
-            ErrorDetails::ContainingDirError {
-                path: path.as_ref().to_path_buf(),
-            }
-            .into(),
-        )
-        .and_then(|dir| {
-            fs::create_dir_all(dir).with_context(|_| ErrorDetails::CreateDirError {
-                dir: dir.to_path_buf(),
-            })
-        })
-}
-
 /// This deletes the input directory, if it exists
 pub fn ensure_dir_does_not_exist<P: AsRef<Path>>(path: &P) -> Fallible<()> {
     if path.as_ref().exists() {

--- a/crates/volta-core/src/shell/mod.rs
+++ b/crates/volta-core/src/shell/mod.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use semver::Version;
 
 use crate::error::{CreatePostscriptErrorPath, ErrorDetails};
-use crate::fs::ensure_containing_dir_exists;
+use fs_utils::ensure_containing_dir_exists;
 use volta_fail::{Fallible, ResultExt, VoltaError};
 
 use crate::env;
@@ -29,7 +29,9 @@ pub trait Shell {
 
     fn save_postscript(&self, postscript: &Postscript) -> Fallible<()> {
         let path = self.postscript_path();
-        ensure_containing_dir_exists(&path)?;
+        ensure_containing_dir_exists(&path).with_context(|_| ErrorDetails::ContainingDirError {
+            path: path.to_path_buf(),
+        })?;
         write(path, self.compile_postscript(postscript).as_bytes()).with_context(|_| {
             let in_dir = path
                 .parent()

--- a/crates/volta-core/src/tool/node/fetch.rs
+++ b/crates/volta-core/src/tool/node/fetch.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use super::super::download_tool_error;
 use crate::error::ErrorDetails;
-use crate::fs::{create_staging_dir, create_staging_file, ensure_containing_dir_exists};
+use crate::fs::{create_staging_dir, create_staging_file};
 use crate::hook::ToolHooks;
 use crate::path;
 use crate::style::{progress_bar, tool_version};
@@ -13,6 +13,7 @@ use crate::tool::{self, Node, NodeVersion};
 use crate::version::VersionSpec;
 use archive::{self, Archive};
 use cfg_if::cfg_if;
+use fs_utils::ensure_containing_dir_exists;
 use log::debug;
 use semver::Version;
 use serde::Deserialize;
@@ -54,7 +55,11 @@ pub fn fetch(version: &Version, hooks: Option<&ToolHooks<Node>>) -> Fallible<Nod
     let node_version = unpack_archive(archive, version)?;
 
     if let Some(staging_file) = staging {
-        ensure_containing_dir_exists(&cache_file)?;
+        ensure_containing_dir_exists(&cache_file).with_context(|_| {
+            ErrorDetails::ContainingDirError {
+                path: cache_file.clone(),
+            }
+        })?;
         staging_file
             .persist(cache_file)
             .with_context(|_| ErrorDetails::PersistInventoryError {
@@ -96,7 +101,8 @@ fn unpack_archive(archive: Box<Archive>, version: &Version) -> Fallible<NodeVers
     save_default_npm_version(&version, &npm)?;
 
     let dest = path::node_image_dir(&version_string, &npm.to_string())?;
-    ensure_containing_dir_exists(&dest)?;
+    ensure_containing_dir_exists(&dest)
+        .with_context(|_| ErrorDetails::ContainingDirError { path: dest.clone() })?;
 
     rename(
         temp.path()

--- a/crates/volta-core/src/tool/package/fetch.rs
+++ b/crates/volta-core/src/tool/package/fetch.rs
@@ -6,15 +6,13 @@ use std::path::{Path, PathBuf};
 
 use super::super::download_tool_error;
 use crate::error::ErrorDetails;
-use crate::fs::{
-    create_staging_dir, ensure_containing_dir_exists, ensure_dir_does_not_exist, read_dir_eager,
-    read_file,
-};
+use crate::fs::{create_staging_dir, ensure_dir_does_not_exist, read_dir_eager, read_file};
 use crate::path;
 use crate::style::{progress_bar, tool_version};
 use crate::tool::{self, PackageDetails};
 use crate::version::VersionSpec;
 use archive::{Archive, Tarball};
+use fs_utils::ensure_containing_dir_exists;
 use log::debug;
 use semver::Version;
 use sha1::{Digest, Sha1};
@@ -109,7 +107,11 @@ fn unpack_archive(archive: Box<Archive>, name: &str, version: &Version) -> Falli
 
     let image_dir = path::package_image_dir(&name, &version.to_string())?;
     // ensure that the dir where this will be unpacked exists
-    ensure_containing_dir_exists(&image_dir)?;
+    ensure_containing_dir_exists(&image_dir).with_context(|_| {
+        ErrorDetails::ContainingDirError {
+            path: image_dir.clone(),
+        }
+    })?;
     // and ensure that the target directory does not exist
     ensure_dir_does_not_exist(&image_dir)?;
 

--- a/crates/volta-core/src/tool/package/fetch.rs
+++ b/crates/volta-core/src/tool/package/fetch.rs
@@ -82,7 +82,7 @@ fn load_cached_distro(file: &Path, shasum_file: &Path) -> Option<Box<dyn Archive
 }
 
 fn fetch_remote_distro(spec: tool::Spec, url: &str, path: &Path) -> Fallible<Box<Archive>> {
-    debug!("Downloading {} from {}", &spec, &url);
+    debug!("Downloading {} from {}, to {}", &spec, &url, path.display());
     Tarball::fetch(url, path).with_context(download_tool_error(spec, url.to_string()))
 }
 

--- a/crates/volta-core/src/tool/package/serial.rs
+++ b/crates/volta-core/src/tool/package/serial.rs
@@ -7,10 +7,10 @@ use super::install::{BinConfig, BinLoader, PackageConfig};
 use super::resolve::PackageIndex;
 use super::PackageDetails;
 use crate::error::ErrorDetails;
-use crate::fs::ensure_containing_dir_exists;
 use crate::path;
 use crate::toolchain;
 use crate::version::version_serde;
+use fs_utils::ensure_containing_dir_exists;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use volta_fail::{Fallible, ResultExt, VoltaError};
@@ -133,7 +133,11 @@ impl RawPackageConfig {
     pub fn write(self) -> Fallible<()> {
         let config_file_path = path::user_package_config_file(&self.name)?;
         let src = self.to_json()?;
-        ensure_containing_dir_exists(&config_file_path)?;
+        ensure_containing_dir_exists(&config_file_path).with_context(|_| {
+            ErrorDetails::ContainingDirError {
+                path: config_file_path.clone(),
+            }
+        })?;
         write(&config_file_path, src).with_context(|_| ErrorDetails::WritePackageConfigError {
             file: config_file_path,
         })
@@ -211,7 +215,11 @@ impl RawBinConfig {
     pub fn write(self) -> Fallible<()> {
         let bin_config_path = path::user_tool_bin_config(&self.name)?;
         let src = self.to_json()?;
-        ensure_containing_dir_exists(&bin_config_path)?;
+        ensure_containing_dir_exists(&bin_config_path).with_context(|_| {
+            ErrorDetails::ContainingDirError {
+                path: bin_config_path.clone(),
+            }
+        })?;
         write(&bin_config_path, src).with_context(|_| ErrorDetails::WriteBinConfigError {
             file: bin_config_path,
         })

--- a/tests/smoke/volta_install.rs
+++ b/tests/smoke/volta_install.rs
@@ -99,3 +99,22 @@ fn install_package() {
         execs().with_status(0).with_stdout_contains(COWSAY_HELLO)
     );
 }
+
+#[test]
+fn install_scoped_package() {
+    let p = temp_project().build();
+
+    // have to install node first, because we need npm
+    assert_that!(p.volta("install node@10.4.1"), execs().with_status(0));
+
+    assert_that!(p.volta("install @wdio/cli@5.12.4"), execs().with_status(0));
+    assert_eq!(p.shim_exists("wdio"), true);
+
+    assert_eq!(p.package_version_is_fetched("wdio", "5.12.4"), true);
+    assert_eq!(p.package_version_is_unpacked("wdio", "5.12.4"), true);
+
+    assert_that!(
+        p.exec_shim("wdio", "--version"),
+        execs().with_status(0).with_stdout_contains("5.12.4")
+    );
+}

--- a/tests/smoke/volta_install.rs
+++ b/tests/smoke/volta_install.rs
@@ -110,8 +110,8 @@ fn install_scoped_package() {
     assert_that!(p.volta("install @wdio/cli@5.12.4"), execs().with_status(0));
     assert_eq!(p.shim_exists("wdio"), true);
 
-    assert_eq!(p.package_version_is_fetched("wdio", "5.12.4"), true);
-    assert_eq!(p.package_version_is_unpacked("wdio", "5.12.4"), true);
+    assert_eq!(p.package_version_is_fetched("@wdio/cli", "5.12.4"), true);
+    assert_eq!(p.package_version_is_unpacked("@wdio/cli", "5.12.4"), true);
 
     assert_that!(
         p.exec_shim("wdio", "--version"),


### PR DESCRIPTION
Fixes #538.

This ensures that the directory exists before trying to unpack the tarball there.

Additional cleanup: I moved the `ensure_containing_dir_exists` function into a new `fs-utils` crate. There are some other functions that could be moved there, but I didn't want to go down that hole for this PR.

When there is an error (I made the parent dir read-only for this), we get the error message from the OS:

```
$ ./target/debug/volta install @wdio/cli --verbose
[verbose] No custom hooks found
[verbose] Running command: `"npm" "view" "--json" "@wdio/cli@latest"`
[verbose] [parsed package metadata (single)]
NpmViewData { name: "@wdio/cli", version: Version { major: 5, minor: 12, patch: 5, pre: [], build: [] }, dist: RawDistInfo { shasum: "f4121b0d7682f67431521b83aa213c23128341a2", tarball: "https://registry.npmjs.org/@wdio/cli/-/cli-5.12.5.tgz" }, dist_tags: RawPackageDistTags { latest: Version { major: 5, minor: 12, patch: 5, pre: [], build: [] }, beta: None } }
[verbose] Found @wdio/cli latest version (5.12.5) from https://registry.npmjs.org/@wdio/cli/-/cli-5.12.5.tgz
[verbose] Downloading @wdio/cli@5.12.5 from https://registry.npmjs.org/@wdio/cli/-/cli-5.12.5.tgz, to /Users/mistewar/.volta/tools/inventory/packages/@wdio/cli-5.12.5.tgz
error: Could not download @wdio/cli@5.12.5
from https://registry.npmjs.org/@wdio/cli/-/cli-5.12.5.tgz

Please verify your internet connection and ensure the correct version is specified.
[verbose] Error cause: Permission denied (os error 13)
Error details written to /Users/mistewar/.volta/log/volta-error-2019-08-27_15_23_26.598.log
```