### PR TITLE
Fix a few more clippy warnings that didn't surface immediately

### DIFF
--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -17,5 +17,5 @@ pub fn ensure_containing_dir_exists<P: AsRef<Path>>(path: &P) -> io::Result<()> 
                 ),
             )
         })
-        .and_then(|dir| fs::create_dir_all(dir))
+        .and_then(fs::create_dir_all)
 }

--- a/crates/validate-npm-package-name/src/lib.rs
+++ b/crates/validate-npm-package-name/src/lib.rs
@@ -91,15 +91,15 @@ pub fn validate(name: &str) -> Validity {
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
 
-    if name.len() == 0 {
+    if name.is_empty() {
         errors.push("name length must be greater than zero".into());
     }
 
-    if name.starts_with(".") {
+    if name.starts_with('.') {
         errors.push("name cannot start with a period".into());
     }
 
-    if name.starts_with("_") {
+    if name.starts_with('_') {
         errors.push("name cannot start with an underscore".into());
     }
 


### PR DESCRIPTION
Enabling Clippy in VS Code shows a few more warnings that weren't being surfaced by running `cargo clippy` in an already-built project.