### PR TITLE
Implement Migration to support custom npm versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,6 +2490,7 @@ name = "volta-migrate"
 version = "0.1.0"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.9.0 (git+https://github.com/mikrostew/semver?branch=new-parser)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "volta-core 0.1.0",
  "volta-fail 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,6 +2490,7 @@ name = "volta-migrate"
 version = "0.1.0"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "volta-core 0.1.0",
  "volta-fail 0.1.0",
  "volta-layout 0.1.1",

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -7,7 +7,7 @@ use double_checked_cell::DoubleCheckedCell;
 use dunce::canonicalize;
 use lazy_static::lazy_static;
 use volta_fail::{Fallible, ResultExt};
-use volta_layout::v1::{VoltaHome, VoltaInstall};
+use volta_layout::v2::{VoltaHome, VoltaInstall};
 
 cfg_if! {
     if #[cfg(unix)] {

--- a/crates/volta-core/src/platform/image.rs
+++ b/crates/volta-core/src/platform/image.rs
@@ -20,9 +20,8 @@ impl Image {
     fn bins(&self) -> Fallible<Vec<PathBuf>> {
         let home = volta_home()?;
         let node_str = self.node.value.to_string();
-        let npm_str = self.npm.value.to_string();
         // ISSUE(#292): Install npm, and handle using that
-        let mut bins = vec![home.node_image_bin_dir(&node_str, &npm_str)];
+        let mut bins = vec![home.node_image_bin_dir(&node_str)];
         if let Some(yarn) = &self.yarn {
             let yarn_str = yarn.value.to_string();
             bins.push(home.yarn_image_bin_dir(&yarn_str));

--- a/crates/volta-core/src/platform/test.rs
+++ b/crates/volta-core/src/platform/test.rs
@@ -32,7 +32,6 @@ fn test_image_path() {
         .join("image")
         .join("node")
         .join("1.2.3")
-        .join("6.4.3")
         .join("bin");
     let expected_node_bin = node_bin.as_path().to_str().unwrap();
 
@@ -97,8 +96,7 @@ fn test_image_path() {
         .join("tools")
         .join("image")
         .join("node")
-        .join("1.2.3")
-        .join("6.4.3");
+        .join("1.2.3");
     let expected_node_bin = node_bin.as_path().to_str().unwrap();
 
     let yarn_bin = volta_home()

--- a/crates/volta-core/src/tool/node/fetch.rs
+++ b/crates/volta-core/src/tool/node/fetch.rs
@@ -112,7 +112,7 @@ fn unpack_archive(archive: Box<dyn Archive>, version: &Version) -> Fallible<Node
     let npm = Manifest::version(&npm_package_json)?;
     save_default_npm_version(&version, &npm)?;
 
-    let dest = volta_home()?.node_image_dir(&version_string, &npm.to_string());
+    let dest = volta_home()?.node_image_dir(&version_string);
     ensure_containing_dir_exists(&dest)
         .with_context(|_| ErrorDetails::ContainingDirError { path: dest.clone() })?;
 

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -11,7 +11,7 @@ use readext::ReadExt;
 use semver::Version;
 use volta_fail::{Fallible, ResultExt};
 
-pub(crate) mod serial;
+pub mod serial;
 
 /// Lazily loaded toolchain
 pub struct LazyToolchain {

--- a/crates/volta-layout/src/lib.rs
+++ b/crates/volta-layout/src/lib.rs
@@ -3,6 +3,7 @@ mod macros;
 
 pub mod v0;
 pub mod v1;
+pub mod v2;
 
 fn executable(name: &str) -> String {
     format!("{}{}", name, std::env::consts::EXE_SUFFIX)

--- a/crates/volta-layout/src/v2.rs
+++ b/crates/volta-layout/src/v2.rs
@@ -18,11 +18,13 @@ layout! {
         "tools": tools_dir {
             "inventory": inventory_dir {
                 "node": node_inventory_dir {}
+                "npm": npm_inventory_dir {}
                 "packages": package_inventory_dir {}
                 "yarn": yarn_inventory_dir {}
             }
             "image": image_dir {
                 "node": node_image_root_dir {}
+                "npm": npm_image_root_dir {}
                 "yarn": yarn_image_root_dir {}
                 "packages": package_image_root_dir {}
             }
@@ -55,6 +57,14 @@ impl VoltaHome {
 
     pub fn node_image_dir(&self, node: &str) -> PathBuf {
         path_buf!(self.node_image_root_dir.clone(), node)
+    }
+
+    pub fn npm_image_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_root_dir.clone(), npm)
+    }
+
+    pub fn npm_image_bin_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_dir(npm), "bin")
     }
 
     pub fn yarn_image_dir(&self, version: &str) -> PathBuf {

--- a/crates/volta-layout/src/v2.rs
+++ b/crates/volta-layout/src/v2.rs
@@ -1,0 +1,111 @@
+use std::path::PathBuf;
+
+use super::executable;
+use volta_layout_macro::layout;
+
+pub use crate::v1::VoltaInstall;
+
+layout! {
+    pub struct VoltaHome {
+        "cache": cache_dir {
+            "node": node_cache_dir {
+                "index.json": node_index_file;
+                "index.json.expires": node_index_expiry_file;
+            }
+        }
+        "bin": shim_dir {}
+        "log": log_dir {}
+        "tools": tools_dir {
+            "inventory": inventory_dir {
+                "node": node_inventory_dir {}
+                "packages": package_inventory_dir {}
+                "yarn": yarn_inventory_dir {}
+            }
+            "image": image_dir {
+                "node": node_image_root_dir {}
+                "yarn": yarn_image_root_dir {}
+                "packages": package_image_root_dir {}
+            }
+            "user": default_toolchain_dir {
+                "bins": default_bin_dir {}
+                "packages": default_package_dir {}
+                "platform.json": default_platform_file;
+            }
+        }
+        "tmp": tmp_dir {}
+        "hooks.json": default_hooks_file;
+        "layout.v2": layout_file;
+    }
+}
+
+impl VoltaHome {
+    pub fn package_distro_file(&self, name: &str, version: &str) -> PathBuf {
+        path_buf!(
+            self.package_inventory_dir.clone(),
+            format!("{}-{}.tgz", name, version)
+        )
+    }
+
+    pub fn package_distro_shasum(&self, name: &str, version: &str) -> PathBuf {
+        path_buf!(
+            self.package_inventory_dir.clone(),
+            format!("{}-{}.shasum", name, version)
+        )
+    }
+
+    pub fn node_image_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_root_dir.clone(), node)
+    }
+
+    pub fn yarn_image_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_root_dir.clone(), version)
+    }
+
+    pub fn yarn_image_bin_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_dir(version), "bin")
+    }
+
+    pub fn package_image_dir(&self, name: &str, version: &str) -> PathBuf {
+        path_buf!(self.package_image_root_dir.clone(), name, version)
+    }
+
+    pub fn default_package_config_file(&self, package_name: &str) -> PathBuf {
+        path_buf!(
+            self.default_package_dir.clone(),
+            format!("{}.json", package_name)
+        )
+    }
+
+    pub fn default_tool_bin_config(&self, bin_name: &str) -> PathBuf {
+        path_buf!(self.default_bin_dir.clone(), format!("{}.json", bin_name))
+    }
+
+    pub fn node_npm_version_file(&self, version: &str) -> PathBuf {
+        path_buf!(
+            self.node_inventory_dir.clone(),
+            format!("node-v{}-npm", version)
+        )
+    }
+
+    pub fn shim_file(&self, toolname: &str) -> PathBuf {
+        path_buf!(self.shim_dir.clone(), executable(toolname))
+    }
+}
+
+#[cfg(windows)]
+impl VoltaHome {
+    pub fn shim_git_bash_script_file(&self, toolname: &str) -> PathBuf {
+        path_buf!(self.shim_dir.clone(), toolname)
+    }
+
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        self.node_image_dir(node)
+    }
+}
+
+#[cfg(unix)]
+impl VoltaHome {
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_dir(node), "bin")
+    }
+}

