### PR TITLE
[Updates] Add 'volta setup' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,6 +2395,7 @@ dependencies = [
  "volta-fail 0.1.0",
  "volta-fail-derive 0.1.0",
  "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2374,6 +2374,7 @@ dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "envoy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ mockito = { version = "0.14.0", optional = true }
 test-support = { path = "crates/test-support" }
 textwrap = "0.11.0"
 which = "2.0.1"
+dirs = "1.0.4"
 
 [dev-dependencies]
 hamcrest2 = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ textwrap = "0.11.0"
 which = "2.0.1"
 dirs = "1.0.4"
 
+[target.'cfg(windows)'.dependencies]
+winreg = "0.6.0"
+
 [dev-dependencies]
 hamcrest2 = "0.3.0"
 envoy = "0.1.3"

--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -202,6 +202,13 @@ pub enum ErrorDetails {
     /// Thrown when Yarn is not set in a project
     NoProjectYarn,
 
+    /// Thrown when no shell profiles could be found
+    #[cfg(feature = "volta-updates")]
+    NoShellProfile {
+        env_profile: String,
+        bin_dir: PathBuf,
+    },
+
     /// Thrown when the user tries to pin Node or Yarn versions outside of a package.
     NotInPackage,
 
@@ -815,6 +822,15 @@ To run any Node command, first set a default version using `volta install node`"
 
 Use `volta pin yarn` to select a version (see `volta help pin` for more info)."
             ),
+            #[cfg(feature = "volta-updates")]
+            ErrorDetails::NoShellProfile { env_profile, bin_dir } => write!(
+                f,
+                "Could not locate user profile.
+Tried $PROFILE ({}), ~/.bashrc, ~/.bash_profile, ~/.zshrc, ~/.profile, and ~/.config/fish/config.fish
+
+Please create one of these and try again; or you can edit your profile manually to add '{}' to your PATH",
+                env_profile, bin_dir.display()
+            ),
             ErrorDetails::NotInPackage => write!(
                 f,
                 "Not in a node package.
@@ -1356,6 +1372,8 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::NoPinnedNodeVersion => ExitCode::ConfigurationError,
             ErrorDetails::NoPlatform => ExitCode::ConfigurationError,
             ErrorDetails::NoProjectYarn => ExitCode::ConfigurationError,
+            #[cfg(feature = "volta-updates")]
+            ErrorDetails::NoShellProfile { .. } => ExitCode::EnvironmentError,
             ErrorDetails::NotInPackage => ExitCode::ConfigurationError,
             ErrorDetails::NoUserYarn => ExitCode::ConfigurationError,
             ErrorDetails::NoVersionsFound => ExitCode::NoVersionMatch,

--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -386,7 +386,7 @@ pub enum ErrorDetails {
     },
 
     /// Thrown when unable to read the user Path environment variable from the registry
-    #[cfg(windows)]
+    #[cfg(all(windows, feature = "volta-updates"))]
     ReadUserPathError,
 
     /// Thrown when the public registry for Node or Yarn could not be downloaded.
@@ -501,7 +501,7 @@ pub enum ErrorDetails {
     },
 
     /// Thrown when unable to write the user PATH environment variable
-    #[cfg(windows)]
+    #[cfg(all(windows, feature = "volta-updates"))]
     WriteUserPathError,
 
     /// Thrown when there is an error fetching the latest version of Yarn
@@ -1140,7 +1140,7 @@ from {}
                 file.display(),
                 PERMISSIONS_CTA
             ),
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "volta-updates"))]
             ErrorDetails::ReadUserPathError => write!(
                 f,
                 "Could not read user Path environment variable.
@@ -1326,7 +1326,7 @@ to {}
                 file.display(),
                 PERMISSIONS_CTA
             ),
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "volta-updates"))]
             ErrorDetails::WriteUserPathError => write!(
                 f,
                 "Could not write Path environment variable.
@@ -1437,7 +1437,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::ReadNpmManifestError => ExitCode::UnknownError,
             ErrorDetails::ReadPackageConfigError { .. } => ExitCode::FileSystemError,
             ErrorDetails::ReadPlatformError { .. } => ExitCode::FileSystemError,
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "volta-updates"))]
             ErrorDetails::ReadUserPathError => ExitCode::EnvironmentError,
             ErrorDetails::RegistryFetchError { .. } => ExitCode::NetworkError,
             #[cfg(feature = "volta-updates")]
