### PR TITLE
[Updates] Create new installers that use 'volta setup'

### DIFF
--- a/dev/rpm/build-rpm-updates.sh
+++ b/dev/rpm/build-rpm-updates.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Build an RPM package for Volta
+
+# using the directions from https://rpm-packaging-guide.github.io/
+
+# exit on error
+set -e
+
+# only argument is the version number
+release_version="${1:?Must specify the release version, like \`build-rpm 1.2.3\`}"
+archive_filename="v${release_version}.tar.gz"
+
+# make sure these packages are installed
+# (https://rpm-packaging-guide.github.io/#prerequisites)
+sudo yum install gcc rpm-build rpm-devel rpmlint make python bash coreutils diffutils patch rpmdevtools
+
+# set up the directory layout for the RPM packaging workspace
+# (https://rpm-packaging-guide.github.io/#rpm-packaging-workspace)
+rpmdev-setuptree
+
+# create a tarball of the repo for the specified version
+# using prefix because the rpmbuild process expects a 'volta-<version>' directory
+# (https://rpm-packaging-guide.github.io/#putting-source-code-into-tarball)
+git archive --format=tar.gz --output=$archive_filename --prefix="volta-${release_version}/" HEAD
+
+# move the archive to the SOURCES dir, after cleaning it up
+# (https://rpm-packaging-guide.github.io/#working-with-spec-files)
+rm -rf "$HOME/rmpbuild/SOURCES/"*
+mv "$archive_filename" "$HOME/rpmbuild/SOURCES/"
+
+# copy the .spec file to SPECS dir
+cp dev/rpm/volta-updates.spec "$HOME/rpmbuild/SPECS/"
+
+# build it!
+# (https://rpm-packaging-guide.github.io/#binary-rpms)
+rpmbuild -bb "$HOME/rpmbuild/SPECS/volta-updates.spec"
+# (there will be a lot of output)
+
+# then install it and verify everything worked...
+echo ""
+echo "Build finished!"
+echo ""
+echo "Run this to install:"
+echo "  \`sudo yum install ~/rpmbuild/RPMS/x86_64/volta-${release_version}-1.el7.x86_64.rpm\`"
+echo ""
+echo "Then run this to uninstall after verifying:"
+echo "  \`sudo yum erase volta-${release_version}-1.el7.x86_64\`"

--- a/dev/rpm/volta-updates.spec
+++ b/dev/rpm/volta-updates.spec
@@ -1,0 +1,70 @@
+Name:           volta
+Version:        0.6.3
+Release:        1%{?dist}
+Summary:        The JavaScript Launcher ⚡
+
+License:        BSD 2-CLAUSE
+URL:            https://%{name}.sh
+Source0:        https://github.com/volta-cli/volta/archive/v%{version}.tar.gz
+
+# cargo is required, but installing from RPM is failing with libcrypto dep error
+# so you will have to install cargo manually to build this
+#BuildRequires:  cargo
+
+# because these are built with openssl
+Requires:       openssl
+
+
+%description
+Volta’s job is to manage your JavaScript command-line tools, such as node, npm, yarn, or executables shipped as part of JavaScript packages. Similar to package managers, Volta keeps track of which project (if any) you’re working on based on your current directory. The tools in your Volta toolchain automatically detect when you’re in a project that’s using a particular version of the tools, and take care of routing to the right version of the tools for you.
+
+
+%prep
+# this unpacks the tarball to the build root
+%setup -q
+
+
+%build
+# build the release binaries
+# NOTE: build expects to `cd` into a volta-<version> directory
+cargo build --features volta-updates --release
+
+
+# this installs into a chroot directory resembling the user's root directory
+%install
+# BUILDROOT/usr/bin
+%define volta_install_dir %{buildroot}/%{_bindir}
+# setup the /usr/bin/volta-lib/ directory
+rm -rf %{buildroot}
+mkdir -p %{volta_install_dir}
+# install everything into into /usr/bin/, so it's on the PATH
+install -m 0755 target/release/%{name} %{volta_install_dir}/%{name}
+install -m 0755 target/release/volta-shim %{volta_install_dir}/volta-shim
+
+
+# files installed by this package
+%files
+%license LICENSE
+%{_bindir}/%{name}
+%{_bindir}/volta-shim
+
+
+# this runs before install
+%pre
+# make sure the /usr/bin/volta/ dir does not exist, from prev RPM installs (or this will fail)
+printf '\033[1;32m%12s\033[0m %s\n' "Running" "Volta pre-install..." 1>&2
+rm -rf %{_bindir}/%{name}
+
+
+# this runs after install, and sets up VOLTA_HOME and the shell integration
+%post
+printf '\033[1;32m%12s\033[0m %s\n' "Running" "Volta post-install setup..." 1>&2
+# run this as the user who invoked sudo (not as root, because we're writing to $HOME)
+/bin/su -c "%{_bindir}/volta setup" - $SUDO_USER
+
+
+%changelog
+* Tue Oct 22 2019 Charles Pierce <cpierce.grad@gmail.com> - 0.6.5-1
+- Update to use 'volta setup' as the postinstall script
+* Mon Jun 03 2019 Michael Stewart <mikrostew@gmail.com> - 0.5.3-1
+- First volta package

