### PR TITLE
Update the initialization of Once to use the const constructor

### DIFF
--- a/crates/test-support/src/paths.rs
+++ b/crates/test-support/src/paths.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 static SMOKE_TEST_DIR: &'static str = "smoke_test";
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
@@ -13,7 +13,7 @@ thread_local!(static TASK_ID: usize = NEXT_ID.fetch_add(1, Ordering::SeqCst));
 // creates the root directory for the tests (once), and
 // initializes the root and home directories for the current task
 fn init() {
-    static GLOBAL_INIT: Once = ONCE_INIT;
+    static GLOBAL_INIT: Once = Once::new();
     thread_local!(static LOCAL_INIT: Cell<bool> = Cell::new(false));
     GLOBAL_INIT.call_once(|| {
         global_root().mkdir_p();


### PR DESCRIPTION
As of Rust 1.38, `ONCE_INIT` is deprecated in favor of `Once::new()` and is showing a warning. Switched the initialization to use that method, and confirmed that it compiles correctly on our stated minimum Rust version 1.34.0