### PR TITLE
[Medium] Prevent concurrent writes to VOLTA_HOME

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,6 +547,15 @@ name = "fs-utils"
 version = "0.1.0"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.73 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fsio"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +1867,7 @@ dependencies = [
  "dunce 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "envoy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs-utils 0.1.0",
+ "fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyperx 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2090,6 +2100,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fs2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 "checksum fsio 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2131cb03096f67334dfba2f0bc46afc5564b08a919d042c6e217e2665741fc54"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -52,6 +52,7 @@ attohttpc = { version = "0.13.0", features = ["json"] }
 chain-map = "0.1.0"
 indexmap = "1.3.2"
 retry = "1.0.0"
+fs2 = "0.4.3"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6.0"

--- a/crates/volta-core/src/lib.rs
+++ b/crates/volta-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod session;
 pub mod shim;
 pub mod signal;
 pub mod style;
+pub mod sync;
 pub mod tool;
 pub mod toolchain;
 pub mod version;

--- a/crates/volta-core/src/sync.rs
+++ b/crates/volta-core/src/sync.rs
@@ -1,0 +1,42 @@
+use std::fs::{File, OpenOptions};
+use std::ops::Drop;
+use std::path::Path;
+
+use crate::style::progress_spinner;
+use fs2::FileExt;
+use log::debug;
+
+const LOCK_FILE: &str = "volta.lock";
+
+/// An RAII implementation of an exclusive lock on the Volta directory. When this falls out of scope,
+/// the lock will be unlocked.
+pub struct VoltaLock {
+    inner: File,
+}
+
+impl VoltaLock {
+    pub fn acquire(volta_home: &Path) -> std::io::Result<Self> {
+        let path = volta_home.join(LOCK_FILE);
+        debug!("Acquiring lock on Volta directory: {}", path.display());
+
+        let file = OpenOptions::new().write(true).create(true).open(path)?;
+        // First we try to lock the file without blocking. If that fails, then we show a spinner
+        // and block until the lock completes.
+        if file.try_lock_exclusive().is_err() {
+            let spinner = progress_spinner("Waiting for file lock on Volta directory");
+            // Note: Blocks until the file can be locked
+            let lock_result = file.lock_exclusive();
+            spinner.finish_and_clear();
+            lock_result?;
+        }
+
+        Ok(Self { inner: file })
+    }
+}
+
+impl Drop for VoltaLock {
+    #[allow(unused_must_use)]
+    fn drop(&mut self) {
+        self.inner.unlock();
+    }
+}

--- a/crates/volta-core/src/tool/package/fetch.rs
+++ b/crates/volta-core/src/tool/package/fetch.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use crate::error::{Context, ErrorKind, Fallible};
-use crate::fs::{create_staging_dir, read_dir_eager, read_file, remove_dir_if_exists, rename};
+use crate::fs::{create_staging_dir, read_dir_eager, read_file, rename};
 use crate::layout::volta_home;
 use crate::platform::CliPlatform;
 use crate::run::{self, ToolCommand};
@@ -200,8 +200,6 @@ fn unpack_archive(archive: Box<dyn Archive>, name: &str, version: &Version) -> F
     ensure_containing_dir_exists(&image_dir).with_context(|| ErrorKind::ContainingDirError {
         path: image_dir.clone(),
     })?;
-    // and ensure that the target directory does not exist
-    remove_dir_if_exists(&image_dir)?;
 
     let unpack_dir = find_unpack_dir(temp.path())?;
     rename(unpack_dir, &image_dir).with_context(|| ErrorKind::SetupToolImageError {

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -10,6 +10,7 @@ use crate::layout::volta_home;
 use crate::session::Session;
 use crate::shim;
 use crate::style::{success_prefix, tool_version};
+use crate::sync::VoltaLock;
 use dunce::canonicalize;
 use log::{info, warn};
 use semver::Version;
@@ -124,6 +125,9 @@ impl Display for Package {
 /// * the unpacked and initialized package
 pub fn uninstall(name: &str) -> Fallible<()> {
     let home = volta_home()?;
+    // Acquire a lock on the Volta directory, if possible, to prevent concurrent changes
+    let _lock = VoltaLock::acquire(home.root()).ok();
+
     // if the package config file exists, use that to remove any installed bins and shims
     let package_config_file = home.default_package_config_file(name);
     let package_found = if package_config_file.exists() {

--- a/tests/smoke/volta_install.rs
+++ b/tests/smoke/volta_install.rs
@@ -1,5 +1,6 @@
-use crate::support::temp_project::temp_project;
+use std::thread;
 
+use crate::support::temp_project::temp_project;
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
@@ -30,6 +31,24 @@ fn install_node_lts() {
 }
 
 #[test]
+fn install_node_concurrent() {
+    let p = temp_project().build();
+
+    let install = p.volta("install node@12.14.0");
+    let run = p.node("--version");
+
+    let concurrent_thread = thread::spawn(move || {
+        assert_that!(install, execs().with_status(0));
+        assert_that!(run, execs().with_status(0));
+    });
+
+    assert_that!(p.volta("install node@12.14.0"), execs().with_status(0));
+    assert_that!(p.node("--version"), execs().with_status(0));
+
+    assert!(concurrent_thread.join().is_ok());
+}
+
+#[test]
 fn install_yarn() {
     let p = temp_project().build();
 
@@ -44,6 +63,26 @@ fn install_yarn() {
     assert!(p.yarn_version_is_fetched("1.22.2"));
     assert!(p.yarn_version_is_unpacked("1.22.2"));
     p.assert_yarn_version_is_installed("1.22.2");
+}
+
+#[test]
+fn install_yarn_concurrent() {
+    let p = temp_project().build();
+
+    assert_that!(p.volta("install node@12.14.0"), execs().with_status(0));
+
+    let install = p.volta("install yarn@1.17.0");
+    let run = p.yarn("--version");
+
+    let concurrent_thread = thread::spawn(move || {
+        assert_that!(install, execs().with_status(0));
+        assert_that!(run, execs().with_status(0));
+    });
+
+    assert_that!(p.volta("install yarn@1.17.0"), execs().with_status(0));
+    assert_that!(p.yarn("--version"), execs().with_status(0));
+
+    assert!(concurrent_thread.join().is_ok());
 }
 
 #[test]
@@ -67,6 +106,26 @@ fn install_npm() {
         p.npm("--version"),
         execs().with_status(0).with_stdout_contains("6.14.3")
     );
+}
+
+#[test]
+fn install_npm_concurrent() {
+    let p = temp_project().build();
+
+    assert_that!(p.volta("install node@12.14.0"), execs().with_status(0));
+
+    let install = p.volta("install npm@6.14.2");
+    let run = p.npm("--version");
+
+    let concurrent_thread = thread::spawn(move || {
+        assert_that!(install, execs().with_status(0));
+        assert_that!(run, execs().with_status(0));
+    });
+
+    assert_that!(p.volta("install npm@6.14.2"), execs().with_status(0));
+    assert_that!(p.npm("--version"), execs().with_status(0));
+
+    assert!(concurrent_thread.join().is_ok());
 }
 
 const COWSAY_HELLO: &'static str = r#" _______
@@ -95,6 +154,26 @@ fn install_package() {
         p.exec_shim("cowsay", "hello"),
         execs().with_status(0).with_stdout_contains(COWSAY_HELLO)
     );
+}
+
+#[test]
+fn install_package_concurrent() {
+    let p = temp_project().build();
+
+    assert_that!(p.volta("install node@12.14.0"), execs().with_status(0));
+
+    let install = p.volta("install cowsay@1.3.0");
+    let run = p.exec_shim("cowsay", "hello");
+
+    let concurrent_thread = thread::spawn(move || {
+        assert_that!(install, execs().with_status(0));
+        assert_that!(run, execs().with_status(0));
+    });
+
+    assert_that!(p.volta("install cowsay@1.3.0"), execs().with_status(0));
+    assert_that!(p.exec_shim("cowsay", "hello"), execs().with_status(0));
+
+    assert!(concurrent_thread.join().is_ok());
 }
 
 #[test]


### PR DESCRIPTION
Closes #612 

Info
-----
* As described in #612, we currently have issues when multiple Volta processes try to mutate the VOLTA_HOME directory simultaneously.
* The most common case we've seen so far for this is when two processes try to download the same version of Node / Yarn at the same time (e.g. in an automated, parallel test).
* This PR alleviates those issues, based on the idea of double-checked locking:
    * First, we check if we need to download the tool.
    * If we do, then we acquire an exclusive file lock to a specific file in the Volta directory.
    * Once the lock is acquired, other processes may have already downloaded the tool we are looking at, so we check _again_.
    * If we detect that we _still_ need to download the tool / version, then because we have the lock, we can be confident that no other process is doing the same concurrently.
    * If, instead, the second check reveals that we don't need to download again, then another process must have taken care of it, so we can proceed.

Changes
-----
* Added the above-described double-checked locking behavior to fetching for all tools: Node, npm, Yarn, and Packages.
* Added similar behavior for the migrations, locking within `volta-migrate` before running detection of which migrations are needed.
* In all cases, errors creating or acquiring the lock fall back to the existing, non-concurrent behavior (e.g. immediately executing the fetch / migration

Tested
-----
* Added smoke tests that use an extra thread to run two concurrent installs to ensure that the changes work as expected (these tests fail without the changes).

Notes
-----
* For more context on double-checked locking, see the description in the [comments of the `double_checked_cell` crate](https://github.com/niklasf/double-checked-cell/blob/5907b25a493b48ec1516ee123b793cfc7be2272b/src/lib.rs#L264)