--- a/dev/unix/release-updates.sh
+++ b/dev/unix/release-updates.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Script to build the binaries and package them up for release.
+# This should be run from the top-level directory.
+
+# get the directory of this script
+# (from https://stackoverflow.com/a/246128)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# get shared functions from the volta-install.sh file
+source "$DIR/volta-install.sh"
+
+usage() {
+  cat >&2 <<END_OF_USAGE
+release.sh
+
+Compile and package a release for Volta
+
+USAGE:
+    ./dev/unix/release.sh [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help          Prints this help info
+
+OPTIONS:
+        --release       Build artifacts in release mode, with optimizations (default)
+        --dev           Build artifacts in dev mode, without optimizations
+END_OF_USAGE
+}
+
+
+# default to compiling with '--release'
+build_with_release="true"
+
+# parse input arguments
+case "$1" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --dev)
+    build_with_release="false"
+    ;;
+  ''|--release)
+    # not really necessary to set this again
+    build_with_release="true"
+    ;;
+  *)
+    error "Unknown argument '$1'"
+    usage
+    exit1
+    ;;
+esac
+
+# read the current version from Cargo.toml
+cargo_toml_contents="$(<Cargo.toml)"
+VOLTA_VERSION="$(parse_cargo_version "$cargo_toml_contents")" || exit 1
+
+# figure out the OS details
+os="$(uname -s)"
+openssl_version="$(openssl version)" || exit 1
+VOLTA_OS="$(parse_os_info "$os" "$openssl_version")"
+if [ "$?" != 0 ]; then
+  error "Releases for '$os' are not yet supported."
+  request "To support '$os', add another case to parse_os_info() in volta-install.sh."
+  exit 1
+fi
+
+release_filename="volta-$VOLTA_VERSION-$VOLTA_OS"
+
+# first make sure the release binaries have been built
+info 'Building' "Volta for $(bold "$release_filename")"
+if [ "$build_with_release" == "true" ]
+then
+  target_dir="target/release"
+  cargo build --features volta-updates --release
+else
+  target_dir="target/debug"
+  cargo build --features volta-updates
+fi || exit 1
+
+# then package the binaries and shell scripts together
+shell_script_dir="shell/unix"
+info 'Packaging' "the compiled binaries and shell scripts"
+cd "$target_dir"
+# using COPYFILE_DISABLE to avoid storing extended attribute files when run on OSX
+# (see https://superuser.com/q/61185)
+COPYFILE_DISABLE=1 tar -czvf "$release_filename.tar.gz" volta volta-shim
+
+info 'Completed' "release in file $target_dir/$release_filename.tar.gz"

