### PR TITLE
Support clearing as well as setting npm and yarn

### DIFF
--- a/crates/volta-core/src/project.rs
+++ b/crates/volta-core/src/project.rs
@@ -191,12 +191,12 @@ impl Project {
     }
 
     /// Writes the specified version of Yarn to the `volta.yarn` key in package.json.
-    pub fn pin_yarn(&mut self, yarn_version: &Version) -> Fallible<()> {
+    pub fn pin_yarn(&mut self, yarn: Option<Version>) -> Fallible<()> {
         if let Some(platform) = self.manifest.platform() {
             let updated_platform = ProjectPlatformSpec {
                 node: platform.node.clone(),
                 npm: platform.npm.clone(),
-                yarn: Some(yarn_version.clone()),
+                yarn,
             };
 
             self.manifest.update_platform(updated_platform);
@@ -207,11 +207,11 @@ impl Project {
     }
 
     /// Writes the specified version of Npm to the `volta.npm` key in package.json.
-    pub fn pin_npm(&mut self, npm_version: &Version) -> Fallible<()> {
+    pub fn pin_npm(&mut self, npm: Option<Version>) -> Fallible<()> {
         if let Some(platform) = self.manifest.platform() {
             let updated_platform = ProjectPlatformSpec {
                 node: platform.node.clone(),
-                npm: Some(npm_version.clone()),
+                npm,
                 yarn: platform.yarn.clone(),
             };
 

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -62,7 +62,9 @@ impl Tool for Yarn {
     fn install(self, session: &mut Session) -> Fallible<()> {
         self.fetch_internal(session)?;
 
-        session.toolchain_mut()?.set_active_yarn(&self.version)?;
+        session
+            .toolchain_mut()?
+            .set_active_yarn(Some(self.version.clone()))?;
 
         info_installed(self);
 

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -79,7 +79,7 @@ impl Tool for Yarn {
 
             // Note: We know this will succeed, since we checked above
             let project = session.project_mut()?.unwrap();
-            project.pin_yarn(&self.version)?;
+            project.pin_yarn(Some(self.version.clone()))?;
 
             info_pinned(self);
             Ok(())

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -93,13 +93,13 @@ impl Toolchain {
     }
 
     /// Set the active Yarn version in the default platform file.
-    pub fn set_active_yarn(&mut self, yarn_version: &Version) -> Fallible<()> {
+    pub fn set_active_yarn(&mut self, yarn: Option<Version>) -> Fallible<()> {
         if let Some(platform) = &self.platform {
-            if platform.yarn.as_ref() != Some(yarn_version) {
+            if platform.yarn != yarn {
                 self.platform = Some(Rc::new(DefaultPlatformSpec {
                     node: platform.node.clone(),
                     npm: platform.npm.clone(),
-                    yarn: Some(yarn_version.clone()),
+                    yarn,
                 }));
                 self.save()?;
             }
@@ -109,12 +109,12 @@ impl Toolchain {
     }
 
     /// Set the active Npm version in the default platform file.
-    pub fn set_active_npm(&mut self, npm_version: &Version) -> Fallible<()> {
+    pub fn set_active_npm(&mut self, npm: Option<Version>) -> Fallible<()> {
         if let Some(platform) = &self.platform {
-            if platform.npm.as_ref() != Some(npm_version) {
+            if platform.npm != npm {
                 self.platform = Some(Rc::new(DefaultPlatformSpec {
                     node: platform.node.clone(),
-                    npm: Some(npm_version.clone()),
+                    npm,
                     yarn: platform.yarn.clone(),
                 }));
                 self.save()?;


### PR DESCRIPTION
Info
-----
* Currently our methods for setting the default `npm` and `yarn` only accept a real version, so it is not possible to unset those values (or set them back to `None`).
* Similarly, the methods for pinning `npm` and `yarn` also expect a real version.
* Allowing these to be unset will be necessary for `volta install npm@bundled`, as well as for supporting `volta uninstall yarn` at some point in the future.

Changes
-----
* Updated `Toolchain` methods `set_active_yarn` and `set_active_npm` to accept an `Option<Version`, instead of a `&Version`.
* Updated `Project` methods `pin_yarn` and `pin_npm` to also accept an `Option<Version>`
* Updated the call sites of each of those methods to pass an `Option`.

Tested
-----
* All tests pass

Note
-----
* This is a small, self-contained PR to help reduce the size of #691 