### PR TITLE
Add note when running 'volta install' within a project

### DIFF
--- a/crates/volta-core/src/style.rs
+++ b/crates/volta-core/src/style.rs
@@ -14,6 +14,11 @@ pub fn success_prefix() -> StyledObject<&'static str> {
     style("success:").green().bold()
 }
 
+/// Generate the styled prefix for a note
+pub fn note_prefix() -> StyledObject<&'static str> {
+    style("   note:").magenta().bold()
+}
+
 /// Format the underlying cause of an error
 pub(crate) fn format_error_cause(inner: &dyn Fail) -> String {
     format!(

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display};
 
 use crate::error::ErrorDetails;
 use crate::session::Session;
-use crate::style::{success_prefix, tool_version};
+use crate::style::{note_prefix, success_prefix, tool_version};
 use crate::version::{parse_version, VersionSpec};
 use log::{debug, info};
 use semver::Version;
@@ -40,6 +40,15 @@ fn info_fetched<T: Display + Sized>(tool: T) {
 #[inline]
 fn info_pinned<T: Display + Sized>(tool: T) {
     info!("{} pinned {} in package.json", success_prefix(), tool);
+}
+
+#[inline]
+fn info_project_version<T: Display + Sized>(tool: T) {
+    info!(
+        "{} you are using {} in the current project",
+        note_prefix(),
+        tool
+    );
 }
 
 /// Trait representing all of the actions that can be taken with a tool

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -1,6 +1,8 @@
 use std::fmt::{self, Display};
 
-use super::{debug_already_fetched, info_fetched, info_installed, info_pinned, Tool};
+use super::{
+    debug_already_fetched, info_fetched, info_installed, info_pinned, info_project_version, Tool,
+};
 use crate::error::ErrorDetails;
 use crate::session::Session;
 use crate::style::tool_version;
@@ -136,6 +138,10 @@ impl Tool for Node {
         session.toolchain_mut()?.set_active_node(&node_version)?;
 
         info_installed(node_version);
+
+        if let Ok(Some(project)) = session.project_platform() {
+            info_project_version(tool_version("node", &project.node_runtime));
+        }
         Ok(())
     }
     fn pin(self, session: &mut Session) -> Fallible<()> {

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -1,6 +1,8 @@
 use std::fmt::{self, Display};
 
-use super::{debug_already_fetched, info_fetched, info_installed, info_pinned, Tool};
+use super::{
+    debug_already_fetched, info_fetched, info_installed, info_pinned, info_project_version, Tool,
+};
 use crate::error::ErrorDetails;
 use crate::session::Session;
 use crate::style::tool_version;
@@ -63,6 +65,12 @@ impl Tool for Yarn {
         session.toolchain_mut()?.set_active_yarn(&self.version)?;
 
         info_installed(self);
+
+        if let Ok(Some(project)) = session.project_platform() {
+            if let Some(yarn) = &project.yarn {
+                info_project_version(tool_version("yarn", yarn));
+            }
+        }
         Ok(())
     }
     fn pin(self, session: &mut Session) -> Fallible<()> {


### PR DESCRIPTION
Closes #609 

Adds a `note:` message after running `volta install` inside a pinned project, reminding the user of the version they have pinned.

I'm more than happy to hear suggestions of better verbiage or formatting for the note, if there are any.

![Screen Shot 2020-01-21 at 2 07 31 PM](https://user-images.githubusercontent.com/18537342/72847870-44f64400-3c58-11ea-8158-18a5b8996606.png)

![Screen Shot 2020-01-21 at 2 07 40 PM](https://user-images.githubusercontent.com/18537342/72847866-41fb5380-3c58-11ea-911f-f28fa030996e.png)
