### PR TITLE
Allow Pinning Node and Yarn in a single command

### DIFF
--- a/crates/volta-core/src/manifest/mod.rs
+++ b/crates/volta-core/src/manifest/mod.rs
@@ -60,28 +60,18 @@ impl Manifest {
         self.platform().map(|t| t.node_runtime.clone())
     }
 
-    /// Returns the pinned verison of Node as a String, if any.
-    pub fn node_str(&self) -> Option<String> {
-        self.platform().map(|t| t.node_runtime.to_string())
-    }
-
     /// Returns the pinned verison of Yarn as a Version, if any.
     pub fn yarn(&self) -> Option<Version> {
         self.platform().map(|t| t.yarn.clone()).unwrap_or(None)
     }
 
-    /// Returns the pinned verison of Yarn as a String, if any.
-    pub fn yarn_str(&self) -> Option<String> {
-        self.platform()
-            .and_then(|t| t.yarn.as_ref().map(|yarn| yarn.to_string()))
+    /// Updates the pinned platform information
+    pub fn update_platform(&mut self, platform: PlatformSpec) {
+        self.platform = Some(Rc::new(platform));
     }
 
-    /// Writes the input ToolchainManifest to package.json, adding the "volta" key if
-    /// necessary.
-    pub fn update_toolchain(
-        toolchain: serial::ToolchainSpec,
-        package_file: PathBuf,
-    ) -> Fallible<()> {
+    /// Updates the `volta` key in the specified `package.json` to match the current Manifest
+    pub fn write(&self, package_file: PathBuf) -> Fallible<()> {
         // Helper for lazily creating the file name string without moving `package_file` into
         // one of the individual `with_context` closures below.
         let get_file = || package_file.to_owned();
@@ -97,9 +87,13 @@ impl Manifest {
             let indent = detect_indent::detect_indent(&contents);
 
             // update the "volta" key
-            let toolchain_value = serde_json::to_value(toolchain)
-                .with_context(|_| ErrorDetails::StringifyToolchainError)?;
-            map.insert("volta".to_string(), toolchain_value);
+            if let Some(platform) = self.platform() {
+                let volta_value = serde_json::to_value(serial::ToolchainSpec::from(platform))
+                    .with_context(|_| ErrorDetails::StringifyToolchainError)?;
+                map.insert("volta".to_string(), volta_value);
+            } else {
+                map.remove("volta");
+            }
 
             // serialize the updated contents back to package.json
             let file = File::create(&package_file)

--- a/crates/volta-core/src/manifest/serial.rs
+++ b/crates/volta-core/src/manifest/serial.rs
@@ -190,16 +190,12 @@ impl From<RawBinManifest> for super::BinManifest {
     }
 }
 
-impl ToolchainSpec {
-    pub fn new(
-        node_version: String,
-        npm_version: Option<String>,
-        yarn_version: Option<String>,
-    ) -> Self {
+impl From<Rc<platform::PlatformSpec>> for ToolchainSpec {
+    fn from(source: Rc<platform::PlatformSpec>) -> Self {
         ToolchainSpec {
-            node: node_version,
-            npm: npm_version,
-            yarn: yarn_version,
+            node: source.node_runtime.to_string(),
+            npm: source.npm.as_ref().map(|v| v.to_string()),
+            yarn: source.yarn.as_ref().map(|v| v.to_string()),
         }
     }
 }

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -101,8 +101,13 @@ impl Session {
     }
 
     /// Produces a reference to the current Node project, if any.
-    pub fn project(&self) -> Fallible<Option<Rc<Project>>> {
+    pub fn project(&self) -> Fallible<Option<&Project>> {
         self.project.get()
+    }
+
+    /// Produces a mutable reference to the current Node project, if any.
+    pub fn project_mut(&mut self) -> Fallible<Option<&mut Project>> {
+        self.project.get_mut()
     }
 
     /// Returns the user's currently active platform, if any

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -140,7 +140,7 @@ impl Tool for Node {
             let node_version = self.fetch_internal(session)?;
 
             // Note: We know this will succeed, since we checked above
-            let project = session.project()?.unwrap();
+            let project = session.project_mut()?.unwrap();
             project.pin_node(&node_version)?;
 
             info_pinned(node_version);

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -136,9 +136,11 @@ impl Tool for Node {
         Ok(())
     }
     fn pin(self, session: &mut Session) -> Fallible<()> {
-        if let Some(ref project) = session.project()? {
+        if session.project()?.is_some() {
             let node_version = self.fetch_internal(session)?;
 
+            // Note: We know this will succeed, since we checked above
+            let project = session.project()?.unwrap();
             project.pin_node(&node_version)?;
 
             info_pinned(node_version);

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -70,7 +70,7 @@ impl Tool for Yarn {
             self.fetch_internal(session)?;
 
             // Note: We know this will succeed, since we checked above
-            let project = session.project()?.unwrap();
+            let project = session.project_mut()?.unwrap();
             project.pin_yarn(&self.version)?;
 
             info_pinned(self);

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -66,8 +66,11 @@ impl Tool for Yarn {
         Ok(())
     }
     fn pin(self, session: &mut Session) -> Fallible<()> {
-        if let Some(ref project) = session.project()? {
+        if session.project()?.is_some() {
             self.fetch_internal(session)?;
+
+            // Note: We know this will succeed, since we checked above
+            let project = session.project()?.unwrap();
             project.pin_yarn(&self.version)?;
 
             info_pinned(self);

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -9,7 +9,6 @@ use semver::Version;
 use structopt::StructOpt;
 
 use crate::command::Command;
-use std::rc::Rc;
 use toolchain::Toolchain;
 use volta_core::inventory::Inventory;
 use volta_core::project::Project;
@@ -135,7 +134,7 @@ impl Package {
 
     fn from_inventory_and_project(
         inventory: &Inventory,
-        project: &Option<Rc<Project>>,
+        project: Option<&Project>,
     ) -> Vec<Package> {
         inventory
             .packages
@@ -147,7 +146,7 @@ impl Package {
             .collect()
     }
 
-    fn source(name: &str, version: &Version, project: &Option<Rc<Project>>) -> Source {
+    fn source(name: &str, version: &Version, project: Option<&Project>) -> Source {
         match project {
             Some(project) if project.has_dependency(name, version) => {
                 Source::Project(project.package_file())
@@ -308,12 +307,12 @@ impl Command for List {
 
         let toolchain = match self.subcommand() {
             // For no subcommand, show the user's current toolchain
-            None => Toolchain::active(&project, &user_platform, inventory)?,
-            Some(Subcommand::All) => Toolchain::all(&project, &user_platform, inventory)?,
-            Some(Subcommand::Node) => Toolchain::node(inventory, &project, &user_platform, &filter),
-            Some(Subcommand::Yarn) => Toolchain::yarn(inventory, &project, &user_platform, &filter),
+            None => Toolchain::active(project, &user_platform, inventory)?,
+            Some(Subcommand::All) => Toolchain::all(project, &user_platform, inventory)?,
+            Some(Subcommand::Node) => Toolchain::node(inventory, project, &user_platform, &filter),
+            Some(Subcommand::Yarn) => Toolchain::yarn(inventory, project, &user_platform, &filter),
             Some(Subcommand::PackageOrTool { name }) => {
-                Toolchain::package_or_tool(&name, inventory, &project, &filter)?
+                Toolchain::package_or_tool(&name, inventory, project, &filter)?
             }
         };
 

--- a/src/command/list/toolchain.rs
+++ b/src/command/list/toolchain.rs
@@ -48,7 +48,7 @@ impl Lookup {
 
     fn version_source<'p>(
         self,
-        project: &'p Option<Rc<Project>>,
+        project: Option<&'p Project>,
         user_platform: &Option<Rc<PlatformSpec>>,
         version: &Version,
     ) -> Source {
@@ -74,7 +74,7 @@ impl Lookup {
     /// Determine the `Source` for a given kind of tool (`Lookup`).
     fn active_tool(
         self,
-        project: &Option<Rc<Project>>,
+        project: Option<&Project>,
         user: &Option<Rc<PlatformSpec>>,
     ) -> Option<(Source, Version)> {
         match project {
@@ -91,11 +91,10 @@ impl Lookup {
 }
 
 /// Look up the `Source` for a tool with a given name.
-fn tool_source(name: &str, version: &Version, project: &Option<Rc<Project>>) -> Fallible<Source> {
+fn tool_source(name: &str, version: &Version, project: Option<&Project>) -> Fallible<Source> {
     match project {
         Some(project) => {
             let project_version_is_tool_version = project
-                .as_ref()
                 .matching_bin(&OsString::from(name), version)?
                 .map_or(false, |bin| &bin.version == version);
 
@@ -111,7 +110,7 @@ fn tool_source(name: &str, version: &Version, project: &Option<Rc<Project>>) -> 
 
 impl Toolchain {
     pub(super) fn active(
-        project: &Option<Rc<Project>>,
+        project: Option<&Project>,
         user_platform: &Option<Rc<PlatformSpec>>,
         inventory: &Inventory,
     ) -> Fallible<Toolchain> {
@@ -138,7 +137,7 @@ impl Toolchain {
     }
 
     pub(super) fn all(
-        project: &Option<Rc<Project>>,
+        project: Option<&Project>,
         user_platform: &Option<Rc<PlatformSpec>>,
         inventory: &Inventory,
     ) -> Fallible<Toolchain> {
@@ -174,7 +173,7 @@ impl Toolchain {
 
     pub(super) fn node(
         inventory: &Inventory,
-        project: &Option<Rc<Project>>,
+        project: Option<&Project>,
         user_platform: &Option<Rc<PlatformSpec>>,
         filter: &Filter,
     ) -> Toolchain {
@@ -198,7 +197,7 @@ impl Toolchain {
 
     pub(super) fn yarn(
         inventory: &Inventory,
-        project: &Option<Rc<Project>>,
+        project: Option<&Project>,
         user_platform: &Option<Rc<PlatformSpec>>,
         filter: &Filter,
     ) -> Toolchain {
@@ -226,7 +225,7 @@ impl Toolchain {
     pub(super) fn package_or_tool(
         name: &str,
         inventory: &Inventory,
-        project: &Option<Rc<Project>>,
+        project: Option<&Project>,
         filter: &Filter,
     ) -> Fallible<Toolchain> {
         /// An internal-only helper for tracking whether we found a given item

--- a/tests/acceptance/volta_pin.rs
+++ b/tests/acceptance/volta_pin.rs
@@ -441,3 +441,24 @@ fn pin_npm() {
         package_json_with_pinned_node_npm("1.2.3", "5.10.12"),
     )
 }
+
+#[test]
+fn pin_node_and_yarn() {
+    let s = sandbox()
+        .package_json(BASIC_PACKAGE_JSON)
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.volta("pin node@6 yarn@1.4"),
+        execs().with_status(ExitCode::Success as i32)
+    );
+
+    assert_eq!(
+        s.read_package_json(),
+        package_json_with_pinned_node_yarn("6.19.62", "1.4.159"),
+    )
+}

--- a/tests/smoke/support/temp_project.rs
+++ b/tests/smoke/support/temp_project.rs
@@ -100,10 +100,7 @@ impl TempProjectBuilder {
         ok_or_panic!(symlink_file(shim_exe(), self.root.yarn_exe()));
         ok_or_panic!(symlink_file(shim_exe(), self.root.npm_exe()));
 
-        ok_or_panic!(symlink_file(
-            shim_exe(),
-            shim_executable(self.root())
-        ));
+        ok_or_panic!(symlink_file(shim_exe(), shim_executable(self.root())));
 
         // write files
         for file_builder in self.files {
@@ -218,7 +215,10 @@ fn user_platform_file(root: PathBuf) -> PathBuf {
     user_dir(root).join("platform.json")
 }
 pub fn node_distro_file_name(version: &str) -> String {
-    format!("node-v{}-{}-{}.tar.gz", version, NODE_DISTRO_OS, NODE_DISTRO_ARCH)
+    format!(
+        "node-v{}-{}-{}.tar.gz",
+        version, NODE_DISTRO_OS, NODE_DISTRO_ARCH
+    )
 }
 fn yarn_distro_file_name(version: &str) -> String {
     format!("yarn-v{}.tar.gz", version)


### PR DESCRIPTION
Closes #522 

Info
-----
* Currently our `Project` state is lazily evaluated and then never updated when we make changes.
* This means that if we try to `volta pin` both Node and Yarn in the same command, the first one succeeds (pinning Node), but the second fails (pinning Yarn) because it looks at the internal `Project` and thinks that Node isn't pinned yet.
* We should update the internal state to reflect any changes that we make, so that future pins in the same command will see the true state, instead of an outdated one.

Changes
-----
* Switched the `LazyProject` and related methods to return a reference instead of an `Rc`
* Added the ability to get a mutable reference to the project.
* Updated `Manifest` to separate changing the stored `PlatformSpec` and writing those changes into separate methods.
* Migrated the `pin` commands to first update the internal `Manifest` and then write the changes, so that our internal state is kept up-to-date.

Tested
-----
* Manual testing on a non-pinned project, confirming that both Node and Yarn are correctly pinned.
* Added an acceptance test to cover the use case of pinning multiple tools in the same command.