### PR TITLE
[Updates] Remove 'volta activate' and 'volta deactivate' commands

### DIFF
--- a/crates/volta-core/src/lib.rs
+++ b/crates/volta-core/src/lib.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(feature = "cross-platform-docs", feature(doc_cfg))]
 
 mod command;
+#[cfg(not(feature = "volta-updates"))]
 pub mod env;
 pub mod error;
 mod event;
@@ -19,6 +20,7 @@ pub mod platform;
 pub mod project;
 pub mod run;
 pub mod session;
+#[cfg(not(feature = "volta-updates"))]
 pub mod shell;
 pub mod shim;
 pub mod signal;

--- a/crates/volta-core/src/platform/mod.rs
+++ b/crates/volta-core/src/platform/mod.rs
@@ -109,6 +109,7 @@ impl System {
 
     /// Reproduces the Volta-enabled `PATH` environment variable for situations where
     /// Volta has been deactivated
+    #[cfg(not(feature = "volta-updates"))]
     pub fn enabled_path() -> Fallible<OsString> {
         let old_path = envoy::path().unwrap_or_else(|| envoy::Var::from(""));
         let mut new_path = old_path.split();
@@ -136,6 +137,7 @@ mod test {
     use crate::layout::volta_install;
     use semver::Version;
     use std;
+    #[cfg(not(feature = "volta-updates"))]
     use std::path::PathBuf;
 
     // Since unit tests are run in parallel, tests that modify the PATH environment variable are subject to race conditions
@@ -144,6 +146,7 @@ mod test {
     fn test_paths() {
         test_image_path();
         test_system_path();
+        #[cfg(not(feature = "volta-updates"))]
         test_system_enabled_path();
     }
 
@@ -322,7 +325,7 @@ mod test {
         );
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(feature = "volta-updates")))]
     fn test_system_enabled_path() {
         let mut pathbufs: Vec<PathBuf> = Vec::new();
         pathbufs.push(volta_home().unwrap().shim_dir().to_owned());
@@ -349,7 +352,7 @@ mod test {
         );
     }
 
-    #[cfg(windows)]
+    #[cfg(all(windows, not(feature = "volta-updates")))]
     fn test_system_enabled_path() {
         let mut pathbufs: Vec<PathBuf> = Vec::new();
         pathbufs.push(volta_install().unwrap().bin_dir());

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -23,7 +23,7 @@ pub mod yarn;
 
 cfg_if! {
     if #[cfg(feature = "volta-updates")] {
-        const UNSAFE_GLOBAL: &'static str = "VOLTA_UNSAFE_GLOBAL";
+        const UNSAFE_GLOBAL: &str = "VOLTA_UNSAFE_GLOBAL";
     } else {
         use crate::env::UNSAFE_GLOBAL;
     }

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -7,12 +7,12 @@ use std::path::Path;
 use std::process::{Command, ExitStatus, Output};
 
 use crate::command::create_command;
-use crate::env::UNSAFE_GLOBAL;
 use crate::error::ErrorDetails;
 use crate::layout::ensure_volta_dirs_exist;
 use crate::platform::System;
 use crate::session::Session;
 use crate::signal::pass_control_to_shim;
+use cfg_if::cfg_if;
 use volta_fail::{Fallible, ResultExt};
 
 pub mod binary;
@@ -20,6 +20,14 @@ pub mod node;
 pub mod npm;
 pub mod npx;
 pub mod yarn;
+
+cfg_if! {
+    if #[cfg(feature = "volta-updates")] {
+        const UNSAFE_GLOBAL: &'static str = "VOLTA_UNSAFE_GLOBAL";
+    } else {
+        use crate::env::UNSAFE_GLOBAL;
+    }
+}
 
 /// Distinguish global `add` commands in npm or yarn from all others.
 enum CommandArg {

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -25,7 +25,9 @@ pub enum ActivityKind {
     Uninstall,
     List,
     Current,
+    #[cfg(not(feature = "volta-updates"))]
     Deactivate,
+    #[cfg(not(feature = "volta-updates"))]
     Activate,
     Default,
     Pin,
@@ -51,7 +53,9 @@ impl Display for ActivityKind {
             ActivityKind::Uninstall => "uninstall",
             ActivityKind::List => "list",
             ActivityKind::Current => "current",
+            #[cfg(not(feature = "volta-updates"))]
             ActivityKind::Deactivate => "deactivate",
+            #[cfg(not(feature = "volta-updates"))]
             ActivityKind::Activate => "activate",
             ActivityKind::Default => "default",
             ActivityKind::Pin => "pin",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,7 @@ pub(crate) enum Subcommand {
     Current(command::Current),
 
     /// [DEPRECATED] Disables Volta in the current shell
+    #[cfg(not(feature = "volta-updates"))]
     #[structopt(
         name = "deactivate",
         author = "",
@@ -106,6 +107,7 @@ pub(crate) enum Subcommand {
     Deactivate(command::Deactivate),
 
     /// [DEPRECATED] Re-enables Volta in the current shell
+    #[cfg(not(feature = "volta-updates"))]
     #[structopt(
         name = "activate",
         author = "",
@@ -158,7 +160,9 @@ impl Subcommand {
             Subcommand::Pin(pin) => pin.run(session),
             Subcommand::List(list) => list.run(session),
             Subcommand::Current(current) => current.run(session),
+            #[cfg(not(feature = "volta-updates"))]
             Subcommand::Deactivate(deactivate) => deactivate.run(session),
+            #[cfg(not(feature = "volta-updates"))]
             Subcommand::Activate(activate) => activate.run(session),
             Subcommand::Completions(completions) => completions.run(session),
             Subcommand::Which(which) => which.run(session),

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -1,6 +1,8 @@
+#[cfg(not(feature = "volta-updates"))]
 pub(crate) mod activate;
 pub(crate) mod completions;
 pub(crate) mod current;
+#[cfg(not(feature = "volta-updates"))]
 pub(crate) mod deactivate;
 pub(crate) mod fetch;
 pub(crate) mod install;
@@ -12,9 +14,11 @@ pub(crate) mod r#use;
 pub(crate) mod which;
 
 pub(crate) use self::which::Which;
+#[cfg(not(feature = "volta-updates"))]
 pub(crate) use activate::Activate;
 pub(crate) use completions::Completions;
 pub(crate) use current::Current;
+#[cfg(not(feature = "volta-updates"))]
 pub(crate) use deactivate::Deactivate;
 pub(crate) use fetch::Fetch;
 pub(crate) use install::Install;

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -3,7 +3,6 @@ use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
 
-use volta_core::env::UNSAFE_GLOBAL;
 use volta_fail::ExitCode;
 
 const PACKAGE_JSON: &str = r#"{
@@ -72,7 +71,7 @@ fn npm_prevents_global_install() {
 fn npm_allows_global_install_with_env_variable() {
     let s = sandbox()
         .package_json(PACKAGE_JSON)
-        .env(UNSAFE_GLOBAL, "1")
+        .env("VOLTA_UNSAFE_GLOBAL", "1")
         .build();
 
     // Since we are using a fake Node version, we expect to get an error about being unable to download
@@ -115,7 +114,7 @@ fn yarn_prevents_global_add() {
 fn yarn_allows_global_add_with_env_variable() {
     let s = sandbox()
         .package_json(PACKAGE_JSON)
-        .env(UNSAFE_GLOBAL, "1")
+        .env("VOLTA_UNSAFE_GLOBAL", "1")
         .build();
 
     // Since we are using a fake Yarn/Node version, we expect to get an error about being unable to download

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -8,6 +8,7 @@ mod intercept_global_installs;
 mod merged_platform;
 mod verbose_errors;
 mod volta_current;
+#[cfg(not(feature = "volta-updates"))]
 mod volta_deactivate;
 mod volta_pin;
 mod volta_uninstall;

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -236,7 +236,7 @@ impl SandboxBuilder {
     }
 
     /// Set the shell for the sandbox (chainable)
-    #[cfg(unix)]
+    #[cfg(all(unix, not(feature = "volta-updates")))]
     pub fn volta_shell(self, shell_name: &str) -> Self {
         self.env("VOLTA_SHELL", shell_name)
     }
@@ -600,7 +600,7 @@ impl Sandbox {
         read_file_to_string(package_file)
     }
 
-    #[cfg(unix)]
+    #[cfg(all(unix, not(feature = "volta-updates")))]
     pub fn read_postscript(&self) -> String {
         let postscript_file = volta_postscript();
         read_file_to_string(postscript_file)


### PR DESCRIPTION
Related to #222 
Closes #562 
Closes #216 
Closes #165 
Closes #104 
Closes #99

Info
-----
* As part of the push towards automatic updates, we want to enable Volta to work directly on the command line, instead of through a shell function wrapper.
* The purpose of the function wrapper was to allow the `volta activate` and `volta deactivate` commands to work as expected, modifying the PATH environment variable for the current shell.
* However, those commands were intended as a release valve for when we were in early testing phases, and are no longer needed since Volta is much more stable now.

Changes
-----
* Removed the `activate` and `deactivate` commands from the Volta CLI and the associated `ActivityType`
* Moved the `VOLTA_UNSAFE_GLOBAL` environment variable definition to the `run` module, where it is used.
* Removed the `shell` and `env` modules, which previous existed primarily to support the Postscript behavior that is no longer needed without `activate` / `deactivate`
* Removed `System::enabled_path`, which was only used by `volta activate` before.
* Deleted tests that referenced no-longer-available blocks / commands.

Tested
-----
* Verified that `volta activate` and `volta deactivate` are no longer allowed commands
* All automated tests pass

Notes
-----
* This PR builds on top of #558, as it uses the feature flag added in that PR, so it will remain a draft until that is merged.
* Since this is connected to the automatic updates, all of the changes are locked behind the `volta-updates` feature flag, so "removal" generally meant adding a `#[cfg(not(feature = "volta-updates"))]` attribute to the relevant block / line of code.