### PR TITLE
Trim loader and store on all platforms

### DIFF
--- a/crates/volta-core/src/tool/package/install.rs
+++ b/crates/volta-core/src/tool/package/install.rs
@@ -290,6 +290,8 @@ fn determine_script_loader(bin_name: &str, full_path: &Path) -> Fallible<Option<
         })?;
     if let Some(Ok(first_line)) = BufReader::new(script).lines().next() {
         if let Some(caps) = SHEBANG.captures(&first_line) {
+            // Note: `caps["args"]` will never panic, since "args" is a non-optional part of the match
+            // So if there is a Regex match, then it will necessarily include the "args" group.
             let args = caps["args"]
                 .trim()
                 .to_string()


### PR DESCRIPTION
Closes #643 

Info
-----
* Packages are sometimes published from Windows with CRLF (`\r\n`) as the line-ending on the scripts.
* This causes issues with shebang loaders, since Unix interprets `\r` as part of the command, instead of part of the EOL marker.
* Volta already supports parsing and storing information about the loader to use when running the command, we can take advantage of that to remove unexpected whitespace before calling the appropriate program.

Changes
-----
* Moved the `determine_script_loader` function out of OS-specific code and set it up to run on all platforms.
* Added a call to `.trim()` to the loader to remove any extraneous `\r` (and other whitespace) characters from the arguments before storing them.

Tested
-----
* Confirmed that the package listed in the original issue (`git-mob@1.0.1`) works correctly with the new loader information.