### PR TITLE
Update CI to use MacOS 10.14 image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
         ubuntu:
           imageName: "ubuntu-16.04"
         mac:
-          imageName: "macos-10.13"
+          imageName: "macos-10.14"
     pool:
       vmImage: $(imageName)
     steps:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         mac:
-          imageName: "macos-10.13"
+          imageName: "macos-10.14"
     steps:
       - template: ci/build-api-docs.yml
     condition: or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), dependencies.vars.outputs['overrides.docs'])
@@ -65,7 +65,7 @@ jobs:
     strategy:
       matrix:
         mac:
-          imageName: "macos-10.13"
+          imageName: "macos-10.14"
     steps:
       - template: ci/publish-api-docs.yml
     condition: and(succeeded('nix'), succeeded('windows'), succeeded('api_docs'))
@@ -77,7 +77,7 @@ jobs:
         ubuntu:
           imageName: "ubuntu-16.04"
         mac:
-          imageName: "macos-10.13"
+          imageName: "macos-10.14"
         windows:
           imageName: "vs2017-win2016"
     steps:


### PR DESCRIPTION
Per [this article](https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/) and warnings in the logs, Microsoft will be removing the MacOS 10.13 image we are using for our Mac builds from the public-hosted images.

Following their suggestion to migrate to 10.14.