### PR TITLE
Regenerate shims on 'volta setup'

### DIFF
--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -1,6 +1,8 @@
 use log::info;
 use structopt::StructOpt;
+use volta_core::layout::volta_home;
 use volta_core::session::{ActivityKind, Session};
+use volta_core::shim::regenerate_shims_for_dir;
 use volta_core::style::success_prefix;
 use volta_fail::{ExitCode, Fallible};
 
@@ -14,6 +16,7 @@ impl Command for Setup {
         session.add_event_start(ActivityKind::Setup);
 
         os::setup_environment()?;
+        regenerate_shims_for_dir(volta_home()?.shim_dir())?;
 
         info!(
             "{} Setup complete. Open a new terminal to start using Volta!",

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,6 +2,7 @@ use std::process::{Command, ExitStatus};
 
 use volta_core::error::ErrorDetails;
 use volta_core::layout::{volta_home, volta_install};
+use volta_core::shim::regenerate_shims_for_dir;
 use volta_fail::{ResultExt, VoltaError};
 
 pub enum Error {
@@ -19,6 +20,7 @@ pub fn ensure_layout() -> Result<(), Error> {
             .status()
             .with_context(|_| ErrorDetails::CouldNotStartMigration)
             .into_result()?;
+        regenerate_shims_for_dir(home.shim_dir()).map_err(Error::Volta)?;
     }
 
     Ok(())

--- a/tests/acceptance/migrations.rs
+++ b/tests/acceptance/migrations.rs
@@ -74,8 +74,7 @@ fn legacy_v0_volta_home_is_upgraded() {
     assert!(Sandbox::path_exists(".volta/layout.v1"));
 
     // shims should all be created
-    // NOTE: this doesn't work in Windows, because the shim directory
-    //       is stored in the Registry, and not accessible
+    // NOTE: this doesn't work in Windows, because the default shims are stored separately
     #[cfg(unix)]
     {
         assert!(Sandbox::shim_exists("node"));


### PR DESCRIPTION
Closes #661 

Info
-----
* Since the `volta setup` command is designed to make sure the user's system is correctly set up for Volta, it should also make sure to enforce that the shims are pointing to the correct location.
* Currently `volta` commands will only regenerate the shims if a migration is run.

Changes
-----
* Moved `regenerate_shims_for_dir` function into `volta_core::shim` module, instead of the `volta-migrate` module.
* Ensured that `regenerate_shims_for_dir` is always called after a migration runs, to maintain existing functionality.
* Added a call to `regenerate_shims_for_dir` into `volta setup` command, so that even if a migration doesn't run, `volta setup` will still cause the shims to be rebuilt.

Tested
-----
* Confirmed that running `volta setup` on an otherwise fully migrated system would correctly regenerate the shims and allow them to point at the correct binaries.

Notes
-----
* Regenerating the shims on `volta setup` does mean that if `volta setup` causes a migration, the shims will be regenerated twice, but it's a quick operation and not on the hot path, so it shouldn't be a major concern.