### PR TITLE
Improve Error Messages around 'npm view'

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -212,13 +212,14 @@ pub enum ErrorDetails {
     NoVersionsFound,
 
     /// Thrown when there is an error running `npm view`
-    NpmViewError,
-
-    /// Thrown when there is an error running `npm view`
-    NpmViewMetadataFetchError,
+    NpmViewMetadataFetchError {
+        package: String,
+    },
 
     /// Thrown when there is an parsing the metadata from `npm view`
-    NpmViewMetadataParseError,
+    NpmViewMetadataParseError {
+        package: String,
+    },
 
     NpxNotAvailable {
         version: String,
@@ -814,24 +815,19 @@ Use `volta install yarn` to select a default version (see `volta help install fo
             ),
             // No CTA as this error is purely informational
             ErrorDetails::NoVersionsFound => write!(f, "No tool versions found"),
-            ErrorDetails::NpmViewError => write!(
+            ErrorDetails::NpmViewMetadataFetchError { package } => write!(
                 f,
-                "Could not query package metadata.
+                "Could not download package metadata for '{}'
 
-{}",
-                PERMISSIONS_CTA
+Please ensure the requested package name is correct.",
+                package
             ),
-            ErrorDetails::NpmViewMetadataFetchError => write!(
+            ErrorDetails::NpmViewMetadataParseError { package } => write!(
                 f,
-                "Could not download package metadata.
+                "Could not parse package metadata for '{}'
 
-Please verify that the package name is correct, and you have Node installed (using `volta install node`)."
-            ),
-            ErrorDetails::NpmViewMetadataParseError => write!(
-                f,
-                "Could not parse package metadata.
-
-Please ensure the requested package name is correct."
+Please ensure the requested package name is correct.",
+                package
             ),
             ErrorDetails::NpxNotAvailable { version } => write!(
                 f,
@@ -1327,8 +1323,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::NotInPackage => ExitCode::ConfigurationError,
             ErrorDetails::NoUserYarn => ExitCode::ConfigurationError,
             ErrorDetails::NoVersionsFound => ExitCode::NoVersionMatch,
-            ErrorDetails::NpmViewError => ExitCode::NetworkError,
-            ErrorDetails::NpmViewMetadataFetchError => ExitCode::NetworkError,
+            ErrorDetails::NpmViewMetadataFetchError { .. } => ExitCode::NetworkError,
             ErrorDetails::NpmViewMetadataParseError { .. } => ExitCode::UnknownError,
             ErrorDetails::NpxNotAvailable { .. } => ExitCode::ExecutableNotFound,
             ErrorDetails::PackageInstallFailed => ExitCode::FileSystemError,

--- a/crates/volta-core/src/run/binary.rs
+++ b/crates/volta-core/src/run/binary.rs
@@ -14,7 +14,7 @@ use crate::tool::{BinConfig, BinLoader};
 use log::debug;
 use volta_fail::{throw, Fallible};
 
-pub(super) fn command<A>(exe: OsString, args: A, session: &mut Session) -> Fallible<ToolCommand>
+pub(crate) fn command<A>(exe: OsString, args: A, session: &mut Session) -> Fallible<ToolCommand>
 where
     A: IntoIterator<Item = OsString>,
 {

--- a/crates/volta-core/src/run/node.rs
+++ b/crates/volta-core/src/run/node.rs
@@ -9,7 +9,7 @@ use crate::style::tool_version;
 use log::debug;
 use volta_fail::Fallible;
 
-pub(super) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
+pub(crate) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
 where
     A: IntoIterator<Item = OsString>,
 {

--- a/crates/volta-core/src/run/npm.rs
+++ b/crates/volta-core/src/run/npm.rs
@@ -10,7 +10,7 @@ use crate::style::tool_version;
 use log::debug;
 use volta_fail::{throw, Fallible};
 
-pub(super) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
+pub(crate) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
 where
     A: IntoIterator<Item = OsString>,
 {

--- a/crates/volta-core/src/run/npx.rs
+++ b/crates/volta-core/src/run/npx.rs
@@ -10,7 +10,7 @@ use crate::version::VersionSpec;
 use log::debug;
 use volta_fail::Fallible;
 
-pub(super) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
+pub(crate) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
 where
     A: IntoIterator<Item = OsString>,
 {

--- a/crates/volta-core/src/run/yarn.rs
+++ b/crates/volta-core/src/run/yarn.rs
@@ -10,7 +10,7 @@ use crate::style::tool_version;
 use log::debug;
 use volta_fail::{throw, Fallible};
 
-pub(super) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
+pub(crate) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
 where
     A: IntoIterator<Item = OsString>,
 {

--- a/src/command/which.rs
+++ b/src/command/which.rs
@@ -6,7 +6,7 @@ use which::which_in;
 
 use volta_core::error::ErrorDetails;
 use volta_core::platform::System;
-use volta_core::run::DefaultBinary;
+use volta_core::run::binary::DefaultBinary;
 use volta_core::session::{ActivityKind, Session};
 use volta_fail::{ExitCode, Fallible, ResultExt};
 


### PR DESCRIPTION
Closes #545 

Info
-----
* The current implementation of `volta install <package>` call `npm view` and relies on the existing `PATH` / shims to execute `npm`.
* This means that calling the command requires calling the shims, which then have to re-build all of Volta's state, before finally calling `npm` directly.
* With the refactor in #505, it's now possible to access the `Session` object while resolving a package version, so we can create the command and call `npm` directly.
* This cuts out one layer of indirection and allows us to provide nicer error messages about the existence of `node` on the system.
* Additionally, we can now separate being unable to find the package from being unable to find `npm` / `node`, so we can improve the error messaging around the failure states.

Changes
-----
* Made the various tool command constructors in the `run` module available to the crate, so that they can be used to create subcommands where needed.
* Updated the `tool::package::resolve` module to use the above commands instead of manually creating a call to `npm` that relies on the shims.
* Added the requested package name to the `npm view` errors, so that the user is clear which package failed when installing multiple packages at once.