### PR TITLE
Prevent ~/.volta/bin from being added to PATH after uninstalling Volta

### DIFF
--- a/dev/rpm/volta-postinstall.sh
+++ b/dev/rpm/volta-postinstall.sh
@@ -189,20 +189,22 @@ build_path_str() {
   if [[ $profile =~ \.fish$ ]]; then
     # fish uses a little different syntax to load the shell integration script, and modify the PATH
     cat <<END_FISH_SCRIPT
-
-set -gx VOLTA_HOME "$profile_install_dir"
-test -s "\$VOLTA_HOME/load.fish"; and source "\$VOLTA_HOME/load.fish"
-
-string match -r ".volta" "\$PATH" > /dev/null; or set -gx PATH "\$VOLTA_HOME/bin" \$PATH
+if test -d "$profile_install_dir"
+  set -gx VOLTA_HOME "$profile_install_dir"
+  test -s "\$VOLTA_HOME/load.fish"; and source "\$VOLTA_HOME/load.fish"
+  
+  string match -r ".volta" "\$PATH" > /dev/null; or set -gx PATH "\$VOLTA_HOME/bin" \$PATH
+end
 END_FISH_SCRIPT
   else
     # bash and zsh
     cat <<END_BASH_SCRIPT
+if [ -d "$profile_install_dir" ]; then
+  export VOLTA_HOME="$profile_install_dir"
+  [ -s "\$VOLTA_HOME/load.sh" ] && . "\$VOLTA_HOME/load.sh"
 
-export VOLTA_HOME="$profile_install_dir"
-[ -s "\$VOLTA_HOME/load.sh" ] && . "\$VOLTA_HOME/load.sh"
-
-export PATH="\$VOLTA_HOME/bin:\$PATH"
+  export PATH="\$VOLTA_HOME/bin:\$PATH"
+fi
 END_BASH_SCRIPT
   fi
 }


### PR DESCRIPTION
They there - this is more of a proposal for improving the shell script :-)

I noticed that Volta adds some lines into ~/.config/fish/config.fish or the bash/zsh profile scripts. Given that Volta doesn't have an uninstaller, some may be tempted to just remove ~/.volta when uninstalling it. This can cause some invalid paths to be added to $PATH.

This change will suppress that if Volta isn't present.