### PR TITLE
Always add Volta shims to PATH

### DIFF
--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -119,7 +119,7 @@ mod os {
         let mut file = File::create(path)?;
         write!(
             file,
-            "{}\nexport VOLTA_HOME=\"{}\"\ngrep --silent \"$VOLTA_HOME/bin\" <<< $PATH || export PATH=\"$VOLTA_HOME/bin:$PATH\"\n",
+            "{}\nexport VOLTA_HOME=\"{}\"\nexport PATH=\"$VOLTA_HOME/bin:$PATH\"\n",
             contents,
             volta_home.display(),
         )
@@ -129,7 +129,7 @@ mod os {
         let mut file = File::create(path)?;
         write!(
             file,
-            "{}\nset -gx VOLTA_HOME \"{}\"\nstring match -r \".volta\" \"$PATH\" > /dev/null; or set -gx PATH \"$VOLTA_HOME/bin\" $PATH\n",
+            "{}\nset -gx VOLTA_HOME \"{}\"\nset -gx PATH \"$VOLTA_HOME/bin\" $PATH\n",
             contents,
             volta_home.display(),
         )


### PR DESCRIPTION
Closes #665 

Info
-----
* Due to how VS Code launches a shell using the existing environment, shells launched with VS Code already have the Volta shim directory on the PATH, before the run any profile / startup scripts.
* As a result, we detect that Volta is on the PATH and don't update it, however it is so far back on the PATH that it is superseded by any existing `node` / `npm` / `yarn` installation already on the machine.
* This causes `node --version` to output the wrong thing when using the VS Code terminal, while using a normal terminal directly works as expected.

Changes
-----
* Updated the lines that we write to profile scripts to always append `$VOLTA_HOME/bin` to the PATH, instead of first checking if it already exists and then updating.

Tested
-----
* Tested both `zsh` and `fish` through VS Code, to confirm that with this change, the Volta shim directory is always prepended to the PATH, not left at the back by the idiosyncrasies of how VS Code launches a shell.

Note
-----
* If you receive Volta updates automatically through a managed install, you may need to run `volta setup` once to update your profile script. Alternatively, you can manually edit your scripts to _always_ prepend `$VOLTA_HOME/bin` to your `PATH`, instead of conditionally updating.