--- a/dev/unix/volta-install-updates.sh
+++ b/dev/unix/volta-install-updates.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+
+# This is the bootstrap Unix installer served by `https://get.volta.sh`.
+# Its responsibility is to query the system to determine what OS (and in the
+# case of Linux, what OpenSSL version) the system has, fetch and install the
+# appropriate build of Volta, and modify the user's profile.
+
+# NOTE: to use an internal company repo, change how this determines the latest version
+get_latest_release() {
+  curl --silent "https://volta.sh/latest-version"
+}
+
+release_url() {
+  echo "https://github.com/volta-cli/volta/releases"
+}
+
+download_release_from_repo() {
+  local version="$1"
+  local os_info="$2"
+  local tmpdir="$3"
+
+  local filename="volta-$version-$os_info.tar.gz"
+  local download_file="$tmpdir/$filename"
+  local archive_url="$(release_url)/download/v$version/$filename"
+
+  curl --progress-bar --show-error --location --fail "$archive_url" --output "$download_file" && echo "$download_file"
+}
+
+usage() {
+    cat >&2 <<END_USAGE
+volta-install: The installer for Volta
+
+USAGE:
+    volta-install [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help                  Prints help information
+
+OPTIONS:
+        --dev                   Compile and install Volta locally, using the dev target
+        --release               Compile and install Volta locally, using the release target
+        --version <version>     Install a specific release version of Volta
+END_USAGE
+}
+
+info() {
+  local action="$1"
+  local details="$2"
+  command printf '\033[1;32m%12s\033[0m %s\n' "$action" "$details" 1>&2
+}
+
+error() {
+  command printf '\033[1;31mError\033[0m: %s\n\n' "$1" 1>&2
+}
+
+warning() {
+  command printf '\033[1;33mWarning\033[0m: %s\n\n' "$1" 1>&2
+}
+
+request() {
+  command printf '\033[1m%s\033[0m\n' "$1" 1>&2
+}
+
+eprintf() {
+  command printf '%s\n' "$1" 1>&2
+}
+
+bold() {
+  command printf '\033[1m%s\033[0m' "$1"
+}
+
+# check for issue with VOLTA_HOME
+# if it is set, and exists, but is not a directory, the install will fail
+volta_home_is_ok() {
+  if [ -n "${VOLTA_HOME-}" ] && [ -e "$VOLTA_HOME" ] && ! [ -d "$VOLTA_HOME" ]; then
+    error "\$VOLTA_HOME is set but is not a directory ($VOLTA_HOME)."
+    eprintf "Please check your profile scripts and environment."
+    return 1
+  fi
+  return 0
+}
+
+# Check if it is OK to upgrade to the new version
+upgrade_is_ok() {
+  local will_install_version="$1"
+  local install_dir="$2"
+  local is_dev_install="$3"
+
+  local volta_bin="$install_dir/volta"
+
+  # this is not able to install Volta prior to 0.5.0 (when it was renamed)
+  if [[ "$will_install_version" =~ ^([0-9]+\.[0-9]+) ]]; then
+    local major_minor="${BASH_REMATCH[1]}"
+    case "$major_minor" in
+      0.1|0.2|0.3|0.4|0.5)
+        eprintf ""
+        error "Cannot install Volta prior to version 0.6.0"
+        request "    To install Volta version $will_install_version, please check out the source and build manually."
+        eprintf ""
+        return 1
+        ;;
+    esac
+  fi
+
+  if [[ -n "$install_dir" && -x "$volta_bin" ]]; then
+    local prev_version="$( ($volta_bin --version 2>/dev/null || echo 0.1) | sed -E 's/^.*([0-9]+\.[0-9]+\.[0-9]+).*$/\1/')"
+    # if this is a local dev install, skip the equality check
+    # if installing the same version, this is a no-op
+    if [ "$is_dev_install" != "true" ] && [ "$prev_version" == "$will_install_version" ]; then
+      eprintf "Version $will_install_version already installed"
+      return 1
+    fi
+    # in the future, check $prev_version for incompatible upgrades
+  fi
+  return 0
+}
+
+# returns the os name to be used in the packaged release,
+# including the openssl info if necessary
+parse_os_info() {
+  local uname_str="$1"
+  local openssl_version="$2"
+
+  case "$uname_str" in
+    Linux)
+      parsed_version="$(parse_openssl_version "$openssl_version")"
+      exit_code="$?"
+      if [ "$exit_code" != 0 ]; then
+        return "$exit_code"
+      fi
+
+      echo "linux-openssl-$parsed_version"
+      ;;
+    Darwin)
+      echo "macos"
+      ;;
+    *)
+      return 1
+  esac
+  return 0
+}
+
+parse_os_pretty() {
+  local uname_str="$1"
+
+  case "$uname_str" in
+    Linux)
+      echo "Linux"
+      ;;
+    Darwin)
+      echo "macOS"
+      ;;
+    *)
+      echo "$uname_str"
+  esac
+}
+
+# return true(0) if the element is contained in the input arguments
+# called like:
+#  if element_in "foo" "${array[@]}"; then ...
+element_in() {
+  local match="$1";
+  shift
+
+  local element;
+  # loop over the input arguments and return when a match is found
+  for element in "$@"; do
+    [ "$element" == "$match" ] && return 0
+  done
+  return 1
+}
+
+# parse the OpenSSL version from the input text
+# for most distros, we only care about MAJOR.MINOR, with the exception of RHEL/CENTOS,
+parse_openssl_version() {
+  local version_str="$1"
+
+  # array containing the SSL libraries that are supported
+  # would be nice to use a bash 4.x associative array, but bash 3.x is the default on OSX
+  SUPPORTED_SSL_LIBS=( 'OpenSSL' )
+
+  # use regex to get the library name and version
+  # typical version string looks like 'OpenSSL 1.0.1e-fips 11 Feb 2013'
+  if [[ "$version_str" =~ ^([^\ ]*)\ ([0-9]+\.[0-9]+) ]]
+  then
+    # check that the lib is supported
+    libname="${BASH_REMATCH[1]}"
+    major_minor="${BASH_REMATCH[2]}"
+    if ! element_in "$libname" "${SUPPORTED_SSL_LIBS[@]}"
+    then
+      error "Releases for '$libname' not currently supported. Supported libraries are: ${SUPPORTED_SSL_LIBS[@]}."
+      return 1
+    fi
+
+    # for version 1.0.x, check for RHEL/CentOS style OpenSSL SONAME (.so.10)
+    if [ "$major_minor" == "1.0" ] && [ -f "/usr/lib64/libcrypto.so.10" ]; then
+      echo "rhel"
+    else
+      echo "$major_minor"
+    fi
+    return 0
+  else
+    error "Could not determine OpenSSL version for '$version_str'."
+    return 1
+  fi
+}
+
+create_tree() {
+  local install_dir="$1"
+
+  info 'Creating' "directory layout"
+
+  # .volta/
+  #     bin/
+
+  mkdir -p "$install_dir"
+  mkdir -p "$install_dir"/bin
+}
+
+install_version() {
+  local version_to_install="$1"
+  local install_dir="$2"
+
+  if ! volta_home_is_ok; then
+    exit 1
+  fi
+
+  case "$version_to_install" in
+    latest)
+      local latest_version="$(get_latest_release)"
+      info 'Installing' "latest version of Volta ($latest_version)"
+      install_release "$latest_version" "$install_dir"
+      ;;
+    local-dev)
+      info 'Installing' "Volta locally after compiling"
+      install_local "dev" "$install_dir"
+      ;;
+    local-release)
+      info 'Installing' "Volta locally after compiling with '--release'"
+      install_local "release" "$install_dir"
+      ;;
+    *)
+      # assume anything else is a specific version
+      info 'Installing' "Volta version $version_to_install"
+      install_release "$version_to_install" "$install_dir"
+      ;;
+  esac
+
+  if [ "$?" == 0 ]
+  then
+      info 'Finished' "installation. Updating user profile settings."
+      "$install_dir"/bin/volta setup
+  fi
+}
+
+# parse the 'version = "X.Y.Z"' line from the input Cargo.toml contents
+# and return the version string
+parse_cargo_version() {
+  local contents="$1"
+
+  while read -r line
+  do
+    if [[ "$line" =~ ^version\ =\ \"(.*)\" ]]
+    then
+      echo "${BASH_REMATCH[1]}"
+      return 0
+    fi
+  done <<< "$contents"
+
+  error "Could not determine the current version from Cargo.toml"
+  return 1
+}
+
+install_release() {
+  local version="$1"
+  local install_dir="$2"
+  local is_dev_install="false"
+
+  info 'Checking' "for existing Volta installation"
+  if upgrade_is_ok "$version" "$install_dir" "$is_dev_install"
+  then
+    download_archive="$(download_release "$version"; exit "$?")"
+    exit_status="$?"
+    if [ "$exit_status" != 0 ]
+    then
+      error "Could not download Volta version '$version'. See $(release_url) for a list of available releases"
+      return "$exit_status"
+    fi
+
+    install_from_file "$download_archive" "$install_dir"
+  else
+    # existing legacy install, or upgrade problem
+    return 1
+  fi
+}
+
+install_local() {
+  local dev_or_release="$1"
+  local install_dir="$2"
+  # this is a local install, so skip the version equality check
+  local is_dev_install="true"
+
+  info 'Checking' "for existing Volta installation"
+  install_version="$(parse_cargo_version "$(<Cargo.toml)" )" || return 1
+  if upgrade_is_ok "$install_version" "$install_dir" "$is_dev_install"
+  then
+    # compile and package the binaries, then install from that local archive
+    compiled_archive="$(compile_and_package "$dev_or_release")" &&
+      install_from_file "$compiled_archive" "$install_dir"
+  else
+    # existing legacy install, or upgrade problem
+    return 1
+  fi
+}
+
+compile_and_package() {
+  local dev_or_release="$1"
+
+  local release_output
+
+  # get the directory of this script
+  # (from https://stackoverflow.com/a/246128)
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+  # call the release script to create the packaged archive file
+  # '2> >(tee /dev/stderr)' copies stderr to stdout, to collect it and parse the filename
+  # TODO: When we merge in the volta-updates feature and remove the feature flag, we can
+  #       update this to be 'release.sh'
+  release_output="$( "$DIR/release-updates.sh" "--$dev_or_release" 2> >(tee /dev/stderr) )"
+  [ "$?" != 0 ] && return 1
+
+  # parse the release filename and return that
+  if [[ "$release_output" =~ release\ in\ file\ (target[^\ ]+) ]]; then
+    echo "${BASH_REMATCH[1]}"
+  else
+    error "Could not determine output filename"
+    return 1
+  fi
+}
+
+download_release() {
+  local version="$1"
+
+  local uname_str="$(uname -s)"
+  local openssl_version="$(openssl version)"
+  local os_info
+  os_info="$(parse_os_info "$uname_str" "$openssl_version")"
+  if [ "$?" != 0 ]; then
+    error "The current operating system ($uname_str) does not appear to be supported by Volta."
+    return 1
+  fi
+  local pretty_os_name="$(parse_os_pretty "$uname_str")"
+
+  info 'Fetching' "archive for $pretty_os_name, version $version"
+  # store the downloaded archive in a temporary directory
+  local download_dir="$(mktemp -d)"
+  download_release_from_repo "$version" "$os_info" "$download_dir"
+}
+
+install_from_file() {
+  local archive="$1"
+  local install_dir="$2"
+
+  create_tree "$install_dir"
+
+  info 'Extracting' "Volta binaries and launchers"
+  # extract the files to the specified directory
+  tar -xzvf "$archive" -C "$install_dir"/bin
+}
+
+check_architecture() {
+  local version="$1"
+  local arch="$2"
+
+  if [[ "$version" != "local"* ]]; then
+    if [ "$arch" != "x86_64" ]; then
+      error "Sorry! Volta currently only provides pre-built binaries for x86_64 architectures."
+      return 1
+    fi
+  fi
+}
+
+
+# return if sourced (for testing the functions above)
+return 0 2>/dev/null
+
+# default to installing the latest available version
+version_to_install="latest"
+
+# install to VOLTA_HOME, defaulting to ~/.volta
+install_dir="${VOLTA_HOME:-"$HOME/.volta"}"
+
+# parse command line options
+while [ $# -gt 0 ]
+do
+  arg="$1"
+
+  case "$arg" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --dev)
+      shift # shift off the argument
+      version_to_install="local-dev"
+      ;;
+    --release)
+      shift # shift off the argument
+      version_to_install="local-release"
+      ;;
+    --version)
+      shift # shift off the argument
+      version_to_install="$1"
+      shift # shift off the value
+      ;;
+    *)
+      error "unknown option: '$arg'"
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+check_architecture "$version_to_install" "$(uname -m)" || exit 1
+
+install_version "$version_to_install" "$install_dir"