@@ -1465,7 +1465,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::WritePackageConfigError { .. } => ExitCode::FileSystemError,
             ErrorDetails::WritePackageShasumError { .. } => ExitCode::FileSystemError,
             ErrorDetails::WritePlatformError { .. } => ExitCode::FileSystemError,
-            #[cfg(windows)]
+            #[cfg(all(windows, feature = "volta-updates"))]
             ErrorDetails::WriteUserPathError => ExitCode::EnvironmentError,
             ErrorDetails::YarnLatestFetchError { .. } => ExitCode::NetworkError,
             ErrorDetails::YarnVersionNotFound { .. } => ExitCode::NoVersionMatch,

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 use crate::error::ErrorDetails;
+#[cfg(unix)]
 use crate::shim;
 use cfg_if::cfg_if;
 use double_checked_cell::DoubleCheckedCell;
@@ -80,7 +81,7 @@ pub fn bootstrap_volta_dirs() -> Fallible<()> {
             dir: home.root().to_owned(),
         })?;
 
-    #[cfg(any(unix, feature = "volta-updates"))]
+    #[cfg(unix)]
     {
         shim::create("node")?;
         shim::create("yarn")?;

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -80,10 +80,13 @@ pub fn bootstrap_volta_dirs() -> Fallible<()> {
             dir: home.root().to_owned(),
         })?;
 
-    shim::create("node")?;
-    shim::create("yarn")?;
-    shim::create("npm")?;
-    shim::create("npx")?;
+    #[cfg(any(unix, feature = "volta-updates"))]
+    {
+        shim::create("node")?;
+        shim::create("yarn")?;
+        shim::create("npm")?;
+        shim::create("npx")?;
+    }
 
     Ok(())
 }

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -2,7 +2,6 @@ use std::env;
 use std::path::PathBuf;
 
 use crate::error::ErrorDetails;
-#[cfg(unix)]
 use crate::shim;
 use cfg_if::cfg_if;
 use double_checked_cell::DoubleCheckedCell;

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -43,6 +43,8 @@ pub enum ActivityKind {
     Shim,
     Completions,
     Which,
+    #[cfg(feature = "volta-updates")]
+    Setup,
 }
 
 impl Display for ActivityKind {
@@ -68,6 +70,8 @@ impl Display for ActivityKind {
             ActivityKind::Help => "help",
             ActivityKind::Version => "version",
             ActivityKind::Binary => "binary",
+            #[cfg(feature = "volta-updates")]
+            ActivityKind::Setup => "setup",
             ActivityKind::Shim => "shim",
             ActivityKind::Completions => "completions",
             ActivityKind::Which => "which",

--- a/crates/volta-core/src/style.rs
+++ b/crates/volta-core/src/style.rs
@@ -10,7 +10,7 @@ const MAX_WIDTH: usize = 100;
 const MAX_PROGRESS_WIDTH: usize = 40;
 
 /// Generate the styled prefix for a success message
-pub(crate) fn success_prefix() -> StyledObject<&'static str> {
+pub fn success_prefix() -> StyledObject<&'static str> {
     style("success:").green().bold()
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -149,6 +149,11 @@ otherwise, they will be written to `stdout`.
         )
     )]
     Use(command::Use),