--- a/crates/volta-migrate/Cargo.toml
+++ b/crates/volta-migrate/Cargo.toml
@@ -9,3 +9,4 @@ volta-core = { path = "../volta-core" }
 volta-fail = { path = "../volta-fail" }
 volta-layout = { path = "../volta-layout" }
 log = { version = "0.4", features = ["std"] }
+tempfile = "3.0.2"

--- a/crates/volta-migrate/Cargo.toml
+++ b/crates/volta-migrate/Cargo.toml
@@ -10,3 +10,4 @@ volta-fail = { path = "../volta-fail" }
 volta-layout = { path = "../volta-layout" }
 log = { version = "0.4", features = ["std"] }
 tempfile = "3.0.2"
+semver = { git = "https://github.com/mikrostew/semver", branch = "new-parser" }

--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -38,13 +38,15 @@ enum MigrationState {
 
 /// Macro to simplify the boilerplate associated with detecting a tagged state.
 ///
-/// Should be passed a series of tuples, each of which contains:
+/// Should be passed a series of tuples, each of which contains (in this order):
 ///
 /// * The layout version (module name from `volta_layout` crate, e.g. `v1`)
 /// * The `MigrationState` variant name (e.g. `V1`)
-/// * The migration object itself (e.g. `V1` from the v1 module)
+/// * The migration object itself (e.g. `V1` from the v1 module in _this_ crate)
 ///
-/// The tuples should be in reverse chronological order, so that the newest is first
+/// The tuples should be in reverse chronological order, so that the newest is first, e.g.:
+///
+/// detect_tagged!((v3, V3, V3), (v2, V2, V2), (v1, V1, V1));
 macro_rules! detect_tagged {
     ($(($layout:ident, $variant:ident, $migration:ident)),*) => {
         impl MigrationState {

--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -9,19 +9,21 @@
 //! able to re-start gracefully from an interrupted migration
 
 use std::convert::TryInto;
+use std::path::Path;
 
 mod empty;
 mod v0;
 mod v1;
+mod v2;
 
 use v0::V0;
 use v1::V1;
+use v2::V2;
 
 use volta_core::layout::volta_home;
 #[cfg(unix)]
 use volta_core::layout::volta_install;
 use volta_fail::Fallible;
-use volta_layout::v1::VoltaHome;
 
 /// Represents the state of the Volta directory at every point in the migration process
 ///
@@ -31,7 +33,45 @@ enum MigrationState {
     Empty(empty::Empty),
     V0(Box<V0>),
     V1(Box<V1>),
+    V2(Box<V2>),
 }
+
+/// Macro to simplify the boilerplate associated with detecting a tagged state.
+///
+/// Should be passed a series of tuples, each of which contains:
+///
+/// * The layout version (module name from `volta_layout` crate, e.g. `v1`)
+/// * The `MigrationState` variant name (e.g. `V1`)
+/// * The migration object itself (e.g. `V1` from the v1 module)
+///
+/// The tuples should be in reverse chronological order, so that the newest is first
+macro_rules! detect_tagged {
+    ($(($layout:ident, $variant:ident, $migration:ident)),*) => {
+        impl MigrationState {
+            fn detect_tagged_state(home: &::std::path::Path) -> Option<Self> {
+                None
+                $(
+                    .or_else(|| detect::$layout(home))
+                )*
+            }
+        }
+
+        mod detect {
+            $(
+                pub(super) fn $layout(home: &::std::path::Path) -> Option<super::MigrationState> {
+                    let volta_home = volta_layout::$layout::VoltaHome::new(home.to_owned());
+                    if volta_home.layout_file().exists() {
+                        Some(super::MigrationState::$variant(Box::new(super::$migration::new(home.to_owned()))))
+                    } else {
+                        None
+                    }
+                }
+            )*
+        }
+    }
+}
+
+detect_tagged!((v2, V2, V2), (v1, V1, V1));
 
 impl MigrationState {
     fn current() -> Fallible<Self> {
@@ -40,24 +80,13 @@ impl MigrationState {
 
         let home = volta_home()?;
 
-        match MigrationState::detect_tagged_state(home) {
+        match MigrationState::detect_tagged_state(home.root()) {
             Some(state) => Ok(state),
-            None => MigrationState::detect_legacy_state(home),
+            None => MigrationState::detect_legacy_state(home.root()),
         }
     }
 
-    fn detect_tagged_state(home: &VoltaHome) -> Option<Self> {
-        // Detect a layout at or above V1, which will always have an associated layout file to use as a discriminant
-        if home.layout_file().exists() {
-            Some(MigrationState::V1(Box::new(V1::new(
-                home.root().to_owned(),
-            ))))
-        } else {
-            None
-        }
-    }
-
-    fn detect_legacy_state(home: &VoltaHome) -> Fallible<Self> {
+    fn detect_legacy_state(home: &Path) -> Fallible<Self> {
         /*
         Triage for determining the legacy layout version:
         - Does Volta Home exist?
@@ -73,7 +102,7 @@ impl MigrationState {
         previous, V0 installation.
         */
 
-        let volta_home = home.root().to_owned();
+        let volta_home = home.to_owned();
 
         if volta_home.exists() {
             #[cfg(windows)]
@@ -108,7 +137,8 @@ pub fn run_migration() -> Fallible<()> {
         state = match state {
             MigrationState::Empty(e) => MigrationState::V1(Box::new(e.try_into()?)),
             MigrationState::V0(zero) => MigrationState::V1(Box::new((*zero).try_into()?)),
-            MigrationState::V1(_) => {
+            MigrationState::V1(one) => MigrationState::V2(Box::new((*one).try_into()?)),
+            MigrationState::V2(_) => {
                 break;
             }
         };

--- a/crates/volta-migrate/src/v1.rs
+++ b/crates/volta-migrate/src/v1.rs
@@ -13,7 +13,7 @@ use volta_core::fs::read_dir_eager;
 use volta_fail::{Fallible, ResultExt, VoltaError};
 use volta_layout::v1;
 
-/// Represents a V1 Volta Layout (from v0.7.0)
+/// Represents a V1 Volta Layout (used by Volta v0.7.0 - v0.7.2)
 ///
 /// Holds a reference to the V1 layout struct to support potential future migrations
 pub struct V1 {

--- a/crates/volta-migrate/src/v2.rs
+++ b/crates/volta-migrate/src/v2.rs
@@ -1,0 +1,158 @@
+use std::convert::TryFrom;
+use std::fs::{read_to_string, remove_file, rename, write, File};
+use std::path::PathBuf;
+
+use super::empty::Empty;
+use super::v1::V1;
+use log::debug;
+use tempfile::tempdir_in;
+use volta_core::error::ErrorDetails;
+use volta_core::fs::{ensure_dir_does_not_exist, read_dir_eager};
+use volta_core::tool::load_default_npm_version;
+use volta_core::toolchain::serial::Platform;
+use volta_core::version::parse_version;
+use volta_fail::{Fallible, ResultExt, VoltaError};
+use volta_layout::v2;
+
+/// Represents a V2 Volta Layout (from v0.7.3)
+///
+/// Holds a reference to the V1 layout struct to support potential future migrations
+pub struct V2 {
+    pub home: v2::VoltaHome,
+}
+
+impl V2 {
+    pub fn new(home: PathBuf) -> Self {
+        V2 {
+            home: v2::VoltaHome::new(home),
+        }
+    }
+
+    /// Write the layout file to mark migration to V1 as complete
+    ///
+    /// Should only be called once all other migration steps are finished, so that we don't
+    /// accidentally mark an incomplete migration as completed
+    fn complete_migration(home: v2::VoltaHome) -> Fallible<Self> {
+        debug!("Writing layout marker file");
+        File::create(home.layout_file()).with_context(|_| ErrorDetails::CreateLayoutFileError {
+            file: home.layout_file().to_owned(),
+        })?;
+
+        Ok(V2 { home })
+    }
+}
+
+impl TryFrom<Empty> for V2 {
+    type Error = VoltaError;
+
+    fn try_from(old: Empty) -> Fallible<V2> {
+        debug!("New Volta installation detected, creating fresh layout");
+
+        let home = v2::VoltaHome::new(old.home);
+        home.create()
+            .with_context(|_| ErrorDetails::CreateDirError {
+                dir: home.root().to_owned(),
+            })?;
+
+        V2::complete_migration(home)
+    }
+}
+
+impl TryFrom<V1> for V2 {
+    type Error = VoltaError;
+
+    fn try_from(old: V1) -> Fallible<V2> {
+        debug!("Migrating from V1 layout");
+
+        let new_home = v2::VoltaHome::new(old.home.root().to_owned());
+        new_home
+            .create()
+            .with_context(|_| ErrorDetails::CreateDirError {
+                dir: new_home.root().to_owned(),
+            })?;
+
+        // Check the default platform file `platform.json`
+        // If it contains an npm version that matches the default, update it to have None instead
+        // This will ensure that we don't treat the default npm from a prior version of Volta
+        // as a "custom" npm that the user explicitly requested
+        let platform_file = old.home.default_platform_file();
+        if platform_file.exists() {
+            let platform_json = read_to_string(platform_file).with_context(|_| {
+                ErrorDetails::ReadPlatformError {
+                    file: platform_file.to_owned(),
+                }
+            })?;
+            let mut existing_platform = Platform::from_json(platform_json)?;
+
+            if let Some(ref mut node_version) = &mut existing_platform.node {
+                if let Some(npm) = &node_version.npm {
+                    if *npm == load_default_npm_version(&node_version.runtime)? {
+                        node_version.npm = None;
+                        write(platform_file, existing_platform.into_json()?).with_context(
+                            |_| ErrorDetails::WritePlatformError {
+                                file: platform_file.to_owned(),
+                            },
+                        )?;
+                    }
+                }
+            }
+        }
+
+        // Move node_image_dir Up one directory (V1 -> V2)
+        let temp_dir =
+            tempdir_in(new_home.tmp_dir()).with_context(|_| ErrorDetails::CreateTempDirError {
+                in_dir: new_home.tmp_dir().to_owned(),
+            })?;
+        let node_installs = read_dir_eager(old.home.node_image_root_dir())
+            .with_context(|_| ErrorDetails::ReadDirError {
+                dir: old.home.node_image_root_dir().to_owned(),
+            })?
+            .filter_map(|(entry, metadata)| {
+                if metadata.is_dir() {
+                    parse_version(entry.file_name().to_string_lossy()).ok()
+                } else {
+                    None
+                }
+            });
+
+        for node_version in node_installs {
+            let npm_version = load_default_npm_version(&node_version)?;
+            let old_install = old
+                .home
+                .node_image_dir(&node_version.to_string(), &npm_version.to_string());
+
+            if old_install.exists() {
+                let temp_image = temp_dir.path().join(node_version.to_string());
+                let new_install = new_home.node_image_dir(&node_version.to_string());
+                rename(&old_install, &temp_image).with_context(|_| {
+                    ErrorDetails::SetupToolImageError {
+                        tool: "Node".to_string(),
+                        version: node_version.to_string(),
+                        dir: temp_image.clone(),
+                    }
+                })?;
+                ensure_dir_does_not_exist(&new_install)?;
+                rename(&temp_image, &new_install).with_context(|_| {
+                    ErrorDetails::SetupToolImageError {
+                        tool: "Node".to_string(),
+                        version: node_version.to_string(),
+                        dir: new_install.clone(),
+                    }
+                })?;
+            }
+        }
+
+        // Complete the migration, writing the V2 layout file
+        let layout = V2::complete_migration(new_home)?;
+
+        // Remove the V1 layout file, since we're now on V2 (do this after writing the V2 so that we know the migration succeeded)
+        let old_layout_file = old.home.layout_file();
+        if old_layout_file.exists() {
+            remove_file(old_layout_file).with_context(|_| ErrorDetails::DeleteFileError {
+                file: old_layout_file.to_owned(),
+            })?;
+        }
+
+        Ok(layout)
+    }
+}

--- a/crates/volta-migrate/src/v2.rs
+++ b/crates/volta-migrate/src/v2.rs
@@ -86,13 +86,15 @@ impl TryFrom<V1> for V2 {
 
             if let Some(ref mut node_version) = &mut existing_platform.node {
                 if let Some(npm) = &node_version.npm {
-                    if *npm == load_default_npm_version(&node_version.runtime)? {
-                        node_version.npm = None;
-                        write(platform_file, existing_platform.into_json()?).with_context(
-                            |_| ErrorDetails::WritePlatformError {
-                                file: platform_file.to_owned(),
-                            },
-                        )?;
+                    if let Ok(default_npm) = load_default_npm_version(&node_version.runtime) {
+                        if *npm == default_npm {
+                            node_version.npm = None;
+                            write(platform_file, existing_platform.into_json()?).with_context(
+                                |_| ErrorDetails::WritePlatformError {
+                                    file: platform_file.to_owned(),
+                                },
+                            )?;
+                        }
                     }
                 }
             }

--- a/tests/acceptance/migrations.rs
+++ b/tests/acceptance/migrations.rs
@@ -31,7 +31,7 @@ fn empty_volta_home_is_created() {
     assert!(Sandbox::path_exists(".volta/tools/user"));
 
     // Layout file should now exist
-    assert!(Sandbox::path_exists(".volta/layout.v1"));
+    assert!(Sandbox::path_exists(".volta/layout.v2"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -58,6 +58,7 @@ fn legacy_v0_volta_home_is_upgraded() {
 
     // Layout file is not there
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
+    assert!(!Sandbox::path_exists(".volta/layout.v2"));
 
     // running volta should not create anything else
     assert_that!(s.volta("--version"), execs().with_status(0));
@@ -71,7 +72,7 @@ fn legacy_v0_volta_home_is_upgraded() {
     assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
 
     // Layout file should now exist
-    assert!(Sandbox::path_exists(".volta/layout.v1"));
+    assert!(Sandbox::path_exists(".volta/layout.v2"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -85,12 +86,12 @@ fn legacy_v0_volta_home_is_upgraded() {
 }
 
 #[test]
-fn current_v1_volta_home_is_unchanged() {
-    let s = sandbox().layout_file("v1").build();
+fn current_v2_volta_home_is_unchanged() {
+    let s = sandbox().layout_file("v2").build();
 
     // directories that are already created by the test framework
     assert!(Sandbox::path_exists(".volta"));
-    assert!(Sandbox::path_exists(".volta/layout.v1"));
+    assert!(Sandbox::path_exists(".volta/layout.v2"));
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
@@ -102,7 +103,7 @@ fn current_v1_volta_home_is_unchanged() {
 
     // everything should be the same as before running the command
     assert!(Sandbox::path_exists(".volta"));
-    assert!(Sandbox::path_exists(".volta/layout.v1"));
+    assert!(Sandbox::path_exists(".volta/layout.v2"));
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -338,6 +338,13 @@ impl SandboxBuilder {
         this
     }
 
+    /// Add an arbitrary file to the sandbox (chainable)
+    pub fn file(mut self, path: &str, contents: &str) -> Self {
+        let file_name = sandbox_path(path);
+        self.files.push(FileBuilder::new(file_name, contents));
+        self
+    }
+
     /// Set a package config file for the sandbox (chainable)
     pub fn package_config(mut self, name: &str, contents: &str) -> Self {
         let package_cfg_file = package_config_file(name);
@@ -381,6 +388,13 @@ impl SandboxBuilder {
         let package_shasum = pkg_inventory_dir.join(format!("{}-{}.shasum", name, version));
         self.files
             .push(FileBuilder::new(package_shasum, "shasum contents"));
+        self
+    }
+
+    /// Write the "default npm" file for a node version (chainable)
+    pub fn node_npm_version_file(mut self, node_version: &str, npm_version: &str) -> Self {
+        let npm_file = node_npm_version_file(node_version);
+        self.files.push(FileBuilder::new(npm_file, npm_version));
         self
     }
 
@@ -501,6 +515,9 @@ fn default_platform_file() -> PathBuf {
 }
 fn layout_file(version: &str) -> PathBuf {
     volta_home().join(format!("layout.{}", version))
+}
+fn node_npm_version_file(node_version: &str) -> PathBuf {
+    node_inventory_dir().join(format!("node-v{}-npm", node_version))
 }
 
 fn sandbox_path(path: &str) -> PathBuf {
@@ -642,6 +659,9 @@ impl Sandbox {
         pkg_inventory_dir
             .join(format!("{}-{}.shasum", name, version))
             .exists()
+    }
+    pub fn read_default_platform() -> String {
+        read_file_to_string(default_platform_file())
     }
 }
 

--- a/tests/smoke/support/temp_project.rs
+++ b/tests/smoke/support/temp_project.rs
@@ -160,11 +160,11 @@ fn image_dir(root: PathBuf) -> PathBuf {
 fn node_image_root_dir(root: PathBuf) -> PathBuf {
     image_dir(root).join("node")
 }
-fn node_image_dir(node: &str, npm: &str, root: PathBuf) -> PathBuf {
-    node_image_root_dir(root).join(node).join(npm)
+fn node_image_dir(node: &str, root: PathBuf) -> PathBuf {
+    node_image_root_dir(root).join(node)
 }
-fn node_image_bin_dir(node: &str, npm: &str, root: PathBuf) -> PathBuf {
-    node_image_dir(node, npm, root).join("bin")
+fn node_image_bin_dir(node: &str, root: PathBuf) -> PathBuf {
+    node_image_dir(node, root).join("bin")
 }
 fn yarn_image_root_dir(root: PathBuf) -> PathBuf {
     image_dir(root).join("yarn")
@@ -315,8 +315,8 @@ impl TempProject {
     }
 
     /// Verify that the input Node version has been unpacked.
-    pub fn node_version_is_unpacked(&self, version: &str, npm_version: &str) -> bool {
-        let unpack_dir = node_image_bin_dir(version, npm_version, self.root());
+    pub fn node_version_is_unpacked(&self, version: &str) -> bool {
+        let unpack_dir = node_image_bin_dir(version, self.root());
         unpack_dir.exists()
     }
 

--- a/tests/smoke/volta_fetch.rs
+++ b/tests/smoke/volta_fetch.rs
@@ -9,9 +9,8 @@ fn fetch_node() {
     let p = temp_project().build();
 
     assert_that!(p.volta("fetch node@10.4.1"), execs().with_status(0));
-    // node 10.4.1 comes with npm 6.1.0
     assert_eq!(p.node_version_is_fetched("10.4.1"), true);
-    assert_eq!(p.node_version_is_unpacked("10.4.1", "6.1.0"), true);
+    assert_eq!(p.node_version_is_unpacked("10.4.1"), true);
 }
 
 #[test]

--- a/tests/smoke/volta_install.rs
+++ b/tests/smoke/volta_install.rs
@@ -15,9 +15,8 @@ fn install_node() {
         execs().with_status(0).with_stdout_contains("v10.2.1")
     );
 
-    // node 10.2.1 comes with npm 5.6.0
     assert!(p.node_version_is_fetched("10.2.1"));
-    assert!(p.node_version_is_unpacked("10.2.1", "5.6.0"));
+    assert!(p.node_version_is_unpacked("10.2.1"));
     p.assert_node_version_is_installed("10.2.1");
 }
 


### PR DESCRIPTION
Info
-----
* To support custom npm versions, there are a few changes that need to be migrated:
    * First, we should remove the `npm` version from the PATH to the Node image directory, since that Node will be used regardless of the npm version.
    * Second, we should make sure that if the default npm version is set in `platform.json` (our internal state), we remove it, since in the new paradigm a value being set represents a custom npm version, and until now we have only had bundled versions.
* Additionally, there was some friction when adding a new migration, so I created a macro to deduplicate some of the detection work.

Changes
-----
* Added a macro for creating methods to handle detecting the existing Volta layout version (checking each existing layout file to see if it exists.
* Added a new `V2` layout that has the `node_image_dir` depend only on the Node version, not the npm version.
* Added a migration from V1 to V2 of the layout, shifting all of the node images to their new location and correctly unsetting the `npm` value in `platform.json`, if necessary.
* Updated all of the code to only use Node version when locating the `node_image_dir`, instead of needing the `npm` version as well.

Tested
-----
* Manually tested that `platform.json` and Node images are updated as expected.
* Updated the existing unit tests to match the new paradigm and confirmed that all passed.
* Added acceptance tests for happy-path Migration as well as already-migrated cases.

Notes
-----
* I'm not thrilled with the migration itself, Migrations are messy and necessarily ad-hoc, so it's difficult to have a "clean" abstraction around the work, but I'm open to any changes that might make it easier to understand going forward.