### PR TITLE
Exit early with an error message if creating install dir fails

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -217,8 +217,12 @@ create_tree() {
   # .volta/
   #     bin/
 
-  mkdir -p "$install_dir"
-  mkdir -p "$install_dir"/bin
+  mkdir -p "$install_dir" && mkdir -p "$install_dir"/bin
+  if [ "$?" != 0 ]
+  then
+    error "Could not create directory layout. Please make sure the target directory is writeable: $install_dir"
+    exit 1
+  fi
 }
 
 install_version() {


### PR DESCRIPTION
Related to an issue reported in Discord: When the installer fails to create `$install_dir` and `$install_dir/bin`, it prints out the error messages but then continues along as if everything is okay. This ultimately results in errors later in the process, but we should detect that situation and show an accurate error message immediately.

Added an early exit if the `mkdir` calls fail.