--- a/wix/updates.wxs
+++ b/wix/updates.wxs
@@ -1,0 +1,191 @@
+<?xml version='1.0' encoding='windows-1252'?>
+<!--
+  Copyright (C) 2017 Christopher R. Field.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!--
+  Please do not remove these pre-processor If-Else blocks. These are used with
+  the `cargo wix` subcommand to automatically determine the installation
+  destination for 32-bit versus 64-bit installers. Removal of these lines will
+  cause installation errors.
+-->
+<?if $(var.Platform) = x64 ?>
+    <?define Win64 = "yes" ?>
+    <?define PlatformProgramFilesFolder = "ProgramFiles64Folder" ?>
+<?else ?>
+  <?define Win64 = "no" ?>
+  <?define PlatformProgramFilesFolder = "ProgramFilesFolder" ?>
+<?endif ?>
+
+<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>
+
+    <Product
+        Id='*'
+        Name='Volta'
+        UpgradeCode='42A39E14-335A-4464-AA37-17FDA38FA377'
+        Manufacturer='The Volta Maintainers'
+        Language='1033'
+        Codepage='1252'
+        Version='$(var.Version)'>
+
+        <Package Id='*'
+            Keywords='Installer'
+            Description='The JavaScript Launcher'
+            Manufacturer='The Volta Maintainers'
+            InstallerVersion='450'
+            Languages='1033'
+            Compressed='yes'
+            InstallScope='perMachine'
+            SummaryCodepage='1252'
+            Platform='$(var.Platform)'/>
+
+        <MajorUpgrade
+            Schedule='afterInstallInitialize'
+            DowngradeErrorMessage='A newer version of [ProductName] is already installed. Setup will now exit.'/>
+
+        <Media Id='1' Cabinet='media1.cab' EmbedCab='yes' CompressionLevel='high'/>
+
+        <Directory Id='TARGETDIR' Name='SourceDir'>
+            <Directory Id='$(var.PlatformProgramFilesFolder)' Name='PFiles'>
+                <Directory Id='INSTALLDIR' Name='Volta'>
+                </Directory>
+            </Directory>
+        </Directory>
+
+        <ComponentGroup Id='Binaries' Directory='INSTALLDIR'>
+            <Component Id='voltaBinary' Guid='*' Win64='$(var.Win64)'>
+                <File
+                    Id='voltaEXE'
+                    Name='volta.exe'
+                    DiskId='1'
+                    Source='target\release\volta.exe'
+                    KeyPath='yes'/>
+                <Environment
+                    Id='INSTALLPATH'
+                    Name='PATH'
+                    Value='[INSTALLDIR]'
+                    Permanent='no'
+                    Part='first'
+                    Action='set'
+                    System='yes' />
+            </Component>
+            <Component Id='shimBinary' Guid='*' Win64='$(var.Win64)'>
+                <File
+                    Id='voltashimEXE'
+                    Name='volta-shim.exe'
+                    DiskId='1'
+                    Source='target\release\volta-shim.exe'
+                    KeyPath='yes'/>
+            </Component>
+            <Component Id='nodeBinary' Guid='*' Win64='$(var.Win64)'>
+                <File
+                    Id='nodeEXE'
+                    Name='node.exe'
+                    DiskId='1'
+                    Source='target\release\volta-shim.exe'
+                    KeyPath='yes'/>
+            </Component>
+            <Component Id='npmBinary' Guid='*' Win64='$(var.Win64)'>
+                <File
+                    Id='npmEXE'
+                    Name='npm.exe'
+                    DiskId='1'
+                    Source='target\release\volta-shim.exe'
+                    KeyPath='yes'/>
+            </Component>
+            <Component Id='npxBinary' Guid='*' Win64='$(var.Win64)'>
+                <File
+                    Id='npxEXE'
+                    Name='npx.exe'
+                    DiskId='1'
+                    Source='target\release\volta-shim.exe'
+                    KeyPath='yes'/>
+            </Component>
+            <Component Id='yarnBinary' Guid='*' Win64='$(var.Win64)'>
+                <File
+                    Id='yarnEXE'
+                    Name='yarn.exe'
+                    DiskId='1'
+                    Source='target\release\volta-shim.exe'
+                    KeyPath='yes'/>
+            </Component>
+        </ComponentGroup>
+
+        <Feature Id='MainProgram'>
+            <ComponentGroupRef Id='Binaries'/>
+        </Feature>
+
+        <SetProperty Id='ARPINSTALLLOCATION' Value='[APPLICATIONFOLDER]' After='CostFinalize'/>
+
+        <CustomAction
+            Id="VoltaSetup"
+            FileKey="voltaEXE"
+            ExeCommand="setup"
+            Execute="deferred"
+            Return="ignore" />
+
+        <InstallExecuteSequence>
+            <Custom Action="VoltaSetup" Before="InstallFinalize" />
+        </InstallExecuteSequence>
+
+        <!--
+          Uncomment the following `Icon` and `Property` tags to change the product icon.
+
+          The product icon is the graphic that appears in the Add/Remove
+          Programs control panel for the application.
+        -->
+        <Icon Id='ProductICO' SourceFile='wix\volta.ico'/>
+        <Property Id='ARPPRODUCTICON' Value='ProductICO' />
+
+        <Property Id='ARPHELPLINK' Value='https://github.com/volta-cli/volta'/>
+        <Property Id='LicenseAccepted' Value='1'/>
+
+        <UI>
+            <UIRef Id='WixUI_FeatureTree' />
+
+            <Publish Dialog='LicenseAgreementDlg' Control='Next' Event='NewDialog' Value='VerifyReadyDlg' Order='2'>1</Publish>
+            <Publish Dialog='VerifyReadyDlg' Control='Back' Event='NewDialog' Value='LicenseAgreementDlg' Order='2'>1</Publish>
+        </UI>
+
+        <!--
+          Enabling the EULA dialog in the installer requires uncommenting
+          the following `WixUILicenseRTF` tag and changing the `Value`
+          attribute.
+        -->
+        <WixVariable Id='WixUILicenseRtf' Value='wix\License.rtf'/>
+
+        <!--
+          Uncomment the next `WixVaraible` tag to customize the installer's
+          Graphical User Interface (GUI) and add a custom banner image across
+          the top of each screen. See the WiX Toolset documentation for details
+          about customization.
+
+          The banner BMP dimensions are 493 x 58 pixels.
+        -->
+        <!--<WixVariable Id='WixUIBannerBmp' Value='wix\Banner.bmp'/>-->
+
+        
+        <!--
+          Uncomment the next `WixVariable` tag to customize the installer's
+          Graphical User Interface (GUI) and add a custom image to the first
+          dialog, or screen. See the WiX Toolset documentation for details about
+          customization.
+
+          The dialog BMP dimensions are 493 x 312 pixels.
+        -->
+        <!--<WixVariable Id='WixUIDialogBmp' Value='wix\Dialog.bmp'/>-->
+
+    </Product>
+</Wix>


### PR DESCRIPTION
Closes #565 

Info
-----
* With `volta setup` created in #578, we can simplify the installers that we currently support to do 2 things:
    * Install the binary files (`volta` and `volta-shim`) onto the PATH
    * Call `volta setup` to handle creating the user directory and adding the Shim directory to the PATH

Changes
-----
* Added new installers for Windows (`updates.wxs`), Unix (`volta-install-updates.sh`), and RPM (`volta-updates.spec`).
* Copied and updated helper scripts (`release.sh` and `build-rpm.sh`) to support compiling with the `volta-updates` feature so that `volta setup` is available.

Notes
-----
* This PR builds on #578, so will remain a draft until that is merged