### PR TITLE
[ci docs] Use the cargo flag for --document-private-items

### DIFF
--- a/ci/build-api-docs.yml
+++ b/ci/build-api-docs.yml
@@ -10,13 +10,16 @@ steps:
     displayName: Ensure nightly toolchain is the default
 
   - script: |
-      cargo doc -p progress-read --no-deps
-      cargo doc -p volta-fail --no-deps
-      cargo doc -p archive --no-deps
-      cargo doc --features cross-platform-docs -p volta-core --no-deps
-      cargo doc --features cross-platform-docs --no-deps
-    env:
-      RUSTDOCFLAGS: --document-private-items
+      cargo doc -p progress-read --no-deps --document-private-items
+      cargo doc -p volta-fail --no-deps --document-private-items
+      cargo doc -p volta-layout --no-deps --document-private-items
+      cargo doc -p volta-migrate --no-deps --document-private-items
+      cargo doc -p archive --no-deps --document-private-items
+      cargo doc -p fs-utils --no-deps --document-private-items
+      cargo doc -p headers-011 --no-deps --document-private-items
+      cargo doc -p validate-npm-package-name --no-deps --document-private-items
+      cargo doc --features cross-platform-docs -p volta-core --no-deps --document-private-items
+      cargo doc --features cross-platform-docs --no-deps --document-private-items
     displayName: Generate docs
 
   - script: |


### PR DESCRIPTION
It appears that setting RUSTDOCFLAGS="--document-private-items" can cause
rustdoc to fail because the setting is set twice, once by cargo and again
by the environment variable. This results in the docs builds failing to
execute.

Updated to use the cargo flag, which ensures that the flag is only passed
to rustdoc once.

Also updated the build-api-docs CI task to include recently added crates.