### PR TITLE
Add VOLTA_BYPASS override to short-circuit shim behavior

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -52,6 +52,11 @@ pub enum ErrorDetails {
     /// Thrown when building the virtual environment path fails
     BuildPathError,
 
+    /// Thrown when unable to launch a command with VOLTA_BYPASS set
+    BypassError {
+        command: String,
+    },
+
     /// Thrown when a user tries to `volta pin` something other than node/yarn/npm.
     CannotPinPackage {
         package: String,
@@ -532,6 +537,13 @@ Use `volta install` to add a package to your toolchain (see `volta help install`
                 "Could not create execution environment.
 
 Please ensure your PATH is valid."
+            ),
+            ErrorDetails::BypassError { command } => write!(
+                f,
+                "Could not execute command '{}'
+
+VOLTA_BYPASS is enabled, please ensure that the command exists on your system or unset VOLTA_BYPASS",
+                command,
             ),
             ErrorDetails::CannotPinPackage { package } => write!(
                 f,
@@ -1321,6 +1333,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::BinaryExecError => ExitCode::ExecutionFailure,
             ErrorDetails::BinaryNotFound { .. } => ExitCode::ExecutableNotFound,
             ErrorDetails::BuildPathError => ExitCode::EnvironmentError,
+            ErrorDetails::BypassError { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::CannotPinPackage { .. } => ExitCode::InvalidArguments,
             ErrorDetails::CompletionsOutFileError { .. } => ExitCode::InvalidArguments,
             ErrorDetails::ContainingDirError { .. } => ExitCode::FileSystemError,

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -9,6 +9,7 @@ mod merged_platform;
 #[cfg(feature = "volta-updates")]
 mod run_shim_directly;
 mod verbose_errors;
+mod volta_bypass;
 mod volta_current;
 #[cfg(not(feature = "volta-updates"))]
 mod volta_deactivate;

--- a/tests/acceptance/volta_bypass.rs
+++ b/tests/acceptance/volta_bypass.rs
@@ -1,0 +1,18 @@
+use crate::support::sandbox::{sandbox, shim_exe};
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+use volta_fail::ExitCode;
+
+#[test]
+fn shim_skips_platform_checks_on_bypass() {
+    let s = sandbox().env("VOLTA_BYPASS", "1").build();
+
+    assert_that!(
+        s.process(&shim_exe()),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("VOLTA_BYPASS is enabled[..]")
+    );
+}

--- a/tests/acceptance/volta_bypass.rs
+++ b/tests/acceptance/volta_bypass.rs
@@ -7,12 +7,27 @@ use volta_fail::ExitCode;
 
 #[test]
 fn shim_skips_platform_checks_on_bypass() {
-    let s = sandbox().env("VOLTA_BYPASS", "1").build();
+    let s = sandbox()
+        .env("VOLTA_BYPASS", "1")
+        .env(
+            "VOLTA_INSTALL_DIR",
+            &shim_exe().parent().unwrap().to_string_lossy(),
+        )
+        .build();
 
+    #[cfg(unix)]
     assert_that!(
         s.process(&shim_exe()),
         execs()
             .with_status(ExitCode::ExecutionFailure as i32)
             .with_stderr_contains("VOLTA_BYPASS is enabled[..]")
+    );
+
+    #[cfg(windows)]
+    assert_that!(
+        s.process(&shim_exe()),
+        execs()
+            .with_status(ExitCode::UnknownError as i32)
+            .with_stderr_contains("[..]is not recognized as an internal or external command[..]")
     );
 }


### PR DESCRIPTION
Closes #599 

Info
-----
* `volta activate` and `volta deactivate` are built as Shell functions that only work in specific unix shells.
* They also don't cleanly interact with the proposed update logic since they require a different install process than we want to support.
* #562 Removed them as part of the updates work, which is still behind a feature flag for the moment.
* However, the escape hatch still has uses (most notably to work with custom versions of npm until we implement installing and pinning npm)
* To provide similar functionality, in a cross-platform way, we want to add a `VOLTA_BYPASS` environment variable that will cause the shims to skip their normal logic and shell out to the existing (non-Volta) system.

Changes
-----
* Added logic to `execute_tool` that checks for the existence of `VOLTA_BYPASS`.
* If it is found, we short-circuit to a Passthrough command (i.e. using the system as if Volta didn't exist).
* We also add a custom error to the Passthrough command that will let the user know about VOLTA_BYPASS being enabled if the command fails to launch (e.g. if the requested tool doesn't exist on the system).

Tested
-----
* Ran `node --version` with VOLTA_BYPASS set to verify that it ran the system node instead of the Volta node.
* Ran `yarn --version` with VOLTA_BYPASS set to verify that it shows the "Bypass enabled" error if it can't find a system executable.