### PR TITLE
Remove UNC Prefix after Canonicalize on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,6 +540,11 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "dunce"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "either"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2413,6 +2418,7 @@ dependencies = [
  "detect-indent 0.1.0 (git+https://github.com/stefanpenner/detect-indent-rs)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "double-checked-cell 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "envoy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2676,6 +2682,7 @@ dependencies = [
 "checksum dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 "checksum double-checked-cell 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "deb515eb73e9bd6190f40e098946e6c476e5a80067294af584c001afa16fe0c8"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
+"checksum dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0ad6bf6a88548d1126045c413548df1453d9be094a8ab9fd59bf1fdd338da4f"
 "checksum either 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a39bffec1e2015c5d8a6773cb0cf48d0d758c842398f624c34969071f5499ea7"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -51,6 +51,7 @@ ctrlc = "3.1.3"
 walkdir = "2.2.9"
 volta-layout = { path = "../volta-layout" }
 double-checked-cell = "2.0.2"
+dunce = "1.0.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6.0"

--- a/crates/volta-core/src/hook/tool.rs
+++ b/crates/volta-core/src/hook/tool.rs
@@ -8,6 +8,7 @@ use crate::command::create_command;
 use crate::error::ErrorDetails;
 use crate::tool::{NODE_DISTRO_ARCH, NODE_DISTRO_OS};
 use cmdline_words_parser::StrExt;
+use dunce::canonicalize;
 use lazy_static::lazy_static;
 use log::debug;
 use semver::Version;
@@ -76,7 +77,7 @@ fn execute_binary(bin: &str, base_path: &Path, extra_arg: Option<String>) -> Fal
         Some(word) => {
             // Treat any path that starts with a './' or '../' as a relative path (using OS separator)
             if word.starts_with(REL_PATH.as_str()) || word.starts_with(REL_PATH_PARENT.as_str()) {
-                base_path.join(word).canonicalize().with_context(|_| {
+                canonicalize(base_path.join(word)).with_context(|_| {
                     ErrorDetails::HookPathError {
                         command: String::from(word),
                     }

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use crate::error::ErrorDetails;
 use cfg_if::cfg_if;
 use double_checked_cell::DoubleCheckedCell;
+use dunce::canonicalize;
 use lazy_static::lazy_static;
 use volta_fail::{Fallible, ResultExt};
 use volta_layout::v1::{VoltaHome, VoltaInstall};
@@ -57,6 +58,6 @@ fn default_install_dir() -> Fallible<PathBuf> {
             path.pop(); // Remove the executable name from the path
             path
         })
-        .and_then(|path| path.canonicalize())
+        .and_then(canonicalize)
         .with_context(|_| ErrorDetails::NoInstallDir)
 }

--- a/crates/volta-core/src/tool/package/fetch.rs
+++ b/crates/volta-core/src/tool/package/fetch.rs
@@ -231,7 +231,7 @@ fn find_unpack_dir(in_dir: &Path) -> Fallible<PathBuf> {
     // if there is only one directory, return that
     if let [(entry, metadata)] = dirs.as_slice() {
         if metadata.is_dir() {
-            return Ok(entry.path().to_path_buf());
+            return Ok(entry.path());
         }
     }
     // there is more than just a single directory here, something is wrong

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -9,6 +9,7 @@ use crate::layout::volta_home;
 use crate::session::Session;
 use crate::shim;
 use crate::style::{success_prefix, tool_version};
+use dunce::canonicalize;
 use log::info;
 use semver::Version;
 use volta_fail::{Fallible, ResultExt};
@@ -30,14 +31,14 @@ pub fn bin_full_path<P>(
 where
     P: AsRef<Path>,
 {
-    // canonicalize because path is relative, and sometimes uses '.' char
-    volta_home()?
+    let raw_path = volta_home()?
         .package_image_dir(package, &version.to_string())
-        .join(bin_path)
-        .canonicalize()
-        .with_context(|_| ErrorDetails::ExecutablePathError {
-            command: bin_name.to_string(),
-        })
+        .join(bin_path);
+
+    // canonicalize because path is relative, and sometimes uses '.' char
+    canonicalize(raw_path).with_context(|_| ErrorDetails::ExecutablePathError {
+        command: bin_name.to_string(),
+    })
 }
 
 /// Details required for fetching a 3rd-party Package

--- a/src/command/list/plain.rs
+++ b/src/command/list/plain.rs
@@ -49,12 +49,12 @@ pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
             Some(format!("{}\n{}", runtimes, package_managers))
         }
         (Some(runtimes), None, Some(packages)) => Some(format!("{}\n{}", runtimes, packages)),
-        (Some(runtimes), None, None) => Some(runtimes.to_string()),
+        (Some(runtimes), None, None) => Some(runtimes),
         (None, Some(package_managers), Some(packages)) => {
             Some(format!("{}\n{}", package_managers, packages))
         }
-        (None, Some(package_managers), None) => Some(package_managers.to_string()),
-        (None, None, Some(packages)) => Some(packages.to_string()),
+        (None, Some(package_managers), None) => Some(package_managers),
+        (None, None, Some(packages)) => Some(packages),
         (None, None, None) => None,
     }
 }


### PR DESCRIPTION
Closes #635 
Closes #630 
Closes #586 

Info
-----
* We use `fs::canonicalize()` in a few places to resolve relative paths and potential symlinks to the target file.
* On Windows, `canonicalize` returns a UNC path with `\\?\` in the prefix, however those paths cause issues in a number of use-cases (see also https://github.com/rust-lang/rust/issues/42869):
    * JS Scripts that append paths using concatenation instead of `path.join` can cause issues, since UNC paths don't support `/` as a separator (see #635 and #586)
    * We incorrectly fail to remove the Volta install directory from the PATH variable when doing a passthrough, because the comparison between `C:\...\Volta` and `\\?\C:\...\Volta` fails to match. This can cause an infinite loop of calls to the built-in shims, since they aren't removed from the PATH (see #630).

Changes
-----
* Updated all calls to `canonicalize` to use [dunce](https://crates.io/crates/dunce)
* Dunce inspects the PATH and strips off the UNC prefix if it is safe (following the Windows conventions for when the two paths are equivalent).
    * On non-Windows systems, `dunce::canonicalize` is an inline passthrough to `fs::canonicalize`, so Unix remains unaffected.
* Also cleaned up some redundant clones that Clippy found.

Tested
-----
* Tested all three bugs caused by UNC paths (`gulp-cli`, `ember-cli`, and calling `npm i` with passthrough.
* Confirmed that each was reproducible prior to and fixed after the changes.