### PR TITLE
Support creating completions in new directories

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -68,6 +68,10 @@ pub enum ErrorDetails {
         path: PathBuf,
     },
 
+    CompletionsDirCreationError {
+        path: PathBuf,
+    },
+
     /// Thrown when the containing directory could not be determined
     ContainingDirError {
         path: PathBuf,
@@ -570,6 +574,11 @@ Use `npm install` or `yarn add` to select a version of {} for this project.",
                 "Completions file `{}` already exists.
 
 Please remove the file or pass `-f` or `--force` to override.",
+                path.display()
+            ),
+            ErrorDetails::CompletionsDirCreationError { path } => write!(
+                f,
+                "Could not create directory {}.",
                 path.display()
             ),
             ErrorDetails::ContainingDirError { path } => write!(
@@ -1370,6 +1379,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::BypassError { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::CannotPinPackage { .. } => ExitCode::InvalidArguments,
             ErrorDetails::CompletionsOutFileError { .. } => ExitCode::InvalidArguments,
+            ErrorDetails::CompletionsDirCreationError { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::ContainingDirError { .. } => ExitCode::FileSystemError,
             ErrorDetails::CouldNotDetermineTool => ExitCode::UnknownError,
             ErrorDetails::CouldNotStartMigration => ExitCode::EnvironmentError,

--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -68,10 +68,6 @@ pub enum ErrorDetails {
         path: PathBuf,
     },
 
-    CompletionsDirCreationError {
-        path: PathBuf,
-    },
-
     /// Thrown when the containing directory could not be determined
     ContainingDirError {
         path: PathBuf,
@@ -574,11 +570,6 @@ Use `npm install` or `yarn add` to select a version of {} for this project.",
                 "Completions file `{}` already exists.
 
 Please remove the file or pass `-f` or `--force` to override.",
-                path.display()
-            ),
-            ErrorDetails::CompletionsDirCreationError { path } => write!(
-                f,
-                "Could not create directory {}.",
                 path.display()
             ),
             ErrorDetails::ContainingDirError { path } => write!(
@@ -1379,7 +1370,6 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::BypassError { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::CannotPinPackage { .. } => ExitCode::InvalidArguments,
             ErrorDetails::CompletionsOutFileError { .. } => ExitCode::InvalidArguments,
-            ErrorDetails::CompletionsDirCreationError { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::ContainingDirError { .. } => ExitCode::FileSystemError,
             ErrorDetails::CouldNotDetermineTool => ExitCode::UnknownError,
             ErrorDetails::CouldNotStartMigration => ExitCode::EnvironmentError,

--- a/src/command/completions.rs
+++ b/src/command/completions.rs
@@ -1,10 +1,12 @@
 use std::path::PathBuf;
 
+use log::info;
 use structopt::{clap::Shell, StructOpt};
 
 use volta_core::{
     error::ErrorDetails,
     session::{ActivityKind, Session},
+    style::{note_prefix, success_prefix},
 };
 use volta_fail::{throw, ExitCode, Fallible, ResultExt};
 
@@ -41,10 +43,36 @@ impl Command for Completions {
                     throw!(ErrorDetails::CompletionsOutFileError { path })
                 }
 
-                let mut file = &std::fs::File::create(&path)
-                    .with_context(|_| ErrorDetails::CompletionsOutFileError { path })?;
+                // The user may have passed a path that does not yet exist. If
+                // so, we create it, informing the user we have done so.
+                if let Some(parent) = path.parent() {
+                    if !parent.is_dir() {
+                        info!(
+                            "{} {} does not exist, creating it",
+                            note_prefix(),
+                            parent.display()
+                        );
+                        std::fs::create_dir_all(parent).with_context(|_| {
+                            ErrorDetails::CompletionsDirCreationError {
+                                path: parent.to_path_buf(),
+                            }
+                        })?;
+                    }
+                }
+
+                let mut file = &std::fs::File::create(&path).with_context(|_| {
+                    ErrorDetails::CompletionsOutFileError {
+                        path: path.to_path_buf(),
+                    }
+                })?;
 
                 app.gen_completions_to("volta", self.shell, &mut file);
+
+                info!(
+                    "{} installed completions to {}",
+                    success_prefix(),
+                    path.display()
+                );
             }
             None => app.gen_completions_to("volta", self.shell, &mut std::io::stdout()),
         };

--- a/src/command/completions.rs
+++ b/src/command/completions.rs
@@ -53,8 +53,8 @@ impl Command for Completions {
                             parent.display()
                         );
                         std::fs::create_dir_all(parent).with_context(|_| {
-                            ErrorDetails::CompletionsDirCreationError {
-                                path: parent.to_path_buf(),
+                            ErrorDetails::CreateDirError {
+                                dir: parent.to_path_buf(),
                             }
                         })?;
                     }


### PR DESCRIPTION
Previously, we were failing when any part of the path did not exist, and reporting the wrong error to boot. Here, we attempt to create the directory instead, informing the user that we are changing their file system. Adds a new error scenario to cover a failure (e.g. a permissions error on creation), and a success message after writing the completion file.

Fixes #645

<img width="807" alt="Screen Shot 2020-01-21 at 16 23 05" src="https://user-images.githubusercontent.com/2403023/72852492-e1761180-3c6b-11ea-9e17-b20244643da2.png">
