### PR TITLE
Fix #636: Improve volta uninstall messaging for non-installed packages

### DIFF
--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -111,7 +111,6 @@ impl Spec {
             .into()),
             Spec::Package(name, _) => {
                 package::uninstall(&name)?;
-                info!("{} package '{}' uninstalled", success_prefix(), name);
                 Ok(())
             }
         }

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -137,12 +137,10 @@ impl Display for Package {
 /// * the shims
 /// * the unpacked and initialized package
 pub fn uninstall(name: &str) -> Fallible<()> {
-    let mut package_found = false;
     let home = volta_home()?;
     // if the package config file exists, use that to remove any installed bins and shims
     let package_config_file = home.default_package_config_file(name);
-    if package_config_file.exists() {
-        package_found = true;
+    let package_found = if package_config_file.exists() {
         let package_config = PackageConfig::from_file(&package_config_file)?;
 
         for bin_name in package_config.bins {
@@ -151,16 +149,19 @@ pub fn uninstall(name: &str) -> Fallible<()> {
 
         fs::remove_file(&package_config_file)
             .with_context(delete_file_error(&package_config_file))?;
+        true
     } else {
         // there is no package config - check for orphaned binaries
         let package_binary_list = binaries_from_package(name)?;
         if !package_binary_list.is_empty() {
-            package_found = true;
             for bin_name in package_binary_list {
                 remove_config_and_shim(&bin_name, name)?;
             }
+            true
+        } else {
+            false
         }
-    }
+    };
 
     // if any unpacked and initialized packages exists, remove them
     let package_image_dir = home.package_image_root_dir().join(name);

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -170,10 +170,11 @@ pub fn uninstall(name: &str) -> Fallible<()> {
             .with_context(delete_dir_error(&package_image_dir))?;
     }
 
-    match package_found {
-        true => info!("{} package '{}' uninstalled", success_prefix(), name),
-        false => warn!("No package '{}' found to uninstall", name),
-    };
+    if package_found {
+        info!("{} package '{}' uninstalled", success_prefix(), name);
+    } else {
+        warn!("No package '{}' found to uninstall", name);
+    }
 
     Ok(())
 }

--- a/tests/acceptance/volta_uninstall.rs
+++ b/tests/acceptance/volta_uninstall.rs
@@ -62,7 +62,7 @@ fn uninstall_nonexistent_pkg() {
         s.volta("uninstall cowsay"),
         execs()
             .with_status(0)
-            .with_stdout_contains("[..]package 'cowsay' uninstalled")
+            .with_stderr_contains("[..]No package 'cowsay' found to uninstall")
     );
 }
 


### PR DESCRIPTION
- Move the logic of showing success/warn into `package::uninstall`
- Show `uninstall success` when package config exists or orphaned binary exists
- Matched unpacked and initialized package won't trigger `uninstall success`

Let me know if there is anything missing or anything I need to change. Thanks!