+
+    /// Enables Volta for the current user / shell
+    #[cfg(feature = "volta-updates")]
+    #[structopt(name = "setup", author = "", version = "")]
+    Setup(command::Setup),
 }
 
 impl Subcommand {
@@ -167,6 +172,8 @@ impl Subcommand {
             Subcommand::Completions(completions) => completions.run(session),
             Subcommand::Which(which) => which.run(session),
             Subcommand::Use(r#use) => r#use.run(session),
+            #[cfg(feature = "volta-updates")]
+            Subcommand::Setup(setup) => setup.run(session),
         }
     }
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -8,8 +8,9 @@ pub(crate) mod fetch;
 pub(crate) mod install;
 pub(crate) mod list;
 pub(crate) mod pin;
+#[cfg(feature = "volta-updates")]
+pub(crate) mod setup;
 pub(crate) mod uninstall;
-#[macro_use]
 pub(crate) mod r#use;
 pub(crate) mod which;
 
@@ -25,6 +26,8 @@ pub(crate) use install::Install;
 pub(crate) use list::List;
 pub(crate) use pin::Pin;
 pub(crate) use r#use::Use;
+#[cfg(feature = "volta-updates")]
+pub(crate) use setup::Setup;
 pub(crate) use uninstall::Uninstall;
 
 use volta_core::session::Session;

--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -37,7 +37,7 @@ mod os {
     use std::io::{self, BufRead, BufReader, Write};
     use std::path::Path;
 
-    use log::debug;
+    use log::{debug, warn};
     use volta_core::error::ErrorDetails;
     use volta_core::layout::volta_home;
     use volta_fail::Fallible;
@@ -75,7 +75,11 @@ mod os {
                         match result {
                             Ok(()) => true,
                             Err(err) => {
-                                debug!("Could not modify profile script: {}", err);
+                                warn!(
+                                    "Found profile script, but could not modify it: {}",
+                                    profile.display()
+                                );
+                                debug!("Profile modification error: {}", err);
                                 prev
                             }
                         }

--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -1,0 +1,100 @@
+use log::info;
+use structopt::StructOpt;
+use volta_core::layout::bootstrap_volta_dirs;
+use volta_core::session::{ActivityKind, Session};
+use volta_core::style::success_prefix;
+use volta_fail::{ExitCode, Fallible};
+
+use crate::command::Command;
+
+#[derive(StructOpt)]
+pub(crate) struct Setup {}
+
+impl Command for Setup {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
+        session.add_event_start(ActivityKind::Setup);
+
+        // ISSUE #566 - Once we have a working migration, we can leave the creation of the
+        // directory structure to the migration and not have to call it here
+        bootstrap_volta_dirs()?;
+        os::setup_environment()?;
+
+        info!(
+            "{} Setup complete. Open a new terminal to start using Volta!",
+            success_prefix()
+        );
+
+        session.add_event_end(ActivityKind::Setup, ExitCode::Success);
+        Ok(ExitCode::Success)
+    }
+}
+
+#[cfg(unix)]
+mod os {
+    use std::fs::{File, OpenOptions};
+    use std::io::Write;
+    use std::path::Path;
+
+    use volta_core::error::ErrorDetails;
+    use volta_core::layout::volta_home;
+    use volta_fail::Fallible;
+
+    const PROFILES: [&'static str; 5] = [
+        ".profile",
+        ".bash_profile",
+        ".bashrc",
+        ".zshrc",
+        ".config/fish/config.fish",
+    ];
+
+    pub fn setup_environment() -> Fallible<()> {
+        let user_home_dir = dirs::home_dir().ok_or(ErrorDetails::NoHomeEnvironmentVar)?;
+        let home = volta_home()?;
+        let mut found_profile = false;
+
+        for path in PROFILES.iter() {
+            let profile = user_home_dir.join(path);
+            if let Some(mut file) = open_for_append(&profile) {
+                let result = match profile.extension() {
+                    Some(ext) if ext == "fish" => write!(
+                        file,
+                        "\nset -gx VOLTA_HOME \"{}\"\nstring match -r \".volta\" \"$PATH\" > /dev/null; or set -gx PATH \"$VOLTA_HOME/bin\" $PATH\n",
+                        home.root().display()
+                    ),
+                    _ => write!(
+                        file,
+                        "\nexport VOLTA_HOME=\"{}\"\ngrep --silent \"$VOLTA_HOME/bin\" <<< $PATH || export PATH=\"$VOLTA_HOME/bin:$PATH\"\n",
+                        home.root().display()
+                    ),
+                };
+
+                if result.is_ok() {
+                    found_profile = true;
+                }
+            }
+        }
+
+        if found_profile {
+            Ok(())
+        } else {
+            Err(ErrorDetails::NoShellProfile {
+                env_profile: String::new(),
+                bin_dir: home.shim_dir().to_owned(),
+            }
+            .into())
+        }
+    }
+
+    fn open_for_append<P: AsRef<Path>>(path: P) -> Option<File> {
+        OpenOptions::new().append(true).open(path).ok()
+    }
+}
+
+#[cfg(windows)]
+mod os {
+    use volta_fail::Fallible;
+    pub fn setup_environment() -> Fallible<()> {
+        // In windows, need to edit HKEY_CURRENT_USER\Environment to modify the User PATH
+        unimplemented!();
+    }
+}

--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -19,6 +19,8 @@ impl Command for Setup {
         bootstrap_volta_dirs()?;
         os::setup_environment()?;
 
+        // TODO - CPIERCE: Show spinner and messages for each step (similar to current shell installer)
+
         info!(
             "{} Setup complete. Open a new terminal to start using Volta!",
             success_prefix()
@@ -53,6 +55,7 @@ mod os {
         let mut found_profile = false;
 
         for path in PROFILES.iter() {
+            // TODO - CPIERCE: Make debug statements about what is happening
             let profile = user_home_dir.join(path);
             if let Some(mut file) = open_for_append(&profile) {
                 let result = match profile.extension() {
@@ -68,6 +71,7 @@ mod os {
                     ),
                 };
 
+                // TODO - CPIERCE: On error, show error details in debug output
                 if result.is_ok() {
                     found_profile = true;
                 }
@@ -92,9 +96,40 @@ mod os {
 
 #[cfg(windows)]
 mod os {
-    use volta_fail::Fallible;
+    use std::process::Command;
+    use volta_core::error::ErrorDetails;
+    use volta_core::layout::volta_home;
+    use volta_fail::{Fallible, ResultExt};
+    use winreg::enums::HKEY_CURRENT_USER;
+    use winreg::RegKey;
+
     pub fn setup_environment() -> Fallible<()> {
-        // In windows, need to edit HKEY_CURRENT_USER\Environment to modify the User PATH
-        unimplemented!();
+        let shim_dir = volta_home()?.shim_dir().to_string_lossy().to_string();
+        let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+        let env = hkcu
+            .open_subkey("Environment")
+            .with_context(|_| ErrorDetails::ReadUserPathError)?;
+        let path: String = env
+            .get_value("Path")
+            .with_context(|_| ErrorDetails::ReadUserPathError)?;
+
+        if !path.contains(&shim_dir) {
+            // Use `setx` command to edit the user Path environment variable
+            let mut command = Command::new("setx");
+            command.arg("Path");
+            command.arg(format!("{};{}", shim_dir, path));
+
+            // TODO - CPIERCE: Debug show the command being run
+            let output = command
+                .output()
+                .with_context(|_| ErrorDetails::WriteUserPathError)?;
+
+            if !output.status.success() {
+                // TODO - CPIERCE: If this fails, write the stdout and stderr to the debug log
+                return Err(ErrorDetails::WriteUserPathError.into());
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -42,7 +42,7 @@ mod os {
     use volta_core::layout::volta_home;
     use volta_fail::Fallible;
 
-    const PROFILES: [&'static str; 5] = [
+    const PROFILES: [&str; 5] = [
         ".profile",
         ".bash_profile",
         ".bashrc",


### PR DESCRIPTION
Closes #564 
Closes #535 

Info
-----
* To support managed installs and automatic updates, we want to have a new command: `volta setup`
* `volta setup` Will bootstrap Volta from a situation where only the binaries are available to a fully-working Volta system. This will allow users in managed situations to "enable" Volta on their system.
* Additionally, the current installers can be simplified with this command to only (see #565):
    1. Install the binaries
    2. Call `volta setup`

Changes
-----
* Added `volta setup` command behind the `volta-updates` feature flag, along with implementations for both Unix and Windows.
    * On both systems, the `VOLTA_HOME` file system layout is initialized.
    * On Unix, we iterate through the same list of profile scripts that the installer uses, and add Volta lines to any that we find. If a given script already mentions VOLTA, we remove that mention and add the new Volta lines.
        * This allows for migrating from older (v0.6.* and before) versions of Volta, where the Profile script was different.
        * It also allows for subsequent calls to `volta setup` to allow Volta to once again "win" over other tools that modify the path (e.g. if a user has Volta, installs nvm, then wants to use Volta, they can run `volta setup` again to get their profile in a working state).
    * On Windows, we read the Registry key that represents the User Path variable, and if it doesn't contain the Volta Shim directory, we add that to the environment using [`setx`](https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/setx)
* Added error messages for possible failure states in the setup process.

Notes
-----
* This PR builds on top of #561, so it will be kept as a draft until that is merged.