### PR TITLE
[npm] [Tiny] Add support for npm hooks

### DIFF
--- a/crates/volta-core/src/hook/mod.rs
+++ b/crates/volta-core/src/hook/mod.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use crate::error::ErrorDetails;
 use crate::layout::volta_home;
 use crate::project::Project;
-use crate::tool::{Node, Package, Tool, Yarn};
+use crate::tool::{Node, Npm, Package, Tool, Yarn};
 use lazycell::LazyCell;
 use log::debug;
 use volta_fail::{Fallible, ResultExt};
@@ -48,6 +48,7 @@ impl LazyHookConfig {
 /// Volta hook configuration
 pub struct HookConfig {
     node: Option<ToolHooks<Node>>,
+    npm: Option<ToolHooks<Npm>>,
     yarn: Option<ToolHooks<Yarn>>,
     package: Option<ToolHooks<Package>>,
     events: Option<EventHooks>,
@@ -93,6 +94,10 @@ impl HookConfig {
         self.node.as_ref()
     }
 
+    pub fn npm(&self) -> Option<&ToolHooks<Npm>> {
+        self.npm.as_ref()
+    }
+
     pub fn yarn(&self) -> Option<&ToolHooks<Yarn>> {
         self.yarn.as_ref()
     }
@@ -122,6 +127,7 @@ impl HookConfig {
                 debug!("No custom hooks found");
                 Self {
                     node: None,
+                    npm: None,
                     yarn: None,
                     package: None,
                     events: None,
@@ -189,6 +195,7 @@ impl HookConfig {
     fn merge(left: Self, right: Self) -> Self {
         Self {
             node: merge_hook_config_field!(left, right, node, ToolHooks),
+            npm: merge_hook_config_field!(left, right, npm, ToolHooks),
             yarn: merge_hook_config_field!(left, right, yarn, ToolHooks),
             package: merge_hook_config_field!(left, right, package, ToolHooks),
             events: merge_hook_config_field!(left, right, events, EventHooks),

--- a/crates/volta-core/src/hook/serial.rs
+++ b/crates/volta-core/src/hook/serial.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use super::tool;
 use crate::error::ErrorDetails;
-use crate::tool::{Node, Package, Tool, Yarn};
+use crate::tool::{Node, Npm, Package, Tool, Yarn};
 use serde::{Deserialize, Serialize};
 use volta_fail::{Fallible, VoltaError};
 
@@ -101,6 +101,7 @@ impl TryFrom<RawPublishHook> for super::Publish {
 #[derive(Serialize, Deserialize)]
 pub struct RawHookConfig {
     pub node: Option<RawToolHooks<Node>>,
+    pub npm: Option<RawToolHooks<Npm>>,
     pub yarn: Option<RawToolHooks<Yarn>>,
     pub packages: Option<RawToolHooks<Package>>,
     pub events: Option<RawEventHooks>,
@@ -136,6 +137,7 @@ pub struct RawToolHooks<T: Tool> {
 impl RawHookConfig {
     pub fn into_hook_config(self, base_dir: &Path) -> Fallible<super::HookConfig> {
         let node = self.node.map(|n| n.into_tool_hooks(base_dir)).transpose()?;
+        let npm = self.npm.map(|n| n.into_tool_hooks(base_dir)).transpose()?;
         let yarn = self.yarn.map(|y| y.into_tool_hooks(base_dir)).transpose()?;
         let package = self
             .packages
@@ -144,6 +146,7 @@ impl RawHookConfig {
         let events = self.events.map(|e| e.try_into()).transpose()?;
         Ok(super::HookConfig {
             node,
+            npm,
             yarn,
             package,
             events,


### PR DESCRIPTION
Info
-----
* To support resolving and installing `npm` versions, we need to add support for `npm` hooks, so that the process can be redirected in the same way as `node` and `yarn`
* These hooks currently will never be called, as fetching `npm` has not been implemented, but that will be included in another PR.

Changes
-----
* Added `npm` hook type to the `HookConfig` object.
* Added deserialization of `npm` hooks.

Tested
-----
* All tests pass