### PR TITLE
Add deprecation warnings to activate and deactivate

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,7 +96,7 @@ pub(crate) enum Subcommand {
     )]
     Current(command::Current),
 
-    /// Disables Volta in the current shell
+    /// [DEPRECATED] Disables Volta in the current shell
     #[structopt(
         name = "deactivate",
         author = "",
@@ -105,7 +105,7 @@ pub(crate) enum Subcommand {
     )]
     Deactivate(command::Deactivate),
 
-    /// Re-enables Volta in the current shell
+    /// [DEPRECATED] Re-enables Volta in the current shell
     #[structopt(
         name = "activate",
         author = "",

--- a/src/command/activate.rs
+++ b/src/command/activate.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use structopt::StructOpt;
 
 use volta_core::error::ErrorDetails;
@@ -25,6 +26,9 @@ impl Command for Activate {
         let postscript = Postscript::Activate(path);
 
         shell.save_postscript(&postscript)?;
+
+        warn!("`volta activate` is deprecated and will be removed in a future version.");
+
         session.add_event_end(ActivityKind::Activate, ExitCode::Success);
         Ok(ExitCode::Success)
     }

--- a/src/command/activate.rs
+++ b/src/command/activate.rs
@@ -27,7 +27,10 @@ impl Command for Activate {
 
         shell.save_postscript(&postscript)?;
 
-        warn!("`volta activate` is deprecated and will be removed in a future version.");
+        warn!(
+            "`volta activate` is deprecated and will be removed in a future version.
+For more information, see https://github.com/volta-cli/volta/issues/562"
+        );
 
         session.add_event_end(ActivityKind::Activate, ExitCode::Success);
         Ok(ExitCode::Success)

--- a/src/command/deactivate.rs
+++ b/src/command/deactivate.rs
@@ -26,7 +26,10 @@ impl Command for Deactivate {
 
         shell.save_postscript(&postscript)?;
 
-        warn!("`volta deactivate` is deprecated and will be removed in a future version.");
+        warn!(
+            "`volta deactivate` is deprecated and will be removed in a future version.
+For more information, see https://github.com/volta-cli/volta/issues/562"
+        );
 
         session.add_event_end(ActivityKind::Deactivate, ExitCode::Success);
         Ok(ExitCode::Success)

--- a/src/command/deactivate.rs
+++ b/src/command/deactivate.rs
@@ -1,3 +1,4 @@
+use log::warn;
 use structopt::StructOpt;
 
 use volta_core::error::ErrorDetails;
@@ -24,6 +25,9 @@ impl Command for Deactivate {
         let postscript = Postscript::Deactivate(path);
 
         shell.save_postscript(&postscript)?;
+
+        warn!("`volta deactivate` is deprecated and will be removed in a future version.");
+
         session.add_event_end(ActivityKind::Deactivate, ExitCode::Success);
         Ok(ExitCode::Success)
     }


### PR DESCRIPTION
Suggestion from @thoov in #559: Add deprecation warning to `volta activate` and `volta deactivate` for the `0.6.x` releases, so that users get a warning that they are going away.

Then when we remove them in `0.7.0` with the update work, it won't be completely out of nowhere to the users.