### PR TITLE
Package Install Improvements

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -32,7 +32,8 @@ impl fmt::Display for CreatePostscriptErrorPath {
     }
 }
 
-#[derive(Debug, Fail, PartialEq)]
+#[derive(Debug, Fail)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum ErrorDetails {
     /// Thrown when package tries to install a binary that is already installed.
     BinaryAlreadyInstalled {

--- a/crates/volta-core/src/inventory/mod.rs
+++ b/crates/volta-core/src/inventory/mod.rs
@@ -8,13 +8,14 @@ mod yarn;
 use std::collections::BTreeSet;
 use std::path::Path;
 
+use crate::error::ErrorDetails;
+use crate::fs::read_dir_eager;
+use crate::version::parse_version;
 use failure::ResultExt;
 use lazycell::LazyCell;
 use regex::Regex;
 use semver::Version;
 use volta_fail::Fallible;
-
-use crate::{error::ErrorDetails, fs::read_dir_eager, version::VersionSpec};
 
 /// Lazily loaded inventory.
 pub struct LazyInventory {
@@ -75,7 +76,7 @@ fn versions_matching(dir: &Path, re: &Regex) -> Fallible<BTreeSet<Version>> {
             let path = entry.path();
             let file_name = path.file_name()?.to_string_lossy();
             let captures = re.captures(&file_name)?;
-            VersionSpec::parse_version(&captures["version"]).ok()
+            parse_version(&captures["version"]).ok()
         })
         .collect();
 

--- a/crates/volta-core/src/manifest/serial.rs
+++ b/crates/volta-core/src/manifest/serial.rs
@@ -6,15 +6,13 @@ use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::rc::Rc;
 
+use super::super::{manifest, platform};
+use crate::version::parse_version;
 use log::warn;
 use serde;
 use serde::de::{Deserialize, Deserializer, Error, MapAccess, Visitor};
 use serde_json::value::Value;
-
 use volta_fail::Fallible;
-
-use super::super::{manifest, platform};
-use crate::version::VersionSpec;
 
 // wrapper for HashMap to use with deserialization
 #[derive(Debug, PartialEq)]
@@ -151,14 +149,14 @@ impl Manifest {
 
         if let Some(toolchain) = &toolchain {
             return Ok(Some(platform::PlatformSpec {
-                node_runtime: VersionSpec::parse_version(&toolchain.node)?,
+                node_runtime: parse_version(&toolchain.node)?,
                 npm: if let Some(npm) = &toolchain.npm {
-                    Some(VersionSpec::parse_version(&npm)?)
+                    Some(parse_version(&npm)?)
                 } else {
                     None
                 },
                 yarn: if let Some(yarn) = &toolchain.yarn {
-                    Some(VersionSpec::parse_version(&yarn)?)
+                    Some(parse_version(&yarn)?)
                 } else {
                     None
                 },

--- a/crates/volta-core/src/run/npx.rs
+++ b/crates/volta-core/src/run/npx.rs
@@ -5,7 +5,7 @@ use crate::error::ErrorDetails;
 use crate::platform::Source;
 use crate::session::{ActivityKind, Session};
 use crate::style::tool_version;
-use crate::version::VersionSpec;
+use crate::version::parse_version;
 
 use log::debug;
 use volta_fail::Fallible;
@@ -22,7 +22,7 @@ where
 
             // npx was only included with npm 5.2.0 and higher. If the npm version is less than that, we
             // should include a helpful error message
-            let required_npm = VersionSpec::parse_version("5.2.0")?;
+            let required_npm = parse_version("5.2.0")?;
             if image.node().npm >= required_npm {
                 let source = match image.source() {
                     Source::Project | Source::ProjectNodeDefaultYarn => "project",

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -53,7 +53,8 @@ pub trait Tool: Display {
 }
 
 /// Specification for a tool and its associated version.
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum Spec {
     Node(VersionSpec),
     Npm(VersionSpec),

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 use crate::error::ErrorDetails;
 use crate::session::Session;
 use crate::style::{success_prefix, tool_version};
-use crate::version::VersionSpec;
+use crate::version::{parse_version, VersionSpec};
 use log::{debug, info};
 use semver::Version;
 use volta_fail::Fallible;
@@ -87,9 +87,7 @@ impl Spec {
             // ISSUE (#292): To preserve error message context, we always resolve Npm to Version 0.0.0
             // This will allow us to show the correct error message based on the user's command
             // e.g. `volta install npm` vs `volta pin npm`
-            Spec::Npm(_) => VersionSpec::parse_version("0.0.0")
-                .map(Npm::new)
-                .map(Resolved::Npm),
+            Spec::Npm(_) => parse_version("0.0.0").map(Npm::new).map(Resolved::Npm),
         }
     }
 

--- a/crates/volta-core/src/tool/node/fetch.rs
+++ b/crates/volta-core/src/tool/node/fetch.rs
@@ -10,7 +10,7 @@ use crate::hook::ToolHooks;
 use crate::layout::volta_home;
 use crate::style::{progress_bar, tool_version};
 use crate::tool::{self, Node, NodeVersion};
-use crate::version::VersionSpec;
+use crate::version::{parse_version, VersionSpec};
 use archive::{self, Archive};
 use cfg_if::cfg_if;
 use fs_utils::ensure_containing_dir_exists;
@@ -179,7 +179,7 @@ fn fetch_remote_distro(
 ) -> Fallible<Box<dyn Archive>> {
     debug!("Downloading {} from {}", tool_version("node", version), url);
     archive::fetch_native(url, staging_path).with_context(download_tool_error(
-        tool::Spec::Node(VersionSpec::exact(&version)),
+        tool::Spec::Node(VersionSpec::Exact(version.clone())),
         url,
     ))
 }
@@ -196,7 +196,7 @@ impl Manifest {
         let file = File::open(path).with_context(|_| ErrorDetails::ReadNpmManifestError)?;
         let manifest: Manifest = serde_json::de::from_reader(file)
             .with_context(|_| ErrorDetails::ParseNpmManifestError)?;
-        VersionSpec::parse_version(manifest.version)
+        parse_version(manifest.version)
     }
 }
 
@@ -208,7 +208,7 @@ pub fn load_default_npm_version(node: &Version) -> Fallible<Version> {
             file: npm_version_file_path,
         }
     })?;
-    VersionSpec::parse_version(npm_version)
+    parse_version(npm_version)
 }
 
 /// Save the default npm version to the filesystem for a given version of Node

--- a/crates/volta-core/src/tool/node/resolve.rs
+++ b/crates/volta-core/src/tool/node/resolve.rs
@@ -15,7 +15,7 @@ use crate::layout::volta_home;
 use crate::session::Session;
 use crate::style::progress_spinner;
 use crate::tool::Node;
-use crate::version::VersionSpec;
+use crate::version::{VersionSpec, VersionTag};
 use cfg_if::cfg_if;
 use fs_utils::ensure_containing_dir_exists;
 use headers_011::Headers011;
@@ -42,10 +42,13 @@ cfg_if! {
 pub fn resolve(matching: VersionSpec, session: &mut Session) -> Fallible<Version> {
     let hooks = session.hooks()?.node();
     match matching {
-        VersionSpec::Latest => resolve_latest(hooks),
-        VersionSpec::Lts => resolve_lts(hooks),
         VersionSpec::Semver(requirement) => resolve_semver(requirement, hooks),
         VersionSpec::Exact(version) => Ok(version),
+        VersionSpec::None | VersionSpec::Tag(VersionTag::Lts) => resolve_lts(hooks),
+        VersionSpec::Tag(VersionTag::Latest) => resolve_latest(hooks),
+        VersionSpec::Tag(VersionTag::Custom(tag)) => {
+            Err(ErrorDetails::NodeVersionNotFound { matching: tag }.into())
+        }
     }
 }
 

--- a/crates/volta-core/src/tool/node/resolve.rs
+++ b/crates/volta-core/src/tool/node/resolve.rs
@@ -47,6 +47,7 @@ pub fn resolve(matching: VersionSpec, session: &mut Session) -> Fallible<Version
         VersionSpec::None | VersionSpec::Tag(VersionTag::Lts) => resolve_lts(hooks),
         VersionSpec::Tag(VersionTag::Latest) => resolve_latest(hooks),
         VersionSpec::Tag(VersionTag::LtsRequirement(req)) => resolve_lts_semver(req, hooks),
+        // Node doesn't have "tagged" versions (apart from 'latest' and 'lts'), so custom tags will always be an error
         VersionSpec::Tag(VersionTag::Custom(tag)) => {
             Err(ErrorDetails::NodeVersionNotFound { matching: tag }.into())
         }

--- a/crates/volta-core/src/tool/package/install.rs
+++ b/crates/volta-core/src/tool/package/install.rs
@@ -16,7 +16,7 @@ use crate::platform::{Image, PlatformSpec};
 use crate::session::Session;
 use crate::shim;
 use crate::style::{progress_spinner, tool_version};
-use crate::version::VersionSpec;
+use crate::version::{VersionSpec, VersionTag};
 use atty::Stream;
 use log::debug;
 use semver::Version;
@@ -139,11 +139,11 @@ fn determine_engine(package_dir: &Path, display: &str) -> Fallible<VersionSpec> 
                 "Found 'engines.node' specification for {}: {}",
                 display, engine
             );
-            VersionSpec::parse(engine)
+            engine.parse()
         }
         None => {
             debug!("No 'engines.node' found for {}, using latest", display);
-            Ok(VersionSpec::Latest)
+            Ok(VersionSpec::Tag(VersionTag::Latest))
         }
     }
 }

--- a/crates/volta-core/src/tool/package/install.rs
+++ b/crates/volta-core/src/tool/package/install.rs
@@ -16,7 +16,7 @@ use crate::platform::{Image, PlatformSpec};
 use crate::session::Session;
 use crate::shim;
 use crate::style::{progress_spinner, tool_version};
-use crate::version::{VersionSpec, VersionTag};
+use crate::version::{parse_requirements, VersionSpec, VersionTag};
 use atty::Stream;
 use log::debug;
 use semver::Version;
@@ -139,11 +139,12 @@ fn determine_engine(package_dir: &Path, display: &str) -> Fallible<VersionSpec> 
                 "Found 'engines.node' specification for {}: {}",
                 display, engine
             );
-            engine.parse()
+            let req = parse_requirements(engine)?;
+            Ok(VersionSpec::Tag(VersionTag::LtsRequirement(req)))
         }
         None => {
-            debug!("No 'engines.node' found for {}, using latest", display);
-            Ok(VersionSpec::Tag(VersionTag::Latest))
+            debug!("No 'engines.node' found for {}, using LTS", display);
+            Ok(VersionSpec::Tag(VersionTag::Lts))
         }
     }
 }

--- a/crates/volta-core/src/tool/package/resolve.rs
+++ b/crates/volta-core/src/tool/package/resolve.rs
@@ -8,7 +8,7 @@ use crate::run::{self, ToolCommand};
 use crate::session::Session;
 use crate::style::{progress_spinner, tool_version};
 use crate::tool::PackageDetails;
-use crate::version::VersionSpec;
+use crate::version::{VersionSpec, VersionTag};
 use log::debug;
 use semver::{Version, VersionReq};
 use volta_fail::{throw, Fallible, ResultExt};
@@ -19,9 +19,14 @@ pub fn resolve(
     session: &mut Session,
 ) -> Fallible<PackageDetails> {
     match matching {
-        VersionSpec::Latest | VersionSpec::Lts => resolve_latest(name, session),
         VersionSpec::Semver(requirement) => resolve_semver(name, requirement, session),
         VersionSpec::Exact(version) => resolve_semver(name, VersionReq::exact(&version), session),
+        VersionSpec::None | VersionSpec::Tag(VersionTag::Latest) => resolve_latest(name, session),
+        VersionSpec::Tag(tag) => Err(ErrorDetails::PackageVersionNotFound {
+            name: name.into(),
+            matching: tag.to_string(),
+        }
+        .into()),
     }
 }
 

--- a/crates/volta-core/src/tool/package/resolve.rs
+++ b/crates/volta-core/src/tool/package/resolve.rs
@@ -1,5 +1,6 @@
 //! Provides resolution of 3rd-party packages into specific versions, using the npm repository
 
+use std::collections::HashMap;
 use std::ffi::OsString;
 
 use crate::error::ErrorDetails;
@@ -21,16 +22,14 @@ pub fn resolve(
     match matching {
         VersionSpec::Semver(requirement) => resolve_semver(name, requirement, session),
         VersionSpec::Exact(version) => resolve_semver(name, VersionReq::exact(&version), session),
-        VersionSpec::None | VersionSpec::Tag(VersionTag::Latest) => resolve_latest(name, session),
-        VersionSpec::Tag(tag) => Err(ErrorDetails::PackageVersionNotFound {
-            name: name.into(),
-            matching: tag.to_string(),
+        VersionSpec::None | VersionSpec::Tag(VersionTag::Latest) => {
+            resolve_tag(name, "latest", session)
         }
-        .into()),
+        VersionSpec::Tag(tag) => resolve_tag(name, &tag.to_string(), session),
     }
 }
 
-fn resolve_latest(name: &str, session: &mut Session) -> Fallible<PackageDetails> {
+fn resolve_tag(name: &str, tag: &str, session: &mut Session) -> Fallible<PackageDetails> {
     let package_index = match session.hooks()?.package() {
         Some(&ToolHooks {
             latest: Some(ref hook),
@@ -40,15 +39,14 @@ fn resolve_latest(name: &str, session: &mut Session) -> Fallible<PackageDetails>
             let url = hook.resolve(&name)?;
             resolve_package_metadata(name, &url)?.into()
         }
-        _ => npm_view_query(name, "latest", session)?,
+        _ => npm_view_query(name, tag, session)?,
     };
 
-    let latest = package_index.latest.clone();
-
+    let mut entries = package_index.entries.into_iter();
     let details_opt = package_index
-        .entries
-        .into_iter()
-        .find(|PackageDetails { version, .. }| &latest == version);
+        .tags
+        .get(tag)
+        .and_then(|v| entries.find(|PackageDetails { version, .. }| v == version));
 
     match details_opt {
         Some(details) => {
@@ -60,7 +58,7 @@ fn resolve_latest(name: &str, session: &mut Session) -> Fallible<PackageDetails>
         }
         None => Err(ErrorDetails::PackageVersionNotFound {
             name: name.to_string(),
-            matching: "latest".into(),
+            matching: tag.into(),
         }
         .into()),
     }
@@ -106,7 +104,7 @@ fn resolve_semver(
 
 /// Index of versions of a specific package.
 pub struct PackageIndex {
-    pub latest: Version,
+    pub tags: HashMap<String, Version>,
     pub entries: Vec<PackageDetails>,
 }
 
@@ -150,8 +148,8 @@ fn npm_view_query(name: &str, version: &str, session: &mut Session) -> Fallible<
         debug!("[parsed package metadata (array)]\n{:?}", metadatas);
 
         // get latest version, making sure the array is not empty
-        let latest = match metadatas.iter().next() {
-            Some(m) => m.dist_tags.latest.clone(),
+        let tags = match metadatas.iter().next() {
+            Some(m) => m.dist_tags.clone(),
             None => throw!(ErrorDetails::PackageNotFound {
                 package: name.to_string()
             }),
@@ -163,7 +161,7 @@ fn npm_view_query(name: &str, version: &str, session: &mut Session) -> Fallible<
 
         debug!("[sorted entries]\n{:?}", entries);
 
-        Ok(PackageIndex { latest, entries })
+        Ok(PackageIndex { tags, entries })
     } else {
         let metadata: super::serial::NpmViewData = serde_json::de::from_str(&response_json)
             .with_context(|_| ErrorDetails::NpmViewMetadataParseError {
@@ -172,7 +170,7 @@ fn npm_view_query(name: &str, version: &str, session: &mut Session) -> Fallible<
         debug!("[parsed package metadata (single)]\n{:?}", metadata);
 
         Ok(PackageIndex {
-            latest: metadata.dist_tags.latest.clone(),
+            tags: metadata.dist_tags.clone(),
             entries: vec![metadata.into()],
         })
     }

--- a/crates/volta-core/src/tool/yarn/fetch.rs
+++ b/crates/volta-core/src/tool/yarn/fetch.rs
@@ -155,7 +155,7 @@ fn fetch_remote_distro(
 ) -> Fallible<Box<dyn Archive>> {
     debug!("Downloading {} from {}", tool_version("yarn", version), url);
     Tarball::fetch(url, staging_path).with_context(download_tool_error(
-        tool::Spec::Yarn(VersionSpec::exact(&version)),
+        tool::Spec::Yarn(VersionSpec::Exact(version.clone())),
         url,
     ))
 }

--- a/crates/volta-core/src/version/mod.rs
+++ b/crates/volta-core/src/version/mod.rs
@@ -1,85 +1,94 @@
-pub(crate) mod serial;
-
 use std::fmt;
 use std::str::FromStr;
 
-use semver::{ReqParseError, Version, VersionReq};
-
 use crate::error::ErrorDetails;
-use volta_fail::{Fallible, ResultExt};
+use semver::{Version, VersionReq};
+use volta_fail::{Fallible, ResultExt, VoltaError};
 
-use self::serial::parse_requirements;
+mod serial;
 
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum VersionSpec {
-    Latest,
-    Lts,
+    None,
     Semver(VersionReq),
     Exact(Version),
+    Tag(VersionTag),
+}
+
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum VersionTag {
+    Latest,
+    Lts,
+    Custom(String),
 }
 
 impl fmt::Display for VersionSpec {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match *self {
-            VersionSpec::Latest => write!(f, "latest"),
-            VersionSpec::Lts => write!(f, "lts"),
-            VersionSpec::Semver(ref req) => req.fmt(f),
-            VersionSpec::Exact(ref version) => version.fmt(f),
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VersionSpec::None => write!(f, "<default>"),
+            VersionSpec::Semver(req) => req.fmt(f),
+            VersionSpec::Exact(version) => version.fmt(f),
+            VersionSpec::Tag(tag) => tag.fmt(f),
+        }
+    }
+}
+
+impl fmt::Display for VersionTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            VersionTag::Latest => write!(f, "latest"),
+            VersionTag::Lts => write!(f, "lts"),
+            VersionTag::Custom(s) => s.fmt(f),
         }
     }
 }
 
 impl Default for VersionSpec {
     fn default() -> Self {
-        VersionSpec::Lts
-    }
-}
-
-impl VersionSpec {
-    pub fn exact(version: &Version) -> Self {
-        VersionSpec::Exact(version.clone())
-    }
-
-    pub fn parse(s: impl AsRef<str>) -> Fallible<Self> {
-        let s = s.as_ref();
-        s.parse().with_context(version_parse_error(s))
-    }
-
-    pub fn parse_requirements(s: impl AsRef<str>) -> Fallible<VersionReq> {
-        parse_requirements(s.as_ref()).with_context(version_parse_error(s))
-    }
-
-    pub fn parse_version(s: impl AsRef<str>) -> Fallible<Version> {
-        Version::parse(s.as_ref()).with_context(version_parse_error(s))
+        VersionSpec::None
     }
 }
 
 impl FromStr for VersionSpec {
-    type Err = ReqParseError;
+    type Err = VoltaError;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "latest" {
-            return Ok(VersionSpec::Latest);
-        } else if s == "lts" {
-            return Ok(VersionSpec::Lts);
-        }
-
-        if let Ok(ref exact) = VersionSpec::parse_version(s) {
-            Ok(VersionSpec::exact(exact))
+    fn from_str(s: &str) -> Fallible<Self> {
+        if let Ok(version) = parse_version(s) {
+            Ok(VersionSpec::Exact(version))
+        } else if let Ok(req) = parse_requirements(s) {
+            Ok(VersionSpec::Semver(req))
         } else {
-            Ok(VersionSpec::Semver(parse_requirements(s)?))
+            s.parse().map(VersionSpec::Tag)
         }
     }
 }
 
-fn version_parse_error<E, S>(version: S) -> impl FnOnce(&E) -> ErrorDetails
-where
-    E: std::error::Error,
-    S: AsRef<str>,
-{
-    let version = version.as_ref().to_string();
-    |_error: &E| ErrorDetails::VersionParseError { version }
+impl FromStr for VersionTag {
+    type Err = VoltaError;
+
+    fn from_str(s: &str) -> Fallible<Self> {
+        if s == "latest" {
+            Ok(VersionTag::Latest)
+        } else if s == "lts" {
+            Ok(VersionTag::Lts)
+        } else {
+            Ok(VersionTag::Custom(s.into()))
+        }
+    }
+}
+
+pub fn parse_requirements(s: impl AsRef<str>) -> Fallible<VersionReq> {
+    let s = s.as_ref();
+    serial::parse_requirements(s)
+        .with_context(|_| ErrorDetails::VersionParseError { version: s.into() })
+}
+
+pub fn parse_version(s: impl AsRef<str>) -> Fallible<Version> {
+    let s = s.as_ref();
+    s.parse()
+        .with_context(|_| ErrorDetails::VersionParseError { version: s.into() })
 }
 
 // remove the leading 'v' from the version string, if present

--- a/crates/volta-core/src/version/mod.rs
+++ b/crates/volta-core/src/version/mod.rs
@@ -10,7 +10,8 @@ use volta_fail::{Fallible, ResultExt};
 
 use self::serial::parse_requirements;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub enum VersionSpec {
     Latest,
     Lts,

--- a/crates/volta-core/src/version/mod.rs
+++ b/crates/volta-core/src/version/mod.rs
@@ -10,18 +10,33 @@ mod serial;
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum VersionSpec {
+    /// No version specified (default)
     None,
+
+    /// Semver Range
     Semver(VersionReq),
+
+    /// Exact Version
     Exact(Version),
+
+    /// Arbitrary Version Tag
     Tag(VersionTag),
 }
 
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum VersionTag {
+    /// The 'latest' tag, a special case that exists for all packages
     Latest,
+
+    /// The 'lts' tag, a special case for Node
     Lts,
+
+    /// An arbitrary tag version
     Custom(String),
+
+    /// An internal tag that represents the latest LTS version which matches a set of requirements
+    LtsRequirement(VersionReq),
 }
 
 impl fmt::Display for VersionSpec {
@@ -41,6 +56,7 @@ impl fmt::Display for VersionTag {
             VersionTag::Latest => write!(f, "latest"),
             VersionTag::Lts => write!(f, "lts"),
             VersionTag::Custom(s) => s.fmt(f),
+            VersionTag::LtsRequirement(req) => req.fmt(f),
         }
     }
 }

--- a/crates/volta-core/src/version/mod.rs
+++ b/crates/volta-core/src/version/mod.rs
@@ -188,3 +188,23 @@ pub mod option_version_serde {
         Ok(None)
     }
 }
+
+// custom deserialization for HashMap<String, Version>
+// because Version doesn't work with serde out of the box
+pub mod hashmap_version_serde {
+    use super::version_serde;
+    use semver::Version;
+    use serde::{self, Deserialize, Deserializer};
+    use std::collections::HashMap;
+
+    #[derive(Deserialize)]
+    struct Wrapper(#[serde(deserialize_with = "version_serde::deserialize")] Version);
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, Version>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let m = HashMap::<String, Wrapper>::deserialize(deserializer)?;
+        Ok(m.into_iter().map(|(k, Wrapper(v))| (k, v)).collect())
+    }
+}

--- a/tests/smoke/volta_install.rs
+++ b/tests/smoke/volta_install.rs
@@ -16,8 +16,8 @@ fn install_node() {
     );
 
     // node 10.2.1 comes with npm 5.6.0
-    assert_eq!(p.node_version_is_fetched("10.2.1"), true);
-    assert_eq!(p.node_version_is_unpacked("10.2.1", "5.6.0"), true);
+    assert!(p.node_version_is_fetched("10.2.1"));
+    assert!(p.node_version_is_unpacked("10.2.1", "5.6.0"));
     p.assert_node_version_is_installed("10.2.1", "5.6.0");
 }
 
@@ -42,8 +42,8 @@ fn install_yarn() {
         execs().with_status(0).with_stdout_contains("1.9.2")
     );
 
-    assert_eq!(p.yarn_version_is_fetched("1.9.2"), true);
-    assert_eq!(p.yarn_version_is_unpacked("1.9.2"), true);
+    assert!(p.yarn_version_is_fetched("1.9.2"));
+    assert!(p.yarn_version_is_unpacked("1.9.2"));
     p.assert_yarn_version_is_installed("1.9.2");
 }
 
@@ -62,8 +62,8 @@ fn install_npm() {
 
     // install npm 6.8.0 and verify that is installed correctly
     assert_that!(p.volta("install npm@6.8.0"), execs().with_status(0));
-    assert_eq!(p.npm_version_is_fetched("6.8.0"), true);
-    assert_eq!(p.npm_version_is_unpacked("6.8.0"), true);
+    assert!(p.npm_version_is_fetched("6.8.0"));
+    assert!(p.npm_version_is_unpacked("6.8.0"));
     p.assert_npm_version_is_installed("6.8.0");
 
     assert_that!(
@@ -89,10 +89,10 @@ fn install_package() {
     assert_that!(p.volta("install node@10.4.1"), execs().with_status(0));
 
     assert_that!(p.volta("install cowsay@1.4.0"), execs().with_status(0));
-    assert_eq!(p.shim_exists("cowsay"), true);
+    assert!(p.shim_exists("cowsay"));
 
-    assert_eq!(p.package_version_is_fetched("cowsay", "1.4.0"), true);
-    assert_eq!(p.package_version_is_unpacked("cowsay", "1.4.0"), true);
+    assert!(p.package_version_is_fetched("cowsay", "1.4.0"));
+    assert!(p.package_version_is_unpacked("cowsay", "1.4.0"));
 
     assert_that!(
         p.exec_shim("cowsay", "hello"),
@@ -108,13 +108,29 @@ fn install_scoped_package() {
     assert_that!(p.volta("install node@10.4.1"), execs().with_status(0));
 
     assert_that!(p.volta("install @wdio/cli@5.12.4"), execs().with_status(0));
-    assert_eq!(p.shim_exists("wdio"), true);
+    assert!(p.shim_exists("wdio"));
 
-    assert_eq!(p.package_version_is_fetched("@wdio/cli", "5.12.4"), true);
-    assert_eq!(p.package_version_is_unpacked("@wdio/cli", "5.12.4"), true);
+    assert!(p.package_version_is_fetched("@wdio/cli", "5.12.4"));
+    assert!(p.package_version_is_unpacked("@wdio/cli", "5.12.4"));
 
     assert_that!(
         p.exec_shim("wdio", "--version"),
         execs().with_status(0).with_stdout_contains("5.12.4")
+    );
+}
+
+#[test]
+fn install_package_tag_version() {
+    let p = temp_project().build();
+
+    // have to install node first, because we need npm
+    assert_that!(p.volta("install node@10.4.1"), execs().with_status(0));
+
+    assert_that!(p.volta("install elm@elm0.19.0"), execs().with_status(0));
+    assert!(p.shim_exists("elm"));
+
+    assert_that!(
+        p.exec_shim("elm", "--version"),
+        execs().with_status(0).with_stdout_contains("0.19.0")
     );
 }


### PR DESCRIPTION
Closes #491 
Closes #480 

Info
-----
Our current `volta install <package>` process has a few slightly-related issues that have come up multiple times:
* We currently select the latest version of Node that matches the `engines` field (or the latest overall if there are no `engines`), which can result in broken CLI tools when there is a major version bump.
* We don't currently support tag versions other than `latest` (e.g. `beta`).

Changes
-----
* Reworked the `VersionSpec` field to support tags, with `latest` and `lts` special-cased since they require additional handling.
* Updated the package resolve logic to support resolving version tags as well as pure versions or version ranges.
* Added an internal-only tag type (that can't be created using the `FromStr` implementation): `LtsRequirement`, which represents the latest LTS version that matches a given SemVer requirement.
* Updated the node resolution algorithm to support the `LtsRequirement` tag, finding the latest LTS version that matches the requirement (or the latest version overall that matches, if no LTS versions match).

Tested
-----
* Ran `volta install elm@elm0.19.0` to confirm that the tag version is correctly resolved into an actual version and installed.
* Ran `volta install ember-cli` followed by `ember --version` to confirm that the latest LTS version of Node was selected, instead of the overall latest.
* Added a smoke test to cover installing a tag version