### PR TITLE
Make all acceptance tests depend on 'mock-network' flag

### DIFF
--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -1,13 +1,18 @@
-mod support;
+use cfg_if::cfg_if;
 
-// test files
+cfg_if! {
+    if #[cfg(feature = "mock-network")] {
+        mod support;
 
-mod corrupted_download;
-mod intercept_global_installs;
-mod merged_platform;
-mod migrations;
-mod run_shim_directly;
-mod verbose_errors;
-mod volta_bypass;
-mod volta_pin;
-mod volta_uninstall;
+        // test files
+        mod corrupted_download;
+        mod intercept_global_installs;
+        mod merged_platform;
+        mod migrations;
+        mod run_shim_directly;
+        mod verbose_errors;
+        mod volta_bypass;
+        mod volta_pin;
+        mod volta_uninstall;
+    }
+}

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -5,15 +5,11 @@ use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
+use mockito::{self, mock, Matcher};
 use reqwest::hyper_011::header::HttpDate;
-
 use test_support::{self, ok_or_panic, paths, paths::PathExt, process::ProcessBuilder};
-
 use volta_core::fs::symlink_file;
 use volta_core::tool::{Node, Yarn, NODE_DISTRO_ARCH, NODE_DISTRO_EXTENSION, NODE_DISTRO_OS};
-
-#[cfg(feature = "mock-network")]
-use mockito::{self, mock, Matcher};
 
 // version cache for node and yarn
 #[derive(PartialEq, Clone)]


### PR DESCRIPTION
The acceptance tests were written with only a few lines marked `#[cfg(feature = "mock-network")]`, however they all actually depended on that feature, since the tests wouldn't compile without it. Updated the test section to rely on that feature flag at the top-level, instead of lower down, so that it always compiles (though no tests will run without the flag).