### PR TITLE
Enable Clippy lints and fix errors

### DIFF
--- a/ci/run-tests-updates.yml
+++ b/ci/run-tests-updates.yml
@@ -16,3 +16,10 @@ steps:
     env:
       RUST_BACKTRACE: full
     displayName: Smoke Tests
+
+  # clippy lints
+  - script: |
+      rustup component add clippy
+      cargo clippy --features volta-updates
+      cargo clippy --tests --features mock-network,volta-updates
+    displayName: Linting with Clippy

--- a/ci/run-tests.yml
+++ b/ci/run-tests.yml
@@ -21,3 +21,10 @@ steps:
   - script: bats dev/unix/tests/
     displayName: Shell Script Tests (not Windows)
     condition: not(eq(variables['Agent.OS'], 'Windows_NT'))
+
+  # clippy lints
+  - script: |
+      rustup component add clippy
+      cargo clippy
+      cargo clippy --tests --features mock-network
+    displayName: Linting with Clippy

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -39,9 +39,10 @@ impl Zip {
         let mut response = reqwest::get(url)?;
 
         if !response.status().is_success() {
-            Err(super::HttpError {
+            return Err(super::HttpError {
                 code: response.status(),
-            })?;
+            }
+            .into());
         }
 
         {

--- a/crates/test-support/src/matchers.rs
+++ b/crates/test-support/src/matchers.rs
@@ -265,12 +265,12 @@ impl Execs {
             );
 
             if let (Err(_), Err(_)) = (match_std, match_err) {
-                Err(format!(
+                return Err(format!(
                     "expected to find:\n\
                      {}\n\n\
                      did not find in either output.",
                     expect
-                ))?;
+                ));
             }
         }
 
@@ -350,6 +350,7 @@ impl Execs {
                 let e = out.lines();
 
                 let mut diffs = self.diff_lines(a.clone(), e.clone(), true);
+                #[allow(clippy::while_let_on_iterator)]
                 while let Some(..) = a.next() {
                     let a = self.diff_lines(a.clone(), e.clone(), true);
                     if a.len() < diffs.len() {
@@ -398,6 +399,7 @@ impl Execs {
                 let e = out.lines();
 
                 let mut diffs = self.diff_lines(a.clone(), e.clone(), true);
+                #[allow(clippy::while_let_on_iterator)]
                 while let Some(..) = a.next() {
                     let a = self.diff_lines(a.clone(), e.clone(), true);
                     if a.len() < diffs.len() {

--- a/crates/test-support/src/paths.rs
+++ b/crates/test-support/src/paths.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Once;
 
-static SMOKE_TEST_DIR: &'static str = "smoke_test";
+static SMOKE_TEST_DIR: &str = "smoke_test";
 static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
 
 thread_local!(static TASK_ID: usize = NEXT_ID.fetch_add(1, Ordering::SeqCst));
@@ -67,7 +67,7 @@ impl Remove {
         }
     }
 
-    fn at(&self, path: &Path) -> () {
+    fn at(&self, path: &Path) {
         if cfg!(windows) {
             let mut p = ok_or_panic!(path.metadata()).permissions();
             p.set_readonly(false);

--- a/crates/volta-core/src/env.rs
+++ b/crates/volta-core/src/env.rs
@@ -3,7 +3,7 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
-pub const UNSAFE_GLOBAL: &'static str = "VOLTA_UNSAFE_GLOBAL";
+pub const UNSAFE_GLOBAL: &str = "VOLTA_UNSAFE_GLOBAL";
 
 pub(crate) fn shell_name() -> Option<String> {
     env::var_os("VOLTA_SHELL").map(|s| s.to_string_lossy().into_owned())

--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -10,13 +10,12 @@ use volta_fail::{ExitCode, VoltaFail};
 use crate::style::{text_width, tool_version};
 use crate::tool;
 
-const REPORT_BUG_CTA: &'static str =
+const REPORT_BUG_CTA: &str =
     "Please rerun the command that triggered this error with the environment
 variables `VOLTA_LOGLEVEL` set to `debug` and `RUST_BACKTRACE` set to `full`, and open
 an issue at https://github.com/volta-cli/volta/issues with the details!";
 
-const PERMISSIONS_CTA: &'static str =
-    "Please ensure you have correct permissions to the Volta directory.";
+const PERMISSIONS_CTA: &str = "Please ensure you have correct permissions to the Volta directory.";
 
 #[derive(Debug, PartialEq)]
 pub enum CreatePostscriptErrorPath {

--- a/crates/volta-core/src/event.rs
+++ b/crates/volta-core/src/event.rs
@@ -81,13 +81,13 @@ fn get_error_env() -> ErrorEnv {
     let platform = info.os_type().to_string();
     let platform_version = info.version().to_string();
 
-    return ErrorEnv {
-        argv: argv,
-        exec_path: exec_path,
-        path: path,
-        platform: platform,
-        platform_version: platform_version,
-    };
+    ErrorEnv {
+        argv,
+        exec_path,
+        path,
+        platform,
+        platform_version,
+    }
 }
 
 pub struct EventLog {
@@ -96,7 +96,7 @@ pub struct EventLog {
 
 impl EventLog {
     /// Constructs a new 'EventLog'
-    pub fn new() -> Self {
+    pub fn init() -> Self {
         EventLog { events: Vec::new() }
     }
 
@@ -113,7 +113,7 @@ impl EventLog {
         let exit_code = error.exit_code();
         self.add_event(
             EventKind::Error {
-                exit_code: exit_code,
+                exit_code,
                 error: error.to_string(),
                 env: get_error_env(),
             },
@@ -149,7 +149,7 @@ pub mod tests {
 
     #[test]
     fn test_adding_events() {
-        let mut event_log = EventLog::new();
+        let mut event_log = EventLog::init();
         assert_eq!(event_log.events.len(), 0);
 
         event_log.add_event_start(ActivityKind::Current);

--- a/crates/volta-core/src/hook/mod.rs
+++ b/crates/volta-core/src/hook/mod.rs
@@ -33,7 +33,7 @@ pub struct LazyHookConfig {
 
 impl LazyHookConfig {
     /// Constructs a new `LazyHookConfig` (but does not initialize it).
-    pub fn new() -> LazyHookConfig {
+    pub fn init() -> LazyHookConfig {
         LazyHookConfig {
             settings: LazyCell::new(),
         }
@@ -41,7 +41,7 @@ impl LazyHookConfig {
 
     /// Forces the loading of the hook configuration
     pub fn get(&self) -> Fallible<&HookConfig> {
-        self.settings.try_borrow_with(|| HookConfig::current())
+        self.settings.try_borrow_with(HookConfig::current)
     }
 }
 
@@ -168,9 +168,9 @@ impl HookConfig {
                 file: file_path.to_path_buf(),
             })?;
 
-        let hooks_path = file_path.parent().unwrap_or(Path::new("/"));
+        let hooks_path = file_path.parent().unwrap_or_else(|| Path::new("/"));
 
-        raw.into_hook_config(hooks_path).map(|hooks| Some(hooks))
+        raw.into_hook_config(hooks_path).map(Some)
     }
 
     /// Returns the per-user hooks, loaded from the filesystem.

--- a/crates/volta-core/src/hook/mod.rs
+++ b/crates/volta-core/src/hook/mod.rs
@@ -32,7 +32,7 @@ pub struct LazyHookConfig {
 }
 
 impl LazyHookConfig {
-    /// Constructs a new `LazyHookConfig` (but does not initialize it).
+    /// Constructs a new `LazyHookConfig`
     pub fn init() -> LazyHookConfig {
         LazyHookConfig {
             settings: LazyCell::new(),

--- a/crates/volta-core/src/hook/tool.rs
+++ b/crates/volta-core/src/hook/tool.rs
@@ -13,9 +13,9 @@ use log::debug;
 use semver::Version;
 use volta_fail::{throw, Fallible, ResultExt};
 
-const ARCH_TEMPLATE: &'static str = "{{arch}}";
-const OS_TEMPLATE: &'static str = "{{os}}";
-const VERSION_TEMPLATE: &'static str = "{{version}}";
+const ARCH_TEMPLATE: &str = "{{arch}}";
+const OS_TEMPLATE: &str = "{{os}}";
+const VERSION_TEMPLATE: &str = "{{version}}";
 
 lazy_static! {
     static ref REL_PATH: String = format!(".{}", std::path::MAIN_SEPARATOR);

--- a/crates/volta-core/src/inventory/mod.rs
+++ b/crates/volta-core/src/inventory/mod.rs
@@ -23,7 +23,7 @@ pub struct LazyInventory {
 
 impl LazyInventory {
     /// Constructs a new `LazyInventory`.
-    pub fn new() -> LazyInventory {
+    pub fn init() -> LazyInventory {
         LazyInventory {
             inventory: LazyCell::new(),
         }
@@ -31,12 +31,12 @@ impl LazyInventory {
 
     /// Forces the loading of the inventory and returns an immutable reference to it.
     pub fn get(&self) -> Fallible<&Inventory> {
-        self.inventory.try_borrow_with(|| Inventory::current())
+        self.inventory.try_borrow_with(Inventory::current)
     }
 
     /// Forces the loading of the inventory and returns a mutable reference to it.
     pub fn get_mut(&mut self) -> Fallible<&mut Inventory> {
-        self.inventory.try_borrow_mut_with(|| Inventory::current())
+        self.inventory.try_borrow_mut_with(Inventory::current)
     }
 }
 

--- a/crates/volta-core/src/layout/windows.rs
+++ b/crates/volta-core/src/layout/windows.rs
@@ -26,10 +26,10 @@ cfg_if! {
 
         // This path needs to exactly match the Registry Key in the Windows Installer
         // wix/main.wxs -
-        const VOLTA_REGISTRY_PATH: &'static str = r#"Software\The Volta Maintainers\Volta"#;
+        const VOLTA_REGISTRY_PATH: &str = r#"Software\The Volta Maintainers\Volta"#;
 
         // This Key needs to exactly match the Name from the above element in the Windows Installer
-        const VOLTA_INSTALL_DIR: &'static str = "InstallDir";
+        const VOLTA_INSTALL_DIR: &str = "InstallDir";
 
         pub(super) fn default_install_dir() -> Fallible<PathBuf> {
             let hklm = RegKey::predef(HKEY_LOCAL_MACHINE);

--- a/crates/volta-core/src/log.rs
+++ b/crates/volta-core/src/log.rs
@@ -8,13 +8,13 @@ use textwrap::{NoHyphenation, Wrapper};
 
 use crate::style::text_width;
 
-const ERROR_PREFIX: &'static str = "error:";
-const WARNING_PREFIX: &'static str = "warning:";
-const SHIM_ERROR_PREFIX: &'static str = "Volta error:";
-const SHIM_WARNING_PREFIX: &'static str = "Volta warning:";
-const VOLTA_LOGLEVEL: &'static str = "VOLTA_LOGLEVEL";
-const ALLOWED_PREFIX: &'static str = "volta";
-const WRAP_INDENT: &'static str = "    ";
+const ERROR_PREFIX: &str = "error:";
+const WARNING_PREFIX: &str = "warning:";
+const SHIM_ERROR_PREFIX: &str = "Volta error:";
+const SHIM_WARNING_PREFIX: &str = "Volta warning:";
+const VOLTA_LOGLEVEL: &str = "VOLTA_LOGLEVEL";
+const ALLOWED_PREFIX: &str = "volta";
+const WRAP_INDENT: &str = "    ";
 
 /// Represents the context from which the logger was created
 pub enum LogContext {

--- a/crates/volta-core/src/manifest/mod.rs
+++ b/crates/volta-core/src/manifest/mod.rs
@@ -43,7 +43,7 @@ impl Manifest {
 
     /// Returns a reference to the platform image specified by manifest, if any.
     pub fn platform(&self) -> Option<Rc<PlatformSpec>> {
-        self.platform.as_ref().map(|p| p.clone())
+        self.platform.as_ref().cloned()
     }
 
     /// Gets the names of all the direct dependencies in the manifest.

--- a/crates/volta-core/src/monitor.rs
+++ b/crates/volta-core/src/monitor.rs
@@ -1,6 +1,5 @@
 use std::io::Write;
 use std::process::{Child, Stdio};
-use std::vec::Vec;
 
 use log::error;
 use serde_json;
@@ -22,7 +21,7 @@ impl Monitor {
 
     /// send event to the monitor process
     // if hook command is not configured, this is a no-op
-    pub fn send_events(&mut self, events: &Vec<Event>) -> () {
+    pub fn send_events(&mut self, events: &[Event]) {
         if let Some(ref mut child_process) = self.monitor_process {
             if let Some(ref mut p_stdin) = child_process.stdin.as_mut() {
                 let json = serde_json::to_string(&events);
@@ -43,9 +42,9 @@ impl Monitor {
 }
 
 fn spawn_process(command: &str) -> Option<Child> {
-    command.split(" ").take(1).next().and_then(|executable| {
+    command.split(' ').take(1).next().and_then(|executable| {
         let child = create_command(executable)
-            .args(command.split(" ").skip(1))
+            .args(command.split(' ').skip(1))
             .stdin(Stdio::piped()) // JSON data is sent over stdin
             // .stdout(Stdio::piped()) // let the plugin write to stdout for now
             .spawn();

--- a/crates/volta-core/src/platform/mod.rs
+++ b/crates/volta-core/src/platform/mod.rs
@@ -74,7 +74,7 @@ impl Image {
     /// will find toolchain executables (Node, Yarn) in the installation directories
     /// for the given versions instead of in the Volta shim directory.
     pub fn path(&self) -> Fallible<OsString> {
-        let old_path = envoy::path().unwrap_or(envoy::Var::from(""));
+        let old_path = envoy::path().unwrap_or_else(|| envoy::Var::from(""));
         let mut new_path = old_path.split();
 
         for remove_path in env_paths()? {
@@ -97,7 +97,7 @@ impl System {
     /// removes the Volta shims and binaries, to use for running system node and
     /// executables.
     pub fn path() -> Fallible<OsString> {
-        let old_path = envoy::path().unwrap_or(envoy::Var::from(""));
+        let old_path = envoy::path().unwrap_or_else(|| envoy::Var::from(""));
         let mut new_path = old_path.split();
 
         for remove_path in env_paths()? {
@@ -110,7 +110,7 @@ impl System {
     /// Reproduces the Volta-enabled `PATH` environment variable for situations where
     /// Volta has been deactivated
     pub fn enabled_path() -> Fallible<OsString> {
-        let old_path = envoy::path().unwrap_or(envoy::Var::from(""));
+        let old_path = envoy::path().unwrap_or_else(|| envoy::Var::from(""));
         let mut new_path = old_path.split();
 
         for add_path in env_paths()? {

--- a/crates/volta-core/src/project.rs
+++ b/crates/volta-core/src/project.rs
@@ -25,7 +25,7 @@ pub struct LazyProject {
 }
 
 impl LazyProject {
-    pub fn new() -> Self {
+    pub fn init() -> Self {
         LazyProject {
             project: LazyCell::new(),
         }
@@ -75,7 +75,7 @@ impl Project {
 
     /// Starts at `base_dir` and walks up the directory tree until a package.json file is found
     pub(crate) fn find_dir(base_dir: &Path) -> Option<&Path> {
-        let mut dir = base_dir.clone();
+        let mut dir = base_dir;
         while !is_project_root(dir) {
             dir = match dir.parent() {
                 Some(parent) => parent,
@@ -174,7 +174,7 @@ impl Project {
         };
 
         has_dep(&self.manifest.dependencies)
-            .or(has_dep(&self.manifest.dev_dependencies))
+            .or_else(|| has_dep(&self.manifest.dev_dependencies))
             .unwrap_or(false)
     }
 

--- a/crates/volta-core/src/run/binary.rs
+++ b/crates/volta-core/src/run/binary.rs
@@ -83,7 +83,7 @@ where
                 loader
                     .args
                     .iter()
-                    .map(|arg| OsString::from(arg))
+                    .map(OsString::from)
                     .chain(once(tool_path))
                     .chain(args),
                 &path,

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -123,7 +123,7 @@ impl fmt::Debug for ToolCommand {
 fn get_tool_name(args: &mut ArgsOs) -> Fallible<OsString> {
     args.nth(0)
         .and_then(|arg0| Path::new(&arg0).file_name().map(tool_name_from_file_name))
-        .ok_or(ErrorDetails::CouldNotDetermineTool.into())
+        .ok_or_else(|| ErrorDetails::CouldNotDetermineTool.into())
 }
 
 #[cfg(unix)]

--- a/crates/volta-core/src/run/npm.rs
+++ b/crates/volta-core/src/run/npm.rs
@@ -53,7 +53,7 @@ fn check_npm_install() -> CommandArg {
     // command itself skipped and all flags excluded entirely. The first item
     // in that skipped, filter iterator is the command itself.
     let mut args = args_os().skip(1).filter(|arg| match arg.to_str() {
-        Some(arg) => !arg.starts_with("-"),
+        Some(arg) => !arg.starts_with('-'),
         None => true,
     });
     let command = args.next();

--- a/crates/volta-core/src/run/yarn.rs
+++ b/crates/volta-core/src/run/yarn.rs
@@ -63,7 +63,7 @@ fn check_yarn_add() -> CommandArg {
     // Yarn global installs must be of the form `yarn global add`
     // However, they may have options intermixed, e.g. yarn --verbose global add ember-cli
     let mut args = args_os().skip(1).filter(|arg| match arg.to_str() {
-        Some(arg) => !arg.starts_with("-"),
+        Some(arg) => !arg.starts_with('-'),
         None => true,
     });
 

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -46,27 +46,27 @@ pub enum ActivityKind {
 impl Display for ActivityKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         let s = match self {
-            &ActivityKind::Fetch => "fetch",
-            &ActivityKind::Install => "install",
-            &ActivityKind::Uninstall => "uninstall",
-            &ActivityKind::List => "list",
-            &ActivityKind::Current => "current",
-            &ActivityKind::Deactivate => "deactivate",
-            &ActivityKind::Activate => "activate",
-            &ActivityKind::Default => "default",
-            &ActivityKind::Pin => "pin",
-            &ActivityKind::Node => "node",
-            &ActivityKind::Npm => "npm",
-            &ActivityKind::Npx => "npx",
-            &ActivityKind::Yarn => "yarn",
-            &ActivityKind::Volta => "volta",
-            &ActivityKind::Tool => "tool",
-            &ActivityKind::Help => "help",
-            &ActivityKind::Version => "version",
-            &ActivityKind::Binary => "binary",
-            &ActivityKind::Shim => "shim",
-            &ActivityKind::Completions => "completions",
-            &ActivityKind::Which => "which",
+            ActivityKind::Fetch => "fetch",
+            ActivityKind::Install => "install",
+            ActivityKind::Uninstall => "uninstall",
+            ActivityKind::List => "list",
+            ActivityKind::Current => "current",
+            ActivityKind::Deactivate => "deactivate",
+            ActivityKind::Activate => "activate",
+            ActivityKind::Default => "default",
+            ActivityKind::Pin => "pin",
+            ActivityKind::Node => "node",
+            ActivityKind::Npm => "npm",
+            ActivityKind::Npx => "npx",
+            ActivityKind::Yarn => "yarn",
+            ActivityKind::Volta => "volta",
+            ActivityKind::Tool => "tool",
+            ActivityKind::Help => "help",
+            ActivityKind::Version => "version",
+            ActivityKind::Binary => "binary",
+            ActivityKind::Shim => "shim",
+            ActivityKind::Completions => "completions",
+            ActivityKind::Which => "which",
         };
         f.write_str(s)
     }
@@ -90,13 +90,13 @@ pub struct Session {
 
 impl Session {
     /// Constructs a new `Session`.
-    pub fn new() -> Session {
+    pub fn init() -> Session {
         Session {
-            hooks: LazyHookConfig::new(),
-            inventory: LazyInventory::new(),
-            toolchain: LazyToolchain::new(),
-            project: LazyProject::new(),
-            event_log: EventLog::new(),
+            hooks: LazyHookConfig::init(),
+            inventory: LazyInventory::init(),
+            toolchain: LazyToolchain::init(),
+            project: LazyProject::init(),
+            event_log: EventLog::init(),
         }
     }
 
@@ -260,7 +260,7 @@ pub mod tests {
     fn test_in_pinned_project() {
         let project_pinned = fixture_path("basic");
         env::set_current_dir(&project_pinned).expect("Could not set current directory");
-        let pinned_session = Session::new();
+        let pinned_session = Session::init();
         let pinned_platform = pinned_session
             .project_platform()
             .expect("Couldn't create Project");
@@ -268,7 +268,7 @@ pub mod tests {
 
         let project_unpinned = fixture_path("no_toolchain");
         env::set_current_dir(&project_unpinned).expect("Could not set current directory");
-        let unpinned_session = Session::new();
+        let unpinned_session = Session::init();
         let unpinned_platform = unpinned_session
             .project_platform()
             .expect("Couldn't create Project");

--- a/crates/volta-core/src/shell/bash.rs
+++ b/crates/volta-core/src/shell/bash.rs
@@ -13,15 +13,15 @@ impl Shell for Bash {
 
     fn compile_postscript(&self, postscript: &Postscript) -> String {
         match postscript {
-            &Postscript::Activate(ref s) => format!(
+            Postscript::Activate(ref s) => format!(
                 "export PATH='{}'\nexport VOLTA_HOME=\"${{HOME}}/.volta\"\n",
                 s
             ),
-            &Postscript::Deactivate(ref s) => {
+            Postscript::Deactivate(ref s) => {
                 // ISSUE(#99): proper escaping
                 format!("export PATH='{}'\nunset VOLTA_HOME\n", s)
             }
-            &Postscript::ToolVersion {
+            Postscript::ToolVersion {
                 ref tool,
                 ref version,
             } => format!(

--- a/crates/volta-core/src/shell/fish.rs
+++ b/crates/volta-core/src/shell/fish.rs
@@ -6,7 +6,7 @@ pub(crate) struct Fish {
     pub(crate) postscript_path: PathBuf,
 }
 
-static STATUS_HANDLING: &'static str = r#"
+static STATUS_HANDLING: &str = r#"
 if test $status != 0;
   printf '\n\033[1;31mError\033[0m: Volta cannot update your `PATH`. If you are running fish 2.x, this often\n' 1>&2
   printf '       happens if your `PATH` includes an entry pointing to a value that is not\n' 1>&2
@@ -17,8 +17,8 @@ if test $status != 0;
 end;
 "#;
 
-static SET_VOLTA_HOME: &'static str = "set -x VOLTA_HOME \"$HOME/.volta\"\n";
-static UNSET_VOLTA_HOME: &'static str = "set -e VOLTA_HOME\n";
+static SET_VOLTA_HOME: &str = "set -x VOLTA_HOME \"$HOME/.volta\"\n";
+static UNSET_VOLTA_HOME: &str = "set -e VOLTA_HOME\n";
 
 impl Shell for Fish {
     fn postscript_path(&self) -> &Path {
@@ -27,16 +27,16 @@ impl Shell for Fish {
 
     fn compile_postscript(&self, postscript: &Postscript) -> String {
         match postscript {
-            &Postscript::Activate(ref s) => {
+            Postscript::Activate(ref s) => {
                 let updated_path = format!("set -x PATH \"{}\"\n", s);
                 updated_path + STATUS_HANDLING + SET_VOLTA_HOME
             }
             // ISSUE(#99): proper escaping
-            &Postscript::Deactivate(ref s) => {
+            Postscript::Deactivate(ref s) => {
                 let updated_path = format!("set -x PATH \"{}\"\n", s);
                 updated_path + STATUS_HANDLING + UNSET_VOLTA_HOME
             }
-            &Postscript::ToolVersion {
+            Postscript::ToolVersion {
                 ref tool,
                 ref version,
             } => format!(

--- a/crates/volta-core/src/shell/mod.rs
+++ b/crates/volta-core/src/shell/mod.rs
@@ -48,7 +48,7 @@ pub struct CurrentShell(Box<dyn Shell>);
 impl CurrentShell {
     pub fn detect() -> Fallible<Self> {
         env::shell_name()
-            .ok_or(ErrorDetails::UnspecifiedShell.into())
+            .ok_or_else(|| ErrorDetails::UnspecifiedShell.into())
             .and_then(|name| name.parse())
     }
 }

--- a/crates/volta-core/src/shim.rs
+++ b/crates/volta-core/src/shim.rs
@@ -84,7 +84,7 @@ mod windows {
     use std::io::ErrorKind;
     use volta_fail::{FailExt, Fallible, ResultExt};
 
-    const BASH_SCRIPT: &'static str = r#"cmd //C $0 "$@""#;
+    const BASH_SCRIPT: &str = r#"cmd //C $0 "$@""#;
 
     pub fn create_git_bash_script(shim_name: &str) -> Fallible<()> {
         let script_path = volta_home()?.shim_git_bash_script_file(shim_name);

--- a/crates/volta-core/src/style.rs
+++ b/crates/volta-core/src/style.rs
@@ -62,15 +62,15 @@ pub fn progress_bar(origin: Origin, details: &str, len: u64) -> ProgressBar {
         None => MAX_PROGRESS_WIDTH,
     };
 
-    let bar = ProgressBar::new(len);
+    let progress = ProgressBar::new(len);
 
-    bar.set_message(&format!(
+    progress.set_message(&format!(
         "{: >width$} {}",
         style(action).green().bold(),
         details,
         width = action_width,
     ));
-    bar.set_style(
+    progress.set_style(
         ProgressStyle::default_bar()
             .template(&format!(
                 "{{msg}}  [{{bar:{}.cyan/blue}}] {{percent:>3}}%",
@@ -79,7 +79,7 @@ pub fn progress_bar(origin: Origin, details: &str, len: u64) -> ProgressBar {
             .progress_chars("=> "),
     );
 
-    bar
+    progress
 }
 
 cfg_if! {

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -18,13 +18,13 @@ pub use resolve::resolve;
 cfg_if! {
     if #[cfg(target_os = "windows")] {
         /// The OS component of a Node distro's filename.
-        pub const NODE_DISTRO_OS: &'static str = "win";
+        pub const NODE_DISTRO_OS: &str = "win";
     } else if #[cfg(target_os = "macos")] {
         /// The OS component of a Node distro's filename.
-        pub const NODE_DISTRO_OS: &'static str = "darwin";
+        pub const NODE_DISTRO_OS: &str = "darwin";
     } else if #[cfg(target_os = "linux")] {
         /// The OS component of a Node distro's filename.
-        pub const NODE_DISTRO_OS: &'static str = "linux";
+        pub const NODE_DISTRO_OS: &str = "linux";
     } else {
         compile_error!("Unsupported operating system (expected Windows, macOS, or Linux).");
     }
@@ -33,10 +33,10 @@ cfg_if! {
 cfg_if! {
     if #[cfg(target_arch = "x86")] {
         /// The system architecture component of a Node distro's name.
-        pub const NODE_DISTRO_ARCH: &'static str = "x86";
+        pub const NODE_DISTRO_ARCH: &str = "x86";
     } else if #[cfg(target_arch = "x86_64")] {
         /// The system architecture component of a Node distro's name.
-        pub const NODE_DISTRO_ARCH: &'static str = "x64";
+        pub const NODE_DISTRO_ARCH: &str = "x64";
     } else {
         compile_error!("Unsupported target_arch variant (expected 'x86' or 'x64').");
     }
@@ -45,10 +45,10 @@ cfg_if! {
 cfg_if! {
     if #[cfg(target_os = "windows")] {
         /// Filename extension for Node distro files.
-        pub const NODE_DISTRO_EXTENSION: &'static str = "zip";
+        pub const NODE_DISTRO_EXTENSION: &str = "zip";
     } else {
         /// Filename extension for Node distro files.
-        pub const NODE_DISTRO_EXTENSION: &'static str = "tar.gz";
+        pub const NODE_DISTRO_EXTENSION: &str = "tar.gz";
     }
 }
 

--- a/crates/volta-core/src/tool/package/fetch.rs
+++ b/crates/volta-core/src/tool/package/fetch.rs
@@ -178,17 +178,17 @@ fn unpack_archive(archive: Box<dyn Archive>, name: &str, version: &Version) -> F
     let temp = create_staging_dir()?;
     debug!("Unpacking {} into '{}'", name, temp.path().display());
 
-    let bar = progress_bar(
+    let progress = progress_bar(
         archive.origin(),
         &tool_version(&name, &version),
         archive
             .uncompressed_size()
-            .unwrap_or(archive.compressed_size()),
+            .unwrap_or_else(|| archive.compressed_size()),
     );
 
     archive
         .unpack(temp.path(), &mut |_, read| {
-            bar.inc(read as u64);
+            progress.inc(read as u64);
         })
         .with_context(|_| ErrorDetails::UnpackArchiveError {
             tool: name.into(),
@@ -212,7 +212,7 @@ fn unpack_archive(archive: Box<dyn Archive>, name: &str, version: &Version) -> F
         dir: image_dir.clone(),
     })?;
 
-    bar.finish_and_clear();
+    progress.finish_and_clear();
 
     // Note: We write this after the progress bar is finished to avoid display bugs with re-renders of the progress
     debug!("Installing {} in '{}'", name, image_dir.display());

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -184,7 +184,7 @@ fn binaries_from_package(package: &str) -> Fallible<Vec<String>> {
         dir_entry_match(&bin_config_dir, |entry| {
             let path = entry.path();
             if let Ok(config) = BinConfig::from_file(path) {
-                if config.package == package.to_string() {
+                if config.package == package {
                     return Some(config.name);
                 }
             };

--- a/crates/volta-core/src/tool/package/resolve.rs
+++ b/crates/volta-core/src/tool/package/resolve.rs
@@ -135,7 +135,7 @@ fn npm_view_query(name: &str, version: &str, session: &mut Session) -> Fallible<
 
     // Sometimes the returned JSON is an array (semver case), otherwise it's a single object.
     // Check if the first char is '[' and parse as an array if so
-    if response_json.chars().next() == Some('[') {
+    if response_json.starts_with('[') {
         let metadatas: Vec<super::serial::NpmViewData> = serde_json::de::from_str(&response_json)
             .with_context(|_| {
             ErrorDetails::NpmViewMetadataParseError {

--- a/crates/volta-core/src/tool/package/serial.rs
+++ b/crates/volta-core/src/tool/package/serial.rs
@@ -120,7 +120,7 @@ pub struct RawPackageConfig {
 }
 
 impl RawPackageConfig {
-    pub fn to_json(self) -> Fallible<String> {
+    pub fn into_json(self) -> Fallible<String> {
         serde_json::to_string_pretty(&self)
             .with_context(|_| ErrorDetails::StringifyPackageConfigError)
     }
@@ -132,7 +132,7 @@ impl RawPackageConfig {
     // Write the package config info to disk
     pub fn write(self) -> Fallible<()> {
         let config_file_path = volta_home()?.user_package_config_file(&self.name);
-        let src = self.to_json()?;
+        let src = self.into_json()?;
         ensure_containing_dir_exists(&config_file_path).with_context(|_| {
             ErrorDetails::ContainingDirError {
                 path: config_file_path.clone(),
@@ -203,7 +203,7 @@ pub struct RawBinLoader {
 }
 
 impl RawBinConfig {
-    pub fn to_json(self) -> Fallible<String> {
+    pub fn into_json(self) -> Fallible<String> {
         serde_json::to_string_pretty(&self).with_context(|_| ErrorDetails::StringifyBinConfigError)
     }
 
@@ -214,7 +214,7 @@ impl RawBinConfig {
     /// Write the config to disk
     pub fn write(self) -> Fallible<()> {
         let bin_config_path = volta_home()?.user_tool_bin_config(&self.name);
-        let src = self.to_json()?;
+        let src = self.into_json()?;
         ensure_containing_dir_exists(&bin_config_path).with_context(|_| {
             ErrorDetails::ContainingDirError {
                 path: bin_config_path.clone(),

--- a/crates/volta-core/src/tool/yarn/fetch.rs
+++ b/crates/volta-core/src/tool/yarn/fetch.rs
@@ -74,18 +74,18 @@ fn unpack_archive(archive: Box<dyn Archive>, version: &Version) -> Fallible<()> 
     let temp = create_staging_dir()?;
     debug!("Unpacking yarn into '{}'", temp.path().display());
 
-    let bar = progress_bar(
+    let progress = progress_bar(
         archive.origin(),
         &tool_version("yarn", version),
         archive
             .uncompressed_size()
-            .unwrap_or(archive.compressed_size()),
+            .unwrap_or_else(|| archive.compressed_size()),
     );
     let version_string = version.to_string();
 
     archive
         .unpack(temp.path(), &mut |_, read| {
-            bar.inc(read as u64);
+            progress.inc(read as u64);
         })
         .with_context(|_| ErrorDetails::UnpackArchiveError {
             tool: "Yarn".into(),
@@ -106,7 +106,7 @@ fn unpack_archive(archive: Box<dyn Archive>, version: &Version) -> Fallible<()> 
         dir: dest.clone(),
     })?;
 
-    bar.finish_and_clear();
+    progress.finish_and_clear();
 
     // Note: We write this after the progress bar is finished to avoid display bugs with re-renders of the progress
     debug!("Installing yarn in '{}'", dest.display());

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -22,7 +22,7 @@ pub struct LazyToolchain {
 
 impl LazyToolchain {
     /// Creates a new `LazyToolchain`
-    pub fn new() -> Self {
+    pub fn init() -> Self {
         LazyToolchain {
             toolchain: LazyCell::new(),
         }
@@ -30,12 +30,12 @@ impl LazyToolchain {
 
     /// Forces loading of the toolchain and returns an immutable reference to it
     pub fn get(&self) -> Fallible<&Toolchain> {
-        self.toolchain.try_borrow_with(|| Toolchain::current())
+        self.toolchain.try_borrow_with(Toolchain::current)
     }
 
     /// Forces loading of the toolchain and returns a mutable reference to it
     pub fn get_mut(&mut self) -> Fallible<&mut Toolchain> {
-        self.toolchain.try_borrow_mut_with(|| Toolchain::current())
+        self.toolchain.try_borrow_mut_with(Toolchain::current)
     }
 }
 
@@ -97,7 +97,7 @@ impl Toolchain {
     pub fn set_active_yarn(&mut self, yarn_version: &Version) -> Fallible<()> {
         let mut dirty = false;
 
-        if let &mut Some(ref mut platform) = &mut self.platform {
+        if let Some(ref mut platform) = self.platform {
             if platform.yarn.as_ref() != Some(yarn_version) {
                 platform.yarn = Some(yarn_version.clone());
                 dirty = true;
@@ -115,7 +115,7 @@ impl Toolchain {
     pub fn set_active_npm(&mut self, npm_version: &Version) -> Fallible<()> {
         let mut dirty = false;
 
-        if let &mut Some(ref mut platform) = &mut self.platform {
+        if let Some(ref mut platform) = self.platform {
             if let Some(ref npm) = &platform.npm {
                 if npm != npm_version {
                     platform.npm = Some(npm_version.clone());
@@ -135,7 +135,7 @@ impl Toolchain {
         let path = volta_home()?.user_platform_file();
         let result = match &self.platform {
             Some(platform) => {
-                let src = platform.to_serial().to_json()?;
+                let src = platform.to_serial().into_json()?;
                 write(&path, src)
             }
             None => write(&path, "{}"),

--- a/crates/volta-core/src/toolchain/serial.rs
+++ b/crates/volta-core/src/toolchain/serial.rs
@@ -47,7 +47,7 @@ impl Platform {
     }
 
     /// Serialize the Platform to a JSON String
-    pub fn to_json(self) -> Fallible<String> {
+    pub fn into_json(self) -> Fallible<String> {
         serde_json::to_string_pretty(&self).with_context(|_| ErrorDetails::StringifyPlatformError)
     }
 }
@@ -108,7 +108,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_to_json() {
+    fn test_into_json() {
         let platform = platform::PlatformSpec {
             yarn: Some(Version::parse("1.2.3").expect("could not parse version")),
             node_runtime: Version::parse("4.5.6").expect("could not parse version"),
@@ -116,7 +116,7 @@ pub mod tests {
         };
         let json_str = platform
             .to_serial()
-            .to_json()
+            .into_json()
             .expect("could not serialize platform to JSON");
         let expected_json_str = BASIC_JSON_STR.to_string();
         assert_eq!(json_str, expected_json_str);

--- a/crates/volta-core/src/version/serial.rs
+++ b/crates/volta-core/src/version/serial.rs
@@ -13,10 +13,10 @@ use semver::{Compat, ReqParseError, VersionReq};
 // a Node-compatible way (or we get the wrong version info returned).
 pub fn parse_requirements(src: &str) -> Result<VersionReq, ReqParseError> {
     let src = src.trim();
-    if src.len() > 0 && src.chars().next().unwrap().is_digit(10) {
+    if !src.is_empty() && src.chars().next().unwrap().is_digit(10) {
         let defaulted = format!("={}", src);
         VersionReq::parse_compat(&defaulted, Compat::Node)
-    } else if src.len() > 0 && src.chars().next().unwrap() == 'v' {
+    } else if !src.is_empty() && src.starts_with('v') {
         let defaulted = src.replacen("v", "=", 1);
         VersionReq::parse_compat(&defaulted, Compat::Node)
     } else {

--- a/src/command/current.rs
+++ b/src/command/current.rs
@@ -32,11 +32,11 @@ impl Command for Current {
                 let user_active = project.is_none() && user.is_some();
                 let any = project.is_some() || user.is_some();
 
-                for version in project {
+                if let Some(version) = project {
                     println!("project: v{} (active)", version);
                 }
 
-                for version in user {
+                if let Some(version) = user {
                     println!(
                         "user: v{}{}",
                         version,

--- a/src/command/list/plain.rs
+++ b/src/command/list/plain.rs
@@ -24,10 +24,10 @@ pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
         } => (
             runtime
                 .as_ref()
-                .and_then(|r| describe_runtimes(&[r.clone()])),
+                .and_then(|r| describe_runtimes(&[(**r).clone()])),
             package_manager
                 .as_ref()
-                .and_then(|p| describe_package_managers(&[p.clone()])),
+                .and_then(|p| describe_package_managers(&[(**p).clone()])),
             describe_packages(&packages),
         ),
         Toolchain::All {
@@ -49,12 +49,12 @@ pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
             Some(format!("{}\n{}", runtimes, package_managers))
         }
         (Some(runtimes), None, Some(packages)) => Some(format!("{}\n{}", runtimes, packages)),
-        (Some(runtimes), None, None) => Some(format!("{}", runtimes)),
+        (Some(runtimes), None, None) => Some(runtimes.to_string()),
         (None, Some(package_managers), Some(packages)) => {
             Some(format!("{}\n{}", package_managers, packages))
         }
-        (None, Some(package_managers), None) => Some(format!("{}", package_managers)),
-        (None, None, Some(packages)) => Some(format!("{}", packages)),
+        (None, Some(package_managers), None) => Some(package_managers.to_string()),
+        (None, None, Some(packages)) => Some(packages.to_string()),
         (None, None, None) => None,
     }
 }

--- a/src/command/use.rs
+++ b/src/command/use.rs
@@ -8,13 +8,13 @@ use volta_fail::{ExitCode, Fallible};
 // NOTE: These use the same text as the `long_about` in crate::cli.
 //       It's hard to abstract since it's in an attribute string.
 
-pub(crate) const USAGE: &'static str = "The subcommand `use` is deprecated.
+pub(crate) const USAGE: &str = "The subcommand `use` is deprecated.
 
     To install a tool in your toolchain, use `volta install`.
     To pin your project's runtime or package manager, use `volta pin`.
 ";
 
-const ADVICE: &'static str = "
+const ADVICE: &str = "
     To install a tool in your toolchain, use `volta install`.
     To pin your project's runtime or package manager, use `volta pin`.
 ";

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ pub fn main() {
     };
     Logger::init(LogContext::Volta, verbosity).expect("Only a single logger should be initialized");
 
-    let mut session = Session::new();
+    let mut session = Session::init();
     session.add_event_start(ActivityKind::Volta);
     let exit_code = volta.run(&mut session).unwrap_or_else(|err| {
         report_error(env!("CARGO_PKG_VERSION"), &err);

--- a/src/shim.rs
+++ b/src/shim.rs
@@ -10,7 +10,7 @@ pub fn main() {
         .expect("Only a single Logger should be initialized");
     setup_signal_handler();
 
-    let mut session = Session::new();
+    let mut session = Session::init();
 
     session.add_event_start(ActivityKind::Tool);
 

--- a/tests/acceptance/corrupted_download.rs
+++ b/tests/acceptance/corrupted_download.rs
@@ -5,7 +5,7 @@ use test_support::matchers::execs;
 
 use volta_fail::ExitCode;
 
-const NODE_VERSION_INFO: &'static str = r#"[
+const NODE_VERSION_INFO: &str = r#"[
 {"version":"v10.99.1040","npm":"6.2.26","lts": "Dubnium","files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]},
 {"version":"v0.0.1","npm":"0.0.2","lts": "Sure","files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]}
 ]
@@ -15,16 +15,16 @@ const NODE_VERSION_FIXTURES: [DistroMetadata; 2] = [
     DistroMetadata {
         version: "0.0.1",
         compressed_size: 10,
-        uncompressed_size: Some(0x00280000),
+        uncompressed_size: Some(0x0028_0000),
     },
     DistroMetadata {
         version: "10.99.1040",
         compressed_size: 273,
-        uncompressed_size: Some(0x00280000),
+        uncompressed_size: Some(0x0028_0000),
     },
 ];
 
-const YARN_VERSION_INFO: &'static str = r#"[
+const YARN_VERSION_INFO: &str = r#"[
 {"tag_name":"v0.0.1","assets":[{"name":"yarn-v0.0.1.tar.gz"}]},
 {"tag_name":"v1.2.42","assets":[{"name":"yarn-v1.2.42.tar.gz"}]}
 ]"#;
@@ -33,12 +33,12 @@ const YARN_VERSION_FIXTURES: [DistroMetadata; 2] = [
     DistroMetadata {
         version: "0.0.1",
         compressed_size: 10,
-        uncompressed_size: Some(0x00280000),
+        uncompressed_size: Some(0x0028_0000),
     },
     DistroMetadata {
         version: "1.2.42",
         compressed_size: 174,
-        uncompressed_size: Some(0x00280000),
+        uncompressed_size: Some(0x0028_0000),
     },
 ];
 

--- a/tests/acceptance/intercept_global_installs.rs
+++ b/tests/acceptance/intercept_global_installs.rs
@@ -6,7 +6,7 @@ use test_support::matchers::execs;
 use volta_core::env::UNSAFE_GLOBAL;
 use volta_fail::ExitCode;
 
-const PACKAGE_JSON: &'static str = r#"{
+const PACKAGE_JSON: &str = r#"{
     "name": "text-package",
     "volta": {
         "node": "10.22.123",

--- a/tests/acceptance/merged_platform.rs
+++ b/tests/acceptance/merged_platform.rs
@@ -5,7 +5,7 @@ use test_support::matchers::execs;
 
 use volta_fail::ExitCode;
 
-const PACKAGE_JSON_WITH_YARN: &'static str = r#"{
+const PACKAGE_JSON_WITH_YARN: &str = r#"{
     "name": "with-yarn",
     "volta": {
         "node": "10.22.123",
@@ -13,14 +13,14 @@ const PACKAGE_JSON_WITH_YARN: &'static str = r#"{
     }
 }"#;
 
-const PACKAGE_JSON_NO_YARN: &'static str = r#"{
+const PACKAGE_JSON_NO_YARN: &str = r#"{
     "name": "without-yarn",
     "volta": {
         "node": "10.22.123"
     }
 }"#;
 
-const PLATFORM_WITH_YARN: &'static str = r#"{
+const PLATFORM_WITH_YARN: &str = r#"{
     "node":{
         "runtime":"9.11.2",
         "npm":"5.6.0"
@@ -28,7 +28,7 @@ const PLATFORM_WITH_YARN: &'static str = r#"{
     "yarn": "1.22.300"
 }"#;
 
-const PLATFORM_NO_YARN: &'static str = r#"{
+const PLATFORM_NO_YARN: &str = r#"{
     "node":{
         "runtime":"9.11.2",
         "npm":"5.6.0"

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -317,10 +317,10 @@ impl SandboxBuilder {
         if let Some(uncompressed_size) = metadata.uncompressed_size {
             // This can be abstracted when https://github.com/rust-lang/rust/issues/52963 lands.
             let uncompressed_size_bytes: [u8; 4] = [
-                ((uncompressed_size & 0xff000000) >> 24) as u8,
-                ((uncompressed_size & 0x00ff0000) >> 16) as u8,
-                ((uncompressed_size & 0x0000ff00) >> 8) as u8,
-                (uncompressed_size & 0x000000ff) as u8,
+                ((uncompressed_size & 0xff00_0000) >> 24) as u8,
+                ((uncompressed_size & 0x00ff_0000) >> 16) as u8,
+                ((uncompressed_size & 0x0000_ff00) >> 8) as u8,
+                (uncompressed_size & 0x0000_00ff) as u8,
             ];
 
             let range_mock = mock("GET", &server_path[..])
@@ -608,7 +608,7 @@ impl Sandbox {
         fs::read_dir(volta_log_dir()).ok()
     }
 
-    pub fn remove_volta_home(&self) -> () {
+    pub fn remove_volta_home(&self) {
         volta_home().rm_rf();
     }
 

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -236,6 +236,7 @@ impl SandboxBuilder {
     }
 
     /// Set the shell for the sandbox (chainable)
+    #[cfg(unix)]
     pub fn volta_shell(self, shell_name: &str) -> Self {
         self.env("VOLTA_SHELL", shell_name)
     }
@@ -599,6 +600,7 @@ impl Sandbox {
         read_file_to_string(package_file)
     }
 
+    #[cfg(unix)]
     pub fn read_postscript(&self) -> String {
         let postscript_file = volta_postscript();
         read_file_to_string(postscript_file)

--- a/tests/acceptance/verbose_errors.rs
+++ b/tests/acceptance/verbose_errors.rs
@@ -5,7 +5,7 @@ use test_support::matchers::execs;
 
 use volta_fail::ExitCode;
 
-const NODE_VERSION_INFO: &'static str = r#"[
+const NODE_VERSION_INFO: &str = r#"[
 {"version":"v10.99.1040","npm":"6.2.26","lts": "Dubnium","files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]},
 {"version":"v9.27.6","npm":"5.6.17","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]},
 {"version":"v8.9.10","npm":"5.6.7","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]},

--- a/tests/acceptance/volta_current.rs
+++ b/tests/acceptance/volta_current.rs
@@ -5,7 +5,7 @@ use test_support::matchers::execs;
 
 use volta_fail::ExitCode;
 
-const BASIC_PACKAGE_JSON: &'static str = r#"{
+const BASIC_PACKAGE_JSON: &str = r#"{
   "name": "test-package"
 }"#;
 

--- a/tests/acceptance/volta_deactivate.rs
+++ b/tests/acceptance/volta_deactivate.rs
@@ -1,10 +1,11 @@
+#![cfg(unix)]
+
 use crate::support::sandbox::sandbox;
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
 
 #[test]
-#[cfg(unix)]
 fn deactivate_bash() {
     let s = sandbox()
         .volta_shell("bash")

--- a/tests/acceptance/volta_pin.rs
+++ b/tests/acceptance/volta_pin.rs
@@ -5,7 +5,7 @@ use test_support::matchers::execs;
 
 use volta_fail::ExitCode;
 
-const BASIC_PACKAGE_JSON: &'static str = r#"{
+const BASIC_PACKAGE_JSON: &str = r#"{
   "name": "test-package"
 }"#;
 
@@ -65,7 +65,7 @@ fn package_json_with_pinned_node_npm_yarn(
     )
 }
 
-const NODE_VERSION_INFO: &'static str = r#"[
+const NODE_VERSION_INFO: &str = r#"[
 {"version":"v10.99.1040","npm":"6.2.26","lts": "Dubnium","files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]},
 {"version":"v9.27.6","npm":"5.6.17","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]},
 {"version":"v8.9.10","npm":"5.6.7","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip"]},
@@ -79,22 +79,22 @@ cfg_if::cfg_if! {
             DistroMetadata {
                 version: "10.99.1040",
                 compressed_size: 273,
-                uncompressed_size: Some(0x00280000),
+                uncompressed_size: Some(0x0028_0000),
             },
             DistroMetadata {
                 version: "9.27.6",
                 compressed_size: 272,
-                uncompressed_size: Some(0x00280000),
+                uncompressed_size: Some(0x0028_0000),
             },
             DistroMetadata {
                 version: "8.9.10",
                 compressed_size: 272,
-                uncompressed_size: Some(0x00280000),
+                uncompressed_size: Some(0x0028_0000),
             },
             DistroMetadata {
                 version: "6.19.62",
                 compressed_size: 273,
-                uncompressed_size: Some(0x00280000),
+                uncompressed_size: Some(0x0028_0000),
             },
         ];
     } else if #[cfg(target_os = "linux")] {
@@ -102,22 +102,22 @@ cfg_if::cfg_if! {
             DistroMetadata {
                 version: "10.99.1040",
                 compressed_size: 273,
-                uncompressed_size: Some(0x00280000),
+                uncompressed_size: Some(0x0028_0000),
             },
             DistroMetadata {
                 version: "9.27.6",
                 compressed_size: 272,
-                uncompressed_size: Some(0x00280000),
+                uncompressed_size: Some(0x0028_0000),
             },
             DistroMetadata {
                 version: "8.9.10",
                 compressed_size: 270,
-                uncompressed_size: Some(0x00280000),
+                uncompressed_size: Some(0x0028_0000),
             },
             DistroMetadata {
                 version: "6.19.62",
                 compressed_size: 273,
-                uncompressed_size: Some(0x00280000),
+                uncompressed_size: Some(0x0028_0000),
             },
         ];
     } else if #[cfg(target_os = "windows")] {
@@ -148,7 +148,7 @@ cfg_if::cfg_if! {
     }
 }
 
-const YARN_VERSION_INFO: &'static str = r#"[
+const YARN_VERSION_INFO: &str = r#"[
 {"tag_name":"v1.2.42","assets":[{"name":"yarn-v1.2.42.tar.gz"}]},
 {"tag_name":"v1.3.1","assets":[{"name":"yarn-v1.3.1.msi"}]},
 {"tag_name":"v1.4.159","assets":[{"name":"yarn-v1.4.159.tar.gz"}]},
@@ -160,26 +160,26 @@ const YARN_VERSION_FIXTURES: [DistroMetadata; 4] = [
     DistroMetadata {
         version: "1.12.99",
         compressed_size: 178,
-        uncompressed_size: Some(0x00280000),
+        uncompressed_size: Some(0x0028_0000),
     },
     DistroMetadata {
         version: "1.7.71",
         compressed_size: 176,
-        uncompressed_size: Some(0x00280000),
+        uncompressed_size: Some(0x0028_0000),
     },
     DistroMetadata {
         version: "1.4.159",
         compressed_size: 177,
-        uncompressed_size: Some(0x00280000),
+        uncompressed_size: Some(0x0028_0000),
     },
     DistroMetadata {
         version: "1.2.42",
         compressed_size: 174,
-        uncompressed_size: Some(0x00280000),
+        uncompressed_size: Some(0x0028_0000),
     },
 ];
 
-const NPM_VERSION_INFO: &'static str = r#"
+const NPM_VERSION_INFO: &str = r#"
 {
     "name":"npm",
     "dist-tags": { "latest":"6.8.0" },
@@ -193,7 +193,7 @@ const NPM_VERSION_INFO: &'static str = r#"
 }
 "#;
 
-const VOLTA_LOGLEVEL: &'static str = "VOLTA_LOGLEVEL";
+const VOLTA_LOGLEVEL: &str = "VOLTA_LOGLEVEL";
 
 #[test]
 fn pin_node() {

--- a/tests/acceptance/volta_uninstall.rs
+++ b/tests/acceptance/volta_uninstall.rs
@@ -3,7 +3,7 @@ use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
 
-const PKG_CONFIG_BASIC: &'static str = r#"{
+const PKG_CONFIG_BASIC: &str = r#"{
   "name": "cowsay",
   "version": "1.4.0",
   "platform": {
@@ -19,7 +19,7 @@ const PKG_CONFIG_BASIC: &'static str = r#"{
   ]
 }"#;
 
-const PKG_CONFIG_NO_BINS: &'static str = r#"{
+const PKG_CONFIG_NO_BINS: &str = r#"{
   "name": "cowsay",
   "version": "1.4.0",
   "platform": {
@@ -51,7 +51,7 @@ fn bin_config(name: &str) -> String {
     )
 }
 
-const VOLTA_LOGLEVEL: &'static str = "VOLTA_LOGLEVEL";
+const VOLTA_LOGLEVEL: &str = "VOLTA_LOGLEVEL";
 
 #[test]
 fn uninstall_nonexistent_pkg() {


### PR DESCRIPTION
Info
-----
* [Clippy](https://github.com/rust-lang/rust-clippy) is the standard linting tool in Rust, including a number of lints to detect non-idiomatic code and possible logical errors.

Changes
-----
* Resolved all Clippy warnings and errors (both in production and test code)
* Added calls to Clippy to the CI runs