### PR TITLE
[volta updates] Ensure layout file is written on new installation

### DIFF
--- a/tests/acceptance/migrations.rs
+++ b/tests/acceptance/migrations.rs
@@ -30,9 +30,11 @@ fn empty_volta_home_is_created() {
     assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
     assert!(Sandbox::path_exists(".volta/tools/user"));
 
+    // Layout file should now exist
+    assert!(Sandbox::path_exists(".volta/layout.v1"));
+
     // shims should all be created
-    // NOTE: this doesn't work in Windows, because the shim directory
-    //       is stored in the Registry, and not accessible
+    // NOTE: this doesn't work in Windows, because the default shims are stored separately
     #[cfg(unix)]
     {
         assert!(Sandbox::shim_exists("node"));


### PR DESCRIPTION
Closes #617 

The layout file was being written on a migration from a legacy V0 layout, but not on creation of an entirely new layout. This was causing the migration to run on every invocation, detecting the system as being in a "new" state, and then not write the layout file.

Updated the logic so both types of migrations result in writing the layout file before finishing.