### PR TITLE
Use dynamic dispatch for tool objects

### DIFF
--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -5,7 +5,6 @@ use crate::session::Session;
 use crate::style::{note_prefix, success_prefix, tool_version};
 use crate::version::{parse_version, VersionSpec};
 use log::{debug, info};
-use semver::Version;
 use volta_fail::Fallible;
 
 mod node;
@@ -53,11 +52,11 @@ fn info_project_version<T: Display + Sized>(tool: T) {
 /// Trait representing all of the actions that can be taken with a tool
 pub trait Tool: Display {
     /// Fetch a Tool into the local inventory
-    fn fetch(self, session: &mut Session) -> Fallible<()>;
+    fn fetch(self: Box<Self>, session: &mut Session) -> Fallible<()>;
     /// Install a tool, making it the default so it is available everywhere on the user's machine
-    fn install(self, session: &mut Session) -> Fallible<()>;
+    fn install(self: Box<Self>, session: &mut Session) -> Fallible<()>;
     /// Pin a tool in the local project so that it is usable within the project
-    fn pin(self, session: &mut Session) -> Fallible<()>;
+    fn pin(self: Box<Self>, session: &mut Session) -> Fallible<()>;
 }
 
 /// Specification for a tool and its associated version.
@@ -70,32 +69,29 @@ pub enum Spec {
     Package(String, VersionSpec),
 }
 
-/// A fully resolved Tool, with all information necessary for fetching
-#[derive(Debug)]
-pub enum Resolved {
-    Node(Node),
-    Npm(Npm),
-    Yarn(Yarn),
-    Package(Package),
-}
-
 impl Spec {
     /// Resolve a tool spec into a fully realized Tool that can be fetched
-    pub fn resolve(self, session: &mut Session) -> Fallible<Resolved> {
+    pub fn resolve(self, session: &mut Session) -> Fallible<Box<dyn Tool>> {
         match self {
-            Spec::Node(version) => node::resolve(version, session)
-                .map(Node::new)
-                .map(Resolved::Node),
-            Spec::Yarn(version) => yarn::resolve(version, session)
-                .map(Yarn::new)
-                .map(Resolved::Yarn),
-            Spec::Package(name, version) => package::resolve(&name, version, session)
-                .map(|details| Package::new(name, details))
-                .map(Resolved::Package),
+            Spec::Node(version) => {
+                let version = node::resolve(version, session)?;
+                Ok(Box::new(Node::new(version)))
+            }
+            Spec::Yarn(version) => {
+                let version = yarn::resolve(version, session)?;
+                Ok(Box::new(Yarn::new(version)))
+            }
+            Spec::Package(name, version) => {
+                let details = package::resolve(&name, version, session)?;
+                Ok(Box::new(Package::new(name, details)))
+            }
             // ISSUE (#292): To preserve error message context, we always resolve Npm to Version 0.0.0
             // This will allow us to show the correct error message based on the user's command
             // e.g. `volta install npm` vs `volta pin npm`
-            Spec::Npm(_) => parse_version("0.0.0").map(Npm::new).map(Resolved::Npm),
+            Spec::Npm(_) => {
+                let version = parse_version("0.0.0")?;
+                Ok(Box::new(Npm::new(version)))
+            }
         }
     }
 
@@ -125,38 +121,6 @@ impl Spec {
     }
 }
 
-impl Resolved {
-    /// Fetch a Tool into the local inventory
-    pub fn fetch(self, session: &mut Session) -> Fallible<()> {
-        match self {
-            Resolved::Node(node) => node.fetch(session),
-            Resolved::Npm(npm) => npm.fetch(session),
-            Resolved::Yarn(yarn) => yarn.fetch(session),
-            Resolved::Package(package) => package.fetch(session),
-        }
-    }
-
-    /// Install a tool, making it the default so it is available everywhere on the user's machine
-    pub fn install(self, session: &mut Session) -> Fallible<()> {
-        match self {
-            Resolved::Node(node) => node.install(session),
-            Resolved::Npm(npm) => npm.install(session),
-            Resolved::Yarn(yarn) => yarn.install(session),
-            Resolved::Package(package) => package.install(session),
-        }
-    }
-
-    /// Pin a tool in the local project so that it is usable within the project
-    pub fn pin(self, session: &mut Session) -> Fallible<()> {
-        match self {
-            Resolved::Node(node) => node.pin(session),
-            Resolved::Npm(npm) => npm.pin(session),
-            Resolved::Yarn(yarn) => yarn.pin(session),
-            Resolved::Package(package) => package.pin(session),
-        }
-    }
-}
-
 impl Display for Spec {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = match self {
@@ -166,17 +130,6 @@ impl Display for Spec {
             Spec::Package(ref name, ref version) => tool_version(name, version),
         };
         f.write_str(&s)
-    }
-}
-
-impl From<Resolved> for Version {
-    fn from(tool: Resolved) -> Self {
-        match tool {
-            Resolved::Node(Node { version })
-            | Resolved::Npm(Npm { version })
-            | Resolved::Yarn(Yarn { version }) => version,
-            Resolved::Package(Package { details, .. }) => details.version,
-        }
     }
 }
 

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -126,13 +126,13 @@ impl Node {
 }
 
 impl Tool for Node {
-    fn fetch(self, session: &mut Session) -> Fallible<()> {
+    fn fetch(self: Box<Self>, session: &mut Session) -> Fallible<()> {
         let node_version = self.fetch_internal(session)?;
 
         info_fetched(node_version);
         Ok(())
     }
-    fn install(self, session: &mut Session) -> Fallible<()> {
+    fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
         let node_version = self.fetch_internal(session)?;
 
         session.toolchain_mut()?.set_active_node(&self.version)?;
@@ -144,7 +144,7 @@ impl Tool for Node {
         }
         Ok(())
     }
-    fn pin(self, session: &mut Session) -> Fallible<()> {
+    fn pin(self: Box<Self>, session: &mut Session) -> Fallible<()> {
         if session.project()?.is_some() {
             let node_version = self.fetch_internal(session)?;
 

--- a/crates/volta-core/src/tool/npm/mod.rs
+++ b/crates/volta-core/src/tool/npm/mod.rs
@@ -21,19 +21,19 @@ impl Npm {
 
 impl Tool for Npm {
     // ISSUE(#292) Implement actions for npm
-    fn fetch(self, _session: &mut Session) -> Fallible<()> {
+    fn fetch(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
         Err(ErrorDetails::Unimplemented {
             feature: "Fetching npm".into(),
         }
         .into())
     }
-    fn install(self, _session: &mut Session) -> Fallible<()> {
+    fn install(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
         Err(ErrorDetails::Unimplemented {
             feature: "Installing npm".into(),
         }
         .into())
     }
-    fn pin(self, _session: &mut Session) -> Fallible<()> {
+    fn pin(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
         Err(ErrorDetails::Unimplemented {
             feature: "Pinning npm".into(),
         }

--- a/crates/volta-core/src/tool/package/install.rs
+++ b/crates/volta-core/src/tool/package/install.rs
@@ -8,7 +8,7 @@ use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::Command;
 
-use super::super::Spec;
+use super::super::node;
 use super::bin_full_path;
 use crate::command::create_command;
 use crate::error::ErrorDetails;
@@ -130,7 +130,7 @@ pub fn install(
 
     let engine = determine_engine(&package_dir, &display)?;
     let platform = BinaryPlatformSpec {
-        node: Spec::Node(engine).resolve(session)?.into(),
+        node: node::resolve(engine, session)?,
         npm: None,
         yarn: None,
     };

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -90,13 +90,13 @@ impl Package {
 }
 
 impl Tool for Package {
-    fn fetch(self, session: &mut Session) -> Fallible<()> {
+    fn fetch(self: Box<Self>, session: &mut Session) -> Fallible<()> {
         self.fetch_internal(session)?;
 
         info_fetched(self);
         Ok(())
     }
-    fn install(self, session: &mut Session) -> Fallible<()> {
+    fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
         if self.is_installed() {
             info!("Package {} is already installed", self);
             Ok(())
@@ -119,7 +119,7 @@ impl Tool for Package {
             Ok(())
         }
     }
-    fn pin(self, _session: &mut Session) -> Fallible<()> {
+    fn pin(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
         Err(ErrorDetails::CannotPinPackage { package: self.name }.into())
     }
 }

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -53,13 +53,13 @@ impl Yarn {
 }
 
 impl Tool for Yarn {
-    fn fetch(self, session: &mut Session) -> Fallible<()> {
+    fn fetch(self: Box<Self>, session: &mut Session) -> Fallible<()> {
         self.fetch_internal(session)?;
 
         info_fetched(self);
         Ok(())
     }
-    fn install(self, session: &mut Session) -> Fallible<()> {
+    fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
         self.fetch_internal(session)?;
 
         session.toolchain_mut()?.set_active_yarn(&self.version)?;
@@ -73,7 +73,7 @@ impl Tool for Yarn {
         }
         Ok(())
     }
-    fn pin(self, session: &mut Session) -> Fallible<()> {
+    fn pin(self: Box<Self>, session: &mut Session) -> Fallible<()> {
         if session.project()?.is_some() {
             self.fetch_internal(session)?;
 


### PR DESCRIPTION
Info
-----
* Currently we have an enum `tool::Resolved`, whose only purpose is to store a `Tool` implementation and dynamically dispatch to the contained `Tool` when one of the methods is called (`fetch`, `install`, or `pin`).
* This is effectively the same as dynamic dispatch with trait objects, so we can implement that and save on some boilerplate.
* Additionally, the switch to trait objects makes sense in the context of #691, which introduces a new `Tool` implementation: `BundledNpm`

Changes
-----
* Removed `Resolved` enum and it's implementation.
* Updated `Spec::resolve` to return a `Box<dyn Tool>` instead of a `Resolved`
* Updated `Tool` trait to use `self: Box<Self>` as the self-type for all methods.
* Fixed the implementations to all take `self: Box<Self>`

Tested
-----
* All tests pass (no functionality change expected in this refactor)

Note
-----
* This is a small PR to help simplify #691 