### PR TITLE
Add shim CMD file to support tools that rely on CMD

### DIFF
--- a/shell/windows/shim.cmd
+++ b/shell/windows/shim.cmd
@@ -1,0 +1,2 @@
+@echo off
+"%~dpn0.exe" %*

--- a/shell/windows/volta.cmd
+++ b/shell/windows/volta.cmd
@@ -1,1 +1,0 @@
-@echo Not yet implemented.

--- a/shell/windows/volta.ps1
+++ b/shell/windows/volta.ps1
@@ -1,1 +1,0 @@
-Write-Host "Not yet implemented"

--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -114,6 +114,14 @@
                     Source='target\release\volta-shim.exe'
                     KeyPath='yes'/>
             </Component>
+            <Component Id='npmScript' Guid='*' Win64='$(var.Win64)'>
+                <File
+                    Id='npmCMD'
+                    Name='npm.cmd'
+                    DiskId='1'
+                    Source='shell\windows\shim.cmd'
+                    KeyPath='yes'/>
+            </Component>
             <Component Id='npxBinary' Guid='*' Win64='$(var.Win64)'>
                 <File
                     Id='npxEXE'
@@ -122,12 +130,28 @@
                     Source='target\release\volta-shim.exe'
                     KeyPath='yes'/>
             </Component>
+            <Component Id='npxScript' Guid='*' Win64='$(var.Win64)'>
+                <File
+                    Id='npxCMD'
+                    Name='npx.cmd'
+                    DiskId='1'
+                    Source='shell\windows\shim.cmd'
+                    KeyPath='yes'/>
+            </Component>
             <Component Id='yarnBinary' Guid='*' Win64='$(var.Win64)'>
                 <File
                     Id='yarnEXE'
                     Name='yarn.exe'
                     DiskId='1'
                     Source='target\release\volta-shim.exe'
+                    KeyPath='yes'/>
+            </Component>
+            <Component Id='yarnScript' Guid='*' Win64='$(var.Win64)'>
+                <File
+                    Id='yarnCMD'
+                    Name='yarn.cmd'
+                    DiskId='1'
+                    Source='shell\windows\shim.cmd'
                     KeyPath='yes'/>
             </Component>
         </ComponentGroup>


### PR DESCRIPTION
Closes #660 

Info
-----
* Some tools on Windows (notably React Native) expect `npm` to be available through `npm.cmd`, which is provided by the standard `npm` installation.
* Volta doesn't currently have a `*.cmd` for the core shims (`npm`, `npx`, and `yarn`).

Changes
-----
* Created a passthrough shim that will call the executable with the same name (e.g. `npm.cmd` will call `npm.exe`)
* Updated the Windows installer to create a `.cmd` file for each of the 3 node tools that we install direct shims for: `npm.cmd`, `npx.cmd`, and `yarn.cmd`
* Also removed old `cmd` and `ps1` files that were left over from early Notion days.

Tested
-----
* Installed using the installer and confirmed that the `cmd` files are created.
* Manually verified that calling `npm.cmd --version` correctly runs the shim executable and passes along the command-line flags.