### PR TITLE
[volta updates] Add volta-updates feature and CI override

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ cross-platform-docs = ["volta-core/cross-platform-docs"]
 mock-network = ["mockito", "volta-core/mock-network"]
 volta-dev = []
 smoke-tests = []
+volta-updates = ["volta-core/volta-updates"]
 
 [[bin]]
 name = "shim"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
         name: overrides
         displayName: Extract overrides from top commit
 
-# Note: The following 2 jobscan be removed when the updates feature is complete, along with the file
+# Note: The following 2 jobs can be removed when the updates feature is complete, along with the file
 # 'ci/run-tests-updates.yml' and the check for '[volta updates]' in 'ci/check-overrides.sh'
   - job: nix_test_updates
     dependsOn:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,43 @@ jobs:
         name: overrides
         displayName: Extract overrides from top commit
 
+# Note: The following 2 jobscan be removed when the updates feature is complete, along with the file
+# 'ci/run-tests-updates.yml' and the check for '[volta updates]' in 'ci/check-overrides.sh'
+  - job: nix_test_updates
+    dependsOn:
+      - vars
+      - nix
+    strategy:
+      matrix:
+        ubuntu:
+          imageName: "ubuntu-16.04"
+        mac:
+          imageName: "macos-10.13"
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - template: ci/install-rust.yml
+      - template: ci/run-tests-updates.yml
+    displayName: Test nix (with Updates Feature)
+    condition: and(succeeded('nix'), dependencies.vars.outputs['overrides.updates'])
+
+  - job: windows_test_updates
+    dependsOn:
+      - vars
+      - windows
+    strategy:
+      matrix:
+        windows:
+          imageName: "vs2017-win2016"
+    pool:
+      vmImage: $(imageName)
+    steps:
+      - template: ci/install-rust.yml
+      - template: ci/run-tests-updates.yml
+    displayName: Test Windows (with Updates Feature)
+    condition: and(succeeded('windows'), dependencies.vars.outputs['overrides.updates'])
+# End updates special case
+
   - job: api_docs
     dependsOn:
       - vars

--- a/ci/check-overrides.sh
+++ b/ci/check-overrides.sh
@@ -49,11 +49,6 @@ check_override() {
     # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#type-casting
     result=$(echo "$message" | fgrep -q "$directive" && echo True)
 
-    if [[ "$SYSTEM_PULLREQUEST_ISFORK" == "True" && "$result" == "True" ]]; then
-      err 'Forks do not have permissions to publish docs.'
-      exit 1
-    fi
-
     pretty_directive=$(cyan "$directive")
     info "Checking override $pretty_directive: ${result:-False}"
 
@@ -84,5 +79,12 @@ echo
 
 # FIXME: add an early check that this isn't from a fork repo, to give a better error message
 docs=$(check_override "$commit_message" '[ci docs]')
+if [[ "$SYSTEM_PULLREQUEST_ISFORK" == "True" && "$docs" == "True" ]]; then
+    err 'Forks do not have permissions to publish docs.'
+    exit 1
+else
+    set_output_variable docs $docs
+fi
 
-set_output_variable docs $docs
+updates=$(check_override "$commit_message" '[volta updates]')
+set_output_variable updates $updates

--- a/ci/run-tests-updates.yml
+++ b/ci/run-tests-updates.yml
@@ -1,0 +1,18 @@
+steps:
+  # the unit tests for all crates (without mocking the network)
+  # run single-threaded because some tests change environment variables,
+  # which is not thread-safe
+  - script: cargo test --features volta-updates --package volta-core --package volta-fail --package archive --package volta-fail-derive --package progress-read -- --test-threads=1
+    displayName: Unit Tests
+
+  # the acceptance tests, using network mocks
+  - script: cargo test --features mock-network volta-updates
+    env:
+      RUST_BACKTRACE: full
+    displayName: Acceptance Tests
+
+  # smoke tests: real data and no mocks
+  - script: cargo test --test smoke --features smoke-tests volta-updates -- --test-threads 1
+    env:
+      RUST_BACKTRACE: full
+    displayName: Smoke Tests

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -11,6 +11,7 @@ mock-network = ["mockito"]
 # See ci/publish-docs.yml for an example of how it's enabled.
 # See volta-core::path for an example of where it's used.
 cross-platform-docs = []
+volta-updates = []
 
 [dependencies]
 term_size = "0.3.0"


### PR DESCRIPTION
Info
-----
* To support working on Volta updates in parallel with other changes, we want to hide the updates work behind a feature flag, which is well supported by `cargo`
* We also want PRs involving the update work to test that work as it goes in, but don't want the update tests to break non-updates CI.

Changes
-----
* Added a `volta-updates` feature flag to `Cargo.toml` for the root project and for `volta-core`
* Added a CI override `[volta updates]` in the commit message that will run the automated tests with the feature flag enabled.
* Added new jobs to `azure-pipelines.yml` to enable the feature flag tests only if the CI override is detected.