### PR TITLE
Write 'volta list' output to stdout directly

### DIFF
--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -318,9 +318,9 @@ impl Command for List {
         };
 
         if let Some(string) = format(&toolchain) {
-            // TODO: #523 -- just `info!("{}", string)` once `human` implemented
+            // TODO: #523 -- just `println!("{}", string)` once `human` implemented
             match self.output_format() {
-                Format::Plain => info!("{}", string),
+                Format::Plain => println!("{}", string),
                 Format::Human => warn!("{}", string),
             }
         };


### PR DESCRIPTION
We are currently using `info!` to write the output of `volta list`. However, that goes to `stderr` since it is part of the logging interface. Since the expected effect of running `volta list` is output to the terminal, we should directly write to stdout using `println!` instead.

This aligns with `volta which` also writing to stdout, since it is expected output instead of a purely informational note about what happened.