### PR TITLE
volta-install.sh: make curl write out downloaded file name

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -23,7 +23,7 @@ download_release_from_repo() {
   local download_file="$tmpdir/$filename"
   local archive_url="$(release_url)/download/v$version/$filename"
 
-  curl --progress-bar --show-error --location --fail "$archive_url" --output "$download_file" && echo "$download_file"
+  curl --progress-bar --show-error --location --fail "$archive_url" --output "$download_file" --write-out '%{filename_effective}'
 }
 
 usage() {


### PR DESCRIPTION
Depending on environment configuration, `download_release_from_repo`
could write to stdout both through `curl` and `echo`.

The install script becomes more robust when we explicitly tell `curl` to
write out the effective name where the download was saved, and nothing
else.

Fixes #686.