### PR TITLE
Implement `volta list` for human

### DIFF
--- a/crates/volta-core/src/style.rs
+++ b/crates/volta-core/src/style.rs
@@ -6,7 +6,7 @@ use failure::Fail;
 use indicatif::{ProgressBar, ProgressStyle};
 use term_size;
 
-const MAX_WIDTH: usize = 100;
+pub const MAX_WIDTH: usize = 100;
 const MAX_PROGRESS_WIDTH: usize = 40;
 
 /// Generate the styled prefix for a success message

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -57,9 +57,8 @@ fn display_active(
     match (runtime, package_manager) {
         (None, _) => NO_RUNTIME.to_string(),
         (Some(runtime), Some(package_manager)) => {
-            let runtime_version: String =
-                WRAPPER.fill(&format!("Node: {}", format_runtime(runtime)));
-            let package_manager_version: String = WRAPPER.fill(&format!(
+            let runtime_version = WRAPPER.fill(&format!("Node: {}", format_runtime(runtime)));
+            let package_manager_version = WRAPPER.fill(&format!(
                 "Yarn: {}",
                 format_package_manager(package_manager)
             ));
@@ -88,7 +87,7 @@ fn display_active(
             } else {
                 WRAPPER.fill(&format!(
                     "Tool binaries available:\n{}",
-                    display_packages(packages)
+                    format_tool_list(packages)
                 ))
             };
 
@@ -144,8 +143,9 @@ fn display_node(runtimes: &[Node]) -> String {
 /// Format a set of `Toolchain::PackageManager`s.
 fn display_package_managers(package_managers: &[PackageManager]) -> String {
     if package_managers.is_empty() {
+        //TODO: adding npm support https://github.com/volta-cli/volta/pull/694
         String::from(
-            "⚡️ No <npm|Yarn> versions installed.
+            "⚡️ No Yarn versions installed.
 
 You can install a Yarn version by running `volta install yarn`.
 See `volta help install` for details and more options.",
@@ -229,7 +229,7 @@ fn format_runtime_list(runtimes: &[Node]) -> String {
     WRAPPER.fill(
         &runtimes
             .iter()
-            .map(|runtime| format_runtime(&runtime))
+            .map(format_runtime)
             .collect::<Vec<String>>()
             .join("\n"),
     )
@@ -662,7 +662,7 @@ See options for more detailed reports by running `volta list --help`.";
 
         #[test]
         fn none_installed() {
-            let expected = "⚡️ No <npm|Yarn> versions installed.
+            let expected = "⚡️ No Yarn versions installed.
 
 You can install a Yarn version by running `volta install yarn`.
 See `volta help install` for details and more options.";

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -2,7 +2,7 @@
 
 use textwrap::Wrapper;
 
-use volta_core::style::text_width;
+use volta_core::style::{text_width, tool_version};
 
 use super::{Node, Package, PackageManager, Source, Toolchain};
 
@@ -16,7 +16,10 @@ pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
     // Formatting here depends on the toolchain: we do different degrees of
     // indentation
     Some(match toolchain {
-        Toolchain::Node(runtimes) => display_node(&runtimes),
+        Toolchain::Node(runtimes) => format!(
+            "⚡️ Node runtimes in your toolchain:\n\n{}",
+            display_runtimes(&runtimes)
+        ),
         Toolchain::Active {
             runtime,
             package_manager,
@@ -28,11 +31,11 @@ pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
             packages,
         } => display_all(runtimes, package_managers, packages),
         Toolchain::PackageManagers(package_managers) => display_package_managers(package_managers),
-        Toolchain::Packages(packages) => display_packages(packages),
+        Toolchain::Packages(packages) => display_packages(packages, true),
         Toolchain::Tool {
             name,
             host_packages,
-        } => display_tool(name, host_packages),
+        } => display_tools(name, host_packages),
     })
 }
 
@@ -41,42 +44,68 @@ pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
 /// Accepts the components *from* the toolchain rather than the item itself so
 /// that
 fn display_active(
-    node: &Option<Box<Node>>,
+    runtime: &Option<Box<Node>>,
     package_manager: &Option<Box<PackageManager>>,
     packages: &[Package],
 ) -> String {
-    match (node, package_manager, packages) {
+    match (runtime, package_manager, packages) {
         (None, _, _) => NO_RUNTIME.to_string(),
-        (Some(node), Some(package_manager), packages) => {
+        (Some(runtime), Some(package_manager), packages) => {
             let width = text_width().unwrap_or(0);
-            let node_version: String = Wrapper::new(width)
+            let runtime_version: String = Wrapper::new(width)
                 .initial_indent(INDENTATION)
-                .subsequent_indent(INDENTATION)
-                .fill(&format!("Node: {} {}", node.version, node.source));
+                .fill(&format!("node: v{}{}", runtime.version, runtime.source));
             let package_manager_version: String = Wrapper::new(width)
                 .initial_indent(INDENTATION)
-                .subsequent_indent(INDENTATION)
-                .fill(&format!(
-                    "{}: {} {}",
-                    package_manager.kind, package_manager.version, package_manager.source
-                ));
-            let package_versions = Wrapper::new(width)
-                .initial_indent(INDENTATION)
-                .subsequent_indent(INDENTATION)
-                .fill(
-                    &packages
-                        .iter()
-                        .map(|package| format!("v{}{}", package., package))
-                        .collect::<Vec<String>>()
-                        .join("\n"),
-                );
+                .fill(&display_package_manager(package_manager));
+            let package_versions = if packages.is_empty() {
+                Wrapper::new(width)
+                    .initial_indent(INDENTATION)
+                    .fill(&format!("Tool binaries available: NONE"))
+            } else {
+                Wrapper::new(width)
+                    .initial_indent(INDENTATION)
+                    .subsequent_indent(INDENTATION)
+                    .fill(&format!(
+                        "Tool binaries available:\n{}",
+                        display_packages(packages, false)
+                    ))
+            };
 
             format!(
-                "⚡️ Currently active tools:\n\n{}\n{}\n{}",
-                node_version, package_manager_version, package_versions
+                "⚡️ Currently active tools:\n\n{}\n{}\n{}\n\n{}",
+                runtime_version,
+                package_manager_version,
+                package_versions,
+                "See options for more detailed reports by running `volta list --help`."
             )
         }
-        _ => unimplemented!(),
+        (Some(runtime), None, packages) => {
+            let width = text_width().unwrap_or(0);
+            let runtime_version: String = Wrapper::new(width)
+                .initial_indent(INDENTATION)
+                .fill(&format!("node: {}", display_runtime(runtime)));
+            let package_versions = if packages.is_empty() {
+                Wrapper::new(width)
+                    .initial_indent(INDENTATION)
+                    .fill(&format!("Tool binaries available: NONE"))
+            } else {
+                Wrapper::new(width)
+                    .initial_indent(INDENTATION)
+                    .subsequent_indent(INDENTATION)
+                    .fill(&format!(
+                        "Tool binaries available:\n{}",
+                        display_packages(packages, false)
+                    ))
+            };
+
+            format!(
+                "⚡️ Currently active tools:\n\n{}\n{}\n\n{}",
+                runtime_version,
+                package_versions,
+                "See options for more detailed reports by running `volta list --help`."
+            )
+        }
     }
 }
 
@@ -86,46 +115,169 @@ fn display_all(
     package_managers: &[PackageManager],
     packages: &[Package],
 ) -> String {
-    unimplemented!()
+    let width = text_width().unwrap_or(0);
+    let runtime_versions: String = Wrapper::new(width)
+        .initial_indent(INDENTATION)
+        .subsequent_indent(INDENTATION)
+        .fill(&format!("node runtimes:\n {}", display_runtimes(runtimes)));
+    let package_manager_versions: String = Wrapper::new(width)
+        .initial_indent(INDENTATION)
+        .subsequent_indent(INDENTATION)
+        .fill(&format!(
+            "Package managers: \n{}",
+            display_package_managers(package_managers)
+        ));
+    let package_versions = Wrapper::new(width)
+        .initial_indent(INDENTATION)
+        .subsequent_indent(INDENTATION)
+        .fill(&format!("Packages:\n{}", display_packages(packages, true)));
+    format!(
+        "⚡️ User toolchain:\n\n{}\n\n{}\n\n{}",
+        runtime_versions, package_manager_versions, package_versions
+    )
 }
 
-/// Format the output for `Toolchain::Node`.
-///
-/// Accepts only `runtimes` since this printer *should* be ignorant of all other
-/// types of `Toolchain` items.
-fn display_node(runtimes: &[Node]) -> String {
+/// Format a set of `Toolchain::Node`s.
+fn display_runtimes(runtimes: &[Node]) -> String {
     if runtimes.is_empty() {
         NO_RUNTIME.to_string()
     } else {
         let width = text_width().unwrap_or(0);
-        let versions = Wrapper::new(width)
+        Wrapper::new(width)
             .initial_indent(INDENTATION)
             .subsequent_indent(INDENTATION)
             .fill(
                 &runtimes
                     .iter()
-                    .map(|runtime| format!("v{}{}", runtime.version, runtime.source))
+                    .map(|runtime| display_runtime(&runtime))
                     .collect::<Vec<String>>()
                     .join("\n"),
-            );
-
-        format!("⚡️ Node runtimes in your toolchain:\n\n{}", versions)
+            )
     }
 }
 
-/// Format the output for `Toolchain::PackageManager`.
+/// Format a single `Toolchain::Node`.
+fn display_runtime(runtime: &Node) -> String {
+    format!("v{}{}", runtime.version, runtime.source)
+}
+
+/// Format a set of `Toolchain::PackageManager`s.
 fn display_package_managers(package_managers: &[PackageManager]) -> String {
-    unimplemented!()
+    if package_managers.is_empty() {
+        String::from("")
+    } else {
+        let width = text_width().unwrap_or(0);
+        Wrapper::new(width)
+            .initial_indent(INDENTATION)
+            .subsequent_indent(INDENTATION)
+            .fill(
+                &package_managers
+                    .iter()
+                    .map(display_package_manager)
+                    .collect::<Vec<String>>()
+                    .join("\n"),
+            )
+    }
+}
+
+/// Format a single `Toolchain::PackageManager`.
+fn display_package_manager(package_manager: &PackageManager) -> String {
+    format!(
+        "{}: v{}{}",
+        package_manager.kind, package_manager.version, package_manager.source
+    )
 }
 
 /// Format a set of `Toolchain::Package`s and their associated tools.
-fn display_packages(packages: &[Package]) -> String {
-    unimplemented!()
+fn display_packages(packages: &[Package], show_detail: bool) -> String {
+    if packages.is_empty() {
+        String::from("")
+    } else {
+        let width = text_width().unwrap_or(0);
+        Wrapper::new(width)
+            .initial_indent(INDENTATION)
+            .subsequent_indent(INDENTATION)
+            .fill(
+                &packages
+                    .iter()
+                    .map(|p| display_package(p, show_detail))
+                    .collect::<Vec<String>>()
+                    .join("\n"),
+            )
+    }
 }
 
-/// Format the output for a specific tool from a set of `Toolchain::Package`s.
-fn display_tool(tool: &str, host_packages: &[Package]) -> String {
-    unimplemented!()
+/// Format a single `Toolchain::Package` and its associated tools.
+fn display_package(package: &Package, show_detail: bool) -> String {
+    match package {
+        Package::Default {
+            details,
+            node,
+            tools,
+            ..
+        }
+        | Package::Project {
+            details,
+            node,
+            tools,
+            ..
+        } => {
+            let tools = match tools.len() {
+                0 => String::from(""),
+                _ => format!("{}", tools.join(", ")),
+            };
+            let width = text_width().unwrap_or(0);
+            if !show_detail {
+                format!("{}{}", tools, package_source(package))
+            } else {
+                // println!("{}\n{}\n{}\n{}", details.name, details.version, node, tools);
+                let version = Wrapper::new(width)
+                    .initial_indent(INDENTATION)
+                    .subsequent_indent(INDENTATION)
+                    .fill(&format!("v{}{}", details.version, package_source(package)));
+                let binaries = Wrapper::new(width)
+                    .initial_indent(INDENTATION)
+                    .subsequent_indent(INDENTATION)
+                    .fill(&format!("binaries: {}", tools));
+                let platform = Wrapper::new(width)
+                    .initial_indent(INDENTATION)
+                    .subsequent_indent(INDENTATION)
+                    .fill(&format!(
+                        "platform: \n\truntime: {}\n\tpackage manager: {}",
+                        tool_version("node", &node),
+                        // TODO: Should be updated when we support installing with custom package_managers,
+                        // whether Yarn or non-built-in versions of npm
+                        "npm@built-in"
+                    ));
+                format!("{}:\n{}\n{}\n{}", details.name, version, binaries, platform)
+            }
+        }
+        Package::Fetched(details) => format!(""),
+    }
+}
+
+/// Format a set of `Toolchain::Package`s.
+/// AKA executable
+fn display_tools(tool: &str, host_packages: &[Package]) -> String {
+    format!("display_tools")
+}
+
+/// Format a single `Toolchain::Package`.
+fn display_tool(tool: &str, host_package: &Package) -> String {
+    match host_package {
+        Package::Default { details, node, .. } | Package::Project { details, node, .. } => {
+            format!("{}", tool)
+        }
+        Package::Fetched(..) => String::from(""),
+    }
+}
+
+fn package_source(package: &Package) -> String {
+    match package {
+        Package::Default { .. } => String::from(" (default)"),
+        Package::Project { path, .. } => format!(" (current @ {})", path.display()),
+        Package::Fetched(..) => String::new(),
+    }
 }
 
 // These tests are organized by way of the *commands* supplied to `list`, unlike
@@ -151,7 +303,7 @@ mod tests {
     mod active {
         use super::*;
         use crate::command::list::{
-            human::display_active, Node, PackageManager, PackageManagerKind, Source,
+            human::display_active, Node, PackageDetails, PackageManager, PackageManagerKind, Source,
         };
 
         #[test]
@@ -169,14 +321,15 @@ mod tests {
         fn runtime_only_default() {
             let expected = "⚡️ Currently active tools:
 
-    Node: v12.2.0 (default)
+    node: v12.2.0 (default)
+    Tool binaries available: NONE
 
 See options for more detailed reports by running `volta list --help`.";
 
-            let runtime = Some(Node {
+            let runtime = Some(Box::new(Node {
                 source: Source::Default,
                 version: NODE_12.clone(),
-            });
+            }));
             let package_manager = None;
             let packages = vec![];
 
@@ -190,16 +343,15 @@ See options for more detailed reports by running `volta list --help`.";
         fn runtime_only_project() {
             let expected = "⚡️ Currently active tools:
 
-    Node: v12.2.0 (project @ ~/path/to/project.json)
-    npm: built-in
+    node: v12.2.0 (current @ ~/path/to/project.json)
     Tool binaries available: NONE
 
 See options for more detailed reports by running `volta list --help`.";
 
-            let runtime = Some(Node {
+            let runtime = Some(Box::new(Node {
                 source: Source::Project(PROJECT_PATH.clone()),
                 version: NODE_12.clone(),
-            });
+            }));
             let package_manager = None;
             let packages = vec![];
 
@@ -213,21 +365,21 @@ See options for more detailed reports by running `volta list --help`.";
         fn runtime_and_yarn_default() {
             let expected = "⚡️ Currently active tools:
 
-    Node: v12.2.0 (default)
-    Yarn: v1.16.0 (default)
+    node: v12.2.0 (default)
+    yarn: v1.16.0 (default)
     Tool binaries available: NONE
 
 See options for more detailed reports by running `volta list --help`.";
 
-            let runtime = Some(Node {
+            let runtime = Some(Box::new(Node {
                 source: Source::Default,
                 version: NODE_12.clone(),
-            });
-            let package_manager = Some(PackageManager {
+            }));
+            let package_manager = Some(Box::new(PackageManager {
                 kind: PackageManagerKind::Yarn,
                 source: Source::Default,
                 version: YARN_VERSION.clone(),
-            });
+            }));
             let packages = vec![];
 
             assert_eq!(
@@ -240,21 +392,21 @@ See options for more detailed reports by running `volta list --help`.";
         fn runtime_and_yarn_mixed() {
             let expected = "⚡️ Currently active tools:
 
-    Node: v12.2.0 (default)
-    Yarn: v1.16.0 (current @ ~/path/to/project.json)
+    node: v12.2.0 (default)
+    yarn: v1.16.0 (current @ ~/path/to/project.json)
     Tool binaries available: NONE
 
 See options for more detailed reports by running `volta list --help`.";
 
-            let runtime = Some(Node {
+            let runtime = Some(Box::new(Node {
                 source: Source::Default,
                 version: NODE_12.clone(),
-            });
-            let package_manager = Some(PackageManager {
+            }));
+            let package_manager = Some(Box::new(PackageManager {
                 kind: PackageManagerKind::Yarn,
                 source: Source::Project(PROJECT_PATH.clone()),
                 version: YARN_VERSION.clone(),
-            });
+            }));
             let packages = vec![];
 
             assert_eq!(
@@ -267,21 +419,21 @@ See options for more detailed reports by running `volta list --help`.";
         fn runtime_and_yarn_project() {
             let expected = "⚡️ Currently active tools:
 
-    Node: v12.2.0 (current @ ~/path/to/project.json)
-    Yarn: v1.16.0 (current @ ~/path/to/project.json)
+    node: v12.2.0 (current @ ~/path/to/project.json)
+    yarn: v1.16.0 (current @ ~/path/to/project.json)
     Tool binaries available: NONE
 
 See options for more detailed reports by running `volta list --help`.";
 
-            let runtime = Some(Node {
+            let runtime = Some(Box::new(Node {
                 source: Source::Project(PROJECT_PATH.clone()),
                 version: NODE_12.clone(),
-            });
-            let package_manager = Some(PackageManager {
+            }));
+            let package_manager = Some(Box::new(PackageManager {
                 kind: PackageManagerKind::Yarn,
                 source: Source::Project(PROJECT_PATH.clone()),
                 version: YARN_VERSION.clone(),
-            });
+            }));
             let packages = vec![];
 
             assert_eq!(
@@ -294,34 +446,36 @@ See options for more detailed reports by running `volta list --help`.";
         fn with_default_tools() {
             let expected = "⚡️ Currently active tools:
 
-    Node: v12.2.0 (current @ ~/path/to/project.json)
-    Yarn: v1.16.0 (current @ ~/path/to/project.json)
+    node: v12.2.0 (current @ ~/path/to/project.json)
+    yarn: v1.16.0 (current @ ~/path/to/project.json)
     Tool binaries available:
         create-react-app, tsc, tsserver (default)
 
 See options for more detailed reports by running `volta list --help`.";
 
-            let runtime = Some(Node {
+            let runtime = Some(Box::new(Node {
                 source: Source::Project(PROJECT_PATH.clone()),
                 version: NODE_12.clone(),
-            });
-            let package_manager = Some(PackageManager {
+            }));
+            let package_manager = Some(Box::new(PackageManager {
                 kind: PackageManagerKind::Yarn,
                 source: Source::Project(PROJECT_PATH.clone()),
                 version: YARN_VERSION.clone(),
-            });
+            }));
             let packages = vec![
-                Package {
-                    name: "create-react-app".to_string(),
-                    source: Source::Default,
-                    version: Version::from((3, 0, 1)),
+                Package::Default {
+                    details: PackageDetails {
+                        name: "create-react-app".to_string(),
+                        version: Version::from((3, 0, 1)),
+                    },
                     node: NODE_12.clone(),
                     tools: vec!["create-react-app".to_string()],
                 },
-                Package {
-                    name: "typescript".to_string(),
-                    source: Source::Default,
-                    version: Version::from((3, 4, 3)),
+                Package::Default {
+                    details: PackageDetails {
+                        name: "typescript".to_string(),
+                        version: Version::from((3, 4, 3)),
+                    },
                     node: NODE_12.clone(),
                     tools: vec!["tsc".to_string(), "tsserver".to_string()],
                 },
@@ -337,35 +491,38 @@ See options for more detailed reports by running `volta list --help`.";
         fn with_project_tools() {
             let expected = "⚡️ Currently active tools:
 
-    Node: v12.2.0 (current @ ~/path/to/project.json)
-    Yarn: v1.16.0 (current @ ~/path/to/project.json)
+    node: v12.2.0 (current @ ~/path/to/project.json)
+    yarn: v1.16.0 (current @ ~/path/to/project.json)
     Tool binaries available:
+        create-react-app (current @ ~/path/to/project.json)
         tsc, tsserver (default)
-        create-react-app (current @ ~/path-to-project.json)
 
 See options for more detailed reports by running `volta list --help`.";
 
-            let runtime = Some(Node {
+            let runtime = Some(Box::new(Node {
                 source: Source::Project(PROJECT_PATH.clone()),
                 version: NODE_12.clone(),
-            });
-            let package_manager = Some(PackageManager {
+            }));
+            let package_manager = Some(Box::new(PackageManager {
                 kind: PackageManagerKind::Yarn,
                 source: Source::Project(PROJECT_PATH.clone()),
                 version: YARN_VERSION.clone(),
-            });
+            }));
             let packages = vec![
-                Package {
-                    name: "create-react-app".to_string(),
-                    source: Source::Project(PROJECT_PATH.clone()),
-                    version: Version::from((3, 0, 1)),
+                Package::Project {
+                    details: PackageDetails {
+                        name: "create-react-app".to_string(),
+                        version: Version::from((3, 0, 1)),
+                    },
+                    path: PROJECT_PATH.clone(),
                     node: NODE_12.clone(),
                     tools: vec!["create-react-app".to_string()],
                 },
-                Package {
-                    name: "typescript".to_string(),
-                    source: Source::Default,
-                    version: Version::from((3, 4, 3)),
+                Package::Default {
+                    details: PackageDetails {
+                        name: "typescript".to_string(),
+                        version: Version::from((3, 4, 3)),
+                    },
                     node: NODE_12.clone(),
                     tools: vec!["tsc".to_string(), "tsserver".to_string()],
                 },
@@ -376,669 +533,642 @@ See options for more detailed reports by running `volta list --help`.";
                 expected
             );
         }
-    }
-
-    mod node {
-        use std::path::PathBuf;
-
-        use semver::Version;
-
-        use super::super::*;
-        use super::*;
-
-        #[test]
-        fn no_runtimes() {
-            let expected = NO_RUNTIME;
-
-            let runtimes = [];
-            assert_eq!(display_node(&runtimes).as_str(), expected);
-        }
-
-        #[test]
-        fn single_default() {
-            let expected = "⚡️ Node runtimes in your toolchain:
-
-    v10.15.3 (default)";
-            let runtimes = [Node {
-                source: Source::Default,
-                version: NODE_10.clone(),
-            }];
-
-            assert_eq!(display_node(&runtimes).as_str(), expected);
-        }
-
-        #[test]
-        fn single_project() {
-            let expected = "⚡️ Node runtimes in your toolchain:
-
-    v12.2.0 (current @ ~/path/to/project.json)";
-
-            let runtimes = [Node {
-                source: Source::Project(PROJECT_PATH.clone()),
-                version: NODE_12.clone(),
-            }];
-
-            assert_eq!(display_node(&runtimes).as_str(), expected);
-        }
-
-        #[test]
-        fn single_installed() {
-            let expected = "⚡️ Node runtimes in your toolchain:
-
-    v11.9.0";
-
-            let runtimes = [Node {
-                source: Source::None,
-                version: NODE_11.clone(),
-            }];
-
-            assert_eq!(display_node(&runtimes).as_str(), expected);
-        }
-
-        #[test]
-        fn multi() {
-            let expected = "⚡️ Node runtimes in your toolchain:
-
-    v12.2.0 (current @ ~/path/to/project.json)
-    v11.9.0
-    v10.15.3 (default)";
-
-            let runtimes = [
-                Node {
-                    source: Source::Project(PROJECT_PATH.clone()),
-                    version: NODE_12.clone(),
-                },
-                Node {
-                    source: Source::None,
-                    version: NODE_11.clone(),
-                },
-                Node {
-                    source: Source::Default,
-                    version: NODE_10.clone(),
-                },
-            ];
-
-            assert_eq!(display_node(&runtimes), expected);
-        }
-    }
-
-    mod package_managers {
-        use super::*;
-        use crate::command::list::Subcommand;
-        use crate::command::list::{PackageManager, PackageManagerKind, Source};
-
-        #[test]
-        fn none_installed() {
-            let expected = "⚡️ No <npm|Yarn> versions installed.
-
-You can install a Yarn version by running `volta install yarn`.
-See `volta help install` for details and more options.";
-
-            assert_eq!(display_package_managers(&[]), expected);
-        }
-
-        #[test]
-        fn single_default() {
-            let expected = "⚡️ Yarn versions in your toolchain:
-
-    v1.16.0 (default)";
-
-            let package_managers = [PackageManager {
-                kind: PackageManagerKind::Yarn,
-                source: Source::Default,
-                version: YARN_VERSION.clone(),
-            }];
-
-            assert_eq!(display_package_managers(&package_managers), expected);
-        }
-
-        #[test]
-        fn single_project() {
-            let expected = "⚡️ Yarn versions in your toolchain:
-
-    v1.16.0 (current @ ~/path/to/project.json)";
-
-            let package_managers = [PackageManager {
-                kind: PackageManagerKind::Yarn,
-                source: Source::Project(PROJECT_PATH.clone()),
-                version: YARN_VERSION.clone(),
-            }];
-
-            assert_eq!(display_package_managers(&package_managers), expected);
-        }
-
-        #[test]
-        fn single_installed() {
-            let expected = "⚡️ Yarn versions in your toolchain:
-
-    v1.16.0";
-
-            let yarns = [PackageManager {
-                kind: PackageManagerKind::Yarn,
-                source: Source::None,
-                version: YARN_VERSION.clone(),
-            }];
-
-            assert_eq!(display_package_managers(&yarns), expected);
-        }
-
-        #[test]
-        fn multi() {
-            let expected = "⚡️ Yarn versions in your toolchain:
-
-    v1.17.0 (current @ ~/path/to/project.json)
-    v1.16.0 (default)
-    v1.3.0";
-
-            let yarns = [
-                PackageManager {
-                    kind: PackageManagerKind::Yarn,
-                    source: Source::None,
-                    version: Version::from((1, 3, 0)),
-                },
-                PackageManager {
-                    kind: PackageManagerKind::Yarn,
-                    source: Source::Default,
-                    version: YARN_VERSION.clone(),
-                },
-                PackageManager {
-                    kind: PackageManagerKind::Yarn,
-                    source: Source::Project(PROJECT_PATH.clone()),
-                    version: Version::from((1, 17, 0)),
-                },
-            ];
-
-            assert_eq!(display_package_managers(&yarns), expected);
-        }
-    }
-
-    mod packages {
-        use super::*;
-        use crate::command::list::{Package, Source};
-        use semver::{Identifier, Version};
-
-        #[test]
-        fn none() {
-            let expected = "⚡️ No tools or packages named `ember` installed.
-            
-You can safely install packages by running `volta install <package name>`.
-See `volta help install` for details and more options.";
-
-            assert_eq!(display_packages(&[]), expected);
-        }
-
-        #[test]
-        fn single_default() {
-            let expected = "⚡️ `ember` package versions in your toolchain:
-            
-    ember-cli@3.10.1 (default)
-        binary tools: ember
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm";
-
-            let packages = [Package {
-                name: "ember-cli".to_string(),
-                version: Version::from((3, 10, 1)),
-                source: Source::Default,
-                node: NODE_12.clone(),
-                tools: vec!["ember".to_string()],
-            }];
-
-            assert_eq!(display_packages(&packages), expected);
-        }
-
-        #[test]
-        fn single_project() {
-            let expected = "⚡️ `ember` package versions in your toolchain:
-            
-    ember-cli@3.10.1 (current @ ~/path/to/project.json)
-        binary tools: ember
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm";
-
-            let packages = [Package {
-                name: "ember-cli".to_string(),
-                version: Version::from((3, 10, 1)),
-                source: Source::Project(PROJECT_PATH.clone()),
-                node: NODE_12.clone(),
-                tools: vec!["ember".to_string()],
-            }];
-
-            assert_eq!(display_packages(&packages), expected);
-        }
-
-        #[test]
-        fn single_fetched() {
-            let expected = "⚡️ tool `ember` exists in one package on your system:
-            
-    ember-cli@3.10.1
-        binary tools: ember
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-
-To make it available to execute, run `volta install ember-cli@3.10.1`.
-See `volta help install` for details and more options.";
-
-            let packages = [Package {
-                name: "ember-cli".to_string(),
-                version: Version::from((3, 10, 1)),
-                source: Source::None,
-                node: NODE_12.clone(),
-                tools: vec!["ember".to_string()],
-            }];
-
-            assert_eq!(display_packages(&packages), expected);
-        }
-
-        #[test]
-        fn multi_fetched() {
-            let expected = "⚡️ tool `ember` exists in the following packages on your system:
-            
-    ember-cli@3.10.1
-        binary tools: ember
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-
-    ember-cli@3.8.2
-        binary tools: ember
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-
-To make it available to execute, run `volta install ember-cli@<version>`.
-See `volta help install` for details and more options.";
-
-            let packages = [
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 10, 1)),
-                    source: Source::None,
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 8, 2)),
-                    source: Source::None,
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-            ];
-
-            assert_eq!(display_packages(&packages), expected);
-        }
-
-        #[test]
-        fn multi() {
-            let expected = "⚡️ `ember` package versions in your toolchain:
-
-    ember-cli@3.11.0-beta.3 (current @ ~/path/to/project.json)
-        binary tools: ember
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-            
-    ember-cli@3.10.1
-        binary tools: ember
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-
-    ember-cli@3.8.2 (default)
-        binary tools: ember
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm";
-
-            let packages = [
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 10, 1)),
-                    source: Source::None,
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 8, 2)),
-                    source: Source::Default,
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version {
-                        major: 3,
-                        minor: 11,
-                        patch: 0,
-                        pre: vec![Identifier::AlphaNumeric("-beta.3".to_string())],
-                        build: vec![],
-                    },
-                    source: Source::Project(PROJECT_PATH.clone()),
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-            ];
-
-            assert_eq!(display_packages(&packages), expected);
-        }
-    }
-
-    mod tools {
-        use super::*;
-        use crate::command::list::{Package, Source};
-        use semver::{Identifier, Version};
-
-        #[test]
-        fn none() {
-            let expected = "⚡️ No tools or packages named `ember` installed.
-            
-You can safely install packages by running `volta install <package name>`.
-See `volta help install` for details and more options.";
-
-            assert_eq!(display_tool("ember", &[]), expected);
-        }
-
-        #[test]
-        fn single_default() {
-            let expected = "⚡️ tool `ember` available from:
-            
-    ember-cli@3.10.1 (default)
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm";
-
-            let packages = [Package {
-                name: "ember-cli".to_string(),
-                version: Version::from((3, 10, 1)),
-                source: Source::Default,
-                node: NODE_12.clone(),
-                tools: vec!["ember".to_string()],
-            }];
-
-            assert_eq!(display_tool("ember", &packages), expected);
-        }
-
-        #[test]
-        fn single_project() {
-            let expected = "⚡️ tool `ember` available from:
-            
-    ember-cli@3.10.1 (current @ ~/path/to/project.json)
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm";
-
-            let packages = [Package {
-                name: "ember-cli".to_string(),
-                version: Version::from((3, 10, 1)),
-                source: Source::Project(PROJECT_PATH.clone()),
-                node: NODE_12.clone(),
-                tools: vec!["ember".to_string()],
-            }];
-
-            assert_eq!(display_tool("ember", &packages), expected);
-        }
-
-        #[test]
-        fn single_fetched() {
-            let expected = "⚡️ tool `ember` available from:
-            
-    ember-cli@3.10.1
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-
-To make it available to execute, run `volta install ember-cli@3.10.1`.
-See `volta help install` for details and more options.";
-
-            let packages = [Package {
-                name: "ember-cli".to_string(),
-                version: Version::from((3, 10, 1)),
-                source: Source::None,
-                node: NODE_12.clone(),
-                tools: vec!["ember".to_string()],
-            }];
-
-            assert_eq!(display_tool("ember", &packages), expected);
-        }
-
-        #[test]
-        fn multi_fetched() {
-            let expected = "⚡️ tool `ember` available from:
-            
-    ember-cli@3.10.1
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-
-    ember-cli@3.8.2
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-
-To make it available to execute, run `volta install ember-cli@<version>`.
-See `volta help install` for details and more options.";
-
-            let packages = [
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 10, 1)),
-                    source: Source::None,
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 8, 2)),
-                    source: Source::None,
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-            ];
-
-            assert_eq!(display_tool("ember", &packages), expected);
-        }
-
-        #[test]
-        fn multi() {
-            let expected = "⚡️ tool `ember` available from:
-
-    ember-cli@3.11.0-beta.3 (current @ ~/path/to/project.json)
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-            
-    ember-cli@3.10.1
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-
-    ember-cli@3.8.2 (default)
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm";
-
-            let packages = [
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 10, 1)),
-                    source: Source::None,
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 8, 2)),
-                    source: Source::Default,
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-                Package {
-                    name: "ember-cli".to_string(),
-                    version: Version {
-                        major: 3,
-                        minor: 11,
-                        patch: 0,
-                        pre: vec![Identifier::AlphaNumeric("-beta.3".to_string())],
-                        build: vec![],
-                    },
-                    source: Source::Project(PROJECT_PATH.clone()),
-                    node: NODE_12.clone(),
-                    tools: vec!["ember".to_string()],
-                },
-            ];
-
-            assert_eq!(display_tool("ember", &packages), expected);
-        }
-    }
-
-    mod all {
-        use super::*;
-        use crate::command::list::PackageManagerKind;
-        use semver::Identifier;
-
-        #[test]
-        fn empty() {
-            let runtimes = [];
-            let package_managers = [];
-            let packages = [];
-
-            assert_eq!(
-                display_all(&runtimes, &package_managers, &packages),
-                NO_RUNTIME
-            );
-        }
-
-        #[test]
-        fn full() {
-            let expected = "⚡️ Default toolchain:
-
-    Node runtimes:
-        v12.2.0 (current @ ~/path/to/project.json)
-        v11.9.0
-        v10.15.3 (default)
-
-    Package managers:
-        Yarn:
-            v1.17.0 (current @ ~/path/to/project.json)
-            v1.16.0 (default)
-            v1.4.0
-
-    Tools:
-        ember-cli:
-            v3.11.0-beta.3
-                binaries: ember
-                platform:
-                    runtime: node@12.2.0
-                    package manager: built-in npm
-
-            v3.10.1 (current @ ~/path/to/project.json):
-                binaries: ember
-                platform:
-                    runtime: node@12.2.0
-                    package manager: built-in npm
-
-            v3.8.2 (default):
-                binaries: ember
-                platform:
-                    runtime: node@12.2.0
-                    package manager: built-in npm
-
-        typescript:
-            v3.5.1 (current @ ~/path/to/project.json):
-                binaries:
-                platform:
-                    runtime: node@12.2.0
-                    package manager: built-in npm
-
-            v3.4.3 (default):
-                binaries:
-                platform:
-                    runtime: node@12.2.0
-                    package manager: built-in npm
-
-            ";
-
-            let runtimes = [
-                Node {
-                    source: Source::Project(PROJECT_PATH.clone()),
-                    version: NODE_12.clone(),
-                },
-                Node {
-                    source: Source::None,
-                    version: NODE_11.clone(),
-                },
-                Node {
-                    source: Source::Default,
-                    version: NODE_10.clone(),
-                },
-            ];
-
-            let package_managers = [
-                PackageManager {
-                    kind: PackageManagerKind::Yarn,
-                    source: Source::Default,
-                    version: YARN_VERSION.clone(),
-                },
-                PackageManager {
-                    kind: PackageManagerKind::Yarn,
-                    source: Source::Project(PROJECT_PATH.clone()),
-                    version: Version::from((1, 17, 0)),
-                },
-                PackageManager {
-                    kind: PackageManagerKind::Npm,
-                    source: Source::None,
-                    version: Version::from((1, 4, 0)),
-                },
-            ];
-
-            let packages = [
-                Package {
-                    name: "typescript".to_string(),
-                    source: Source::Default,
-                    version: Version::from((3, 4, 3)),
-                    node: NODE_12.clone(),
-                    tools: vec!["tsc".to_string(), "tsserver".to_string()],
-                },
-                Package {
-                    name: "typescript".to_string(),
-                    source: Source::Project(PROJECT_PATH.clone()),
-                    version: Version::from((3, 5, 1)),
-                    node: NODE_12.clone(),
-                    tools: vec!["tsc".to_string(), "tsserver".to_string()],
-                },
-                Package {
-                    name: "ember".to_string(),
-                    source: Source::None,
-                    version: Version {
-                        major: 3,
-                        minor: 11,
-                        patch: 0,
-                        pre: vec![Identifier::AlphaNumeric("-beta.3".to_string())],
-                        build: vec![],
-                    },
-                    node: NODE_12.clone(),
-                    tools: vec!["tsc".to_string(), "tsserver".to_string()],
-                },
-                Package {
-                    name: "ember".to_string(),
-                    source: Source::Project(PROJECT_PATH.clone()),
-                    version: Version::from((3, 10, 1)),
-                    node: NODE_12.clone(),
-                    tools: vec!["tsc".to_string(), "tsserver".to_string()],
-                },
-                Package {
-                    name: "ember".to_string(),
-                    source: Source::Default,
-                    version: Version::from((3, 8, 2)),
-                    node: NODE_12.clone(),
-                    tools: vec!["tsc".to_string(), "tsserver".to_string()],
-                },
-            ];
-        }
+        // }
+
+        //     mod node {
+        //         use std::path::PathBuf;
+
+        //         use semver::Version;
+
+        //         use super::super::*;
+        //         use super::*;
+
+        //         #[test]
+        //         fn no_runtimes() {
+        //             let expected = NO_RUNTIME;
+
+        //             let runtimes = [];
+        //             assert_eq!(display_node(&runtimes).as_str(), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_default() {
+        //             let expected = "⚡️ Node runtimes in your toolchain:
+        //     v10.15.3 (default)";
+        //             let runtimes = [Node {
+        //                 source: Source::Default,
+        //                 version: NODE_10.clone(),
+        //             }];
+
+        //             assert_eq!(display_node(&runtimes).as_str(), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_project() {
+        //             let expected = "⚡️ Node runtimes in your toolchain:
+        //     v12.2.0 (current @ ~/path/to/project.json)";
+
+        //             let runtimes = [Node {
+        //                 source: Source::Project(PROJECT_PATH.clone()),
+        //                 version: NODE_12.clone(),
+        //             }];
+
+        //             assert_eq!(display_node(&runtimes).as_str(), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_installed() {
+        //             let expected = "⚡️ Node runtimes in your toolchain:
+        //     v11.9.0";
+
+        //             let runtimes = [Node {
+        //                 source: Source::None,
+        //                 version: NODE_11.clone(),
+        //             }];
+
+        //             assert_eq!(display_node(&runtimes).as_str(), expected);
+        //         }
+
+        //         #[test]
+        //         fn multi() {
+        //             let expected = "⚡️ Node runtimes in your toolchain:
+        //     v12.2.0 (current @ ~/path/to/project.json)
+        //     v11.9.0
+        //     v10.15.3 (default)";
+
+        //             let runtimes = [
+        //                 Node {
+        //                     source: Source::Project(PROJECT_PATH.clone()),
+        //                     version: NODE_12.clone(),
+        //                 },
+        //                 Node {
+        //                     source: Source::None,
+        //                     version: NODE_11.clone(),
+        //                 },
+        //                 Node {
+        //                     source: Source::Default,
+        //                     version: NODE_10.clone(),
+        //                 },
+        //             ];
+
+        //             assert_eq!(display_node(&runtimes), expected);
+        //         }
+        //     }
+
+        //     mod package_managers {
+        //         use super::*;
+        //         use crate::command::list::Subcommand;
+        //         use crate::command::list::{PackageManager, PackageManagerKind, Source};
+
+        //         #[test]
+        //         fn none_installed() {
+        //             let expected = "⚡️ No <npm|Yarn> versions installed.
+        // You can install a Yarn version by running `volta install yarn`.
+        // See `volta help install` for details and more options.";
+
+        //             assert_eq!(display_package_managers(&[]), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_default() {
+        //             let expected = "⚡️ Yarn versions in your toolchain:
+        //     v1.16.0 (default)";
+
+        //             let package_managers = [PackageManager {
+        //                 kind: PackageManagerKind::Yarn,
+        //                 source: Source::Default,
+        //                 version: YARN_VERSION.clone(),
+        //             }];
+
+        //             assert_eq!(display_package_managers(&package_managers), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_project() {
+        //             let expected = "⚡️ Yarn versions in your toolchain:
+        //     v1.16.0 (current @ ~/path/to/project.json)";
+
+        //             let package_managers = [PackageManager {
+        //                 kind: PackageManagerKind::Yarn,
+        //                 source: Source::Project(PROJECT_PATH.clone()),
+        //                 version: YARN_VERSION.clone(),
+        //             }];
+
+        //             assert_eq!(display_package_managers(&package_managers), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_installed() {
+        //             let expected = "⚡️ Yarn versions in your toolchain:
+        //     v1.16.0";
+
+        //             let yarns = [PackageManager {
+        //                 kind: PackageManagerKind::Yarn,
+        //                 source: Source::None,
+        //                 version: YARN_VERSION.clone(),
+        //             }];
+
+        //             assert_eq!(display_package_managers(&yarns), expected);
+        //         }
+
+        //         #[test]
+        //         fn multi() {
+        //             let expected = "⚡️ Yarn versions in your toolchain:
+        //     v1.17.0 (current @ ~/path/to/project.json)
+        //     v1.16.0 (default)
+        //     v1.3.0";
+
+        //             let yarns = [
+        //                 PackageManager {
+        //                     kind: PackageManagerKind::Yarn,
+        //                     source: Source::None,
+        //                     version: Version::from((1, 3, 0)),
+        //                 },
+        //                 PackageManager {
+        //                     kind: PackageManagerKind::Yarn,
+        //                     source: Source::Default,
+        //                     version: YARN_VERSION.clone(),
+        //                 },
+        //                 PackageManager {
+        //                     kind: PackageManagerKind::Yarn,
+        //                     source: Source::Project(PROJECT_PATH.clone()),
+        //                     version: Version::from((1, 17, 0)),
+        //                 },
+        //             ];
+
+        //             assert_eq!(display_package_managers(&yarns), expected);
+        //         }
+        //     }
+
+        //     mod packages {
+        //         use super::*;
+        //         use crate::command::list::{Package, Source};
+        //         use semver::{Identifier, Version};
+
+        //         #[test]
+        //         fn none() {
+        //             let expected = "⚡️ No tools or packages named `ember` installed.
+
+        // You can safely install packages by running `volta install <package name>`.
+        // See `volta help install` for details and more options.";
+
+        //             assert_eq!(display_packages(&[]), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_default() {
+        //             let expected = "⚡️ `ember` package versions in your toolchain:
+
+        //     ember-cli@3.10.1 (default)
+        //         binary tools: ember
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm";
+
+        //             let packages = [Package {
+        //                 name: "ember-cli".to_string(),
+        //                 version: Version::from((3, 10, 1)),
+        //                 source: Source::Default,
+        //                 node: NODE_12.clone(),
+        //                 tools: vec!["ember".to_string()],
+        //             }];
+
+        //             assert_eq!(display_packages(&packages), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_project() {
+        //             let expected = "⚡️ `ember` package versions in your toolchain:
+
+        //     ember-cli@3.10.1 (current @ ~/path/to/project.json)
+        //         binary tools: ember
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm";
+
+        //             let packages = [Package {
+        //                 name: "ember-cli".to_string(),
+        //                 version: Version::from((3, 10, 1)),
+        //                 source: Source::Project(PROJECT_PATH.clone()),
+        //                 node: NODE_12.clone(),
+        //                 tools: vec!["ember".to_string()],
+        //             }];
+
+        //             assert_eq!(display_packages(&packages), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_fetched() {
+        //             let expected = "⚡️ tool `ember` exists in one package on your system:
+
+        //     ember-cli@3.10.1
+        //         binary tools: ember
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+        // To make it available to execute, run `volta install ember-cli@3.10.1`.
+        // See `volta help install` for details and more options.";
+
+        //             let packages = [Package {
+        //                 name: "ember-cli".to_string(),
+        //                 version: Version::from((3, 10, 1)),
+        //                 source: Source::None,
+        //                 node: NODE_12.clone(),
+        //                 tools: vec!["ember".to_string()],
+        //             }];
+
+        //             assert_eq!(display_packages(&packages), expected);
+        //         }
+
+        //         #[test]
+        //         fn multi_fetched() {
+        //             let expected = "⚡️ tool `ember` exists in the following packages on your system:
+
+        //     ember-cli@3.10.1
+        //         binary tools: ember
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+        //     ember-cli@3.8.2
+        //         binary tools: ember
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+        // To make it available to execute, run `volta install ember-cli@<version>`.
+        // See `volta help install` for details and more options.";
+
+        //             let packages = [
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version::from((3, 10, 1)),
+        //                     source: Source::None,
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version::from((3, 8, 2)),
+        //                     source: Source::None,
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //             ];
+
+        //             assert_eq!(display_packages(&packages), expected);
+        //         }
+
+        //         #[test]
+        //         fn multi() {
+        //             let expected = "⚡️ `ember` package versions in your toolchain:
+        //     ember-cli@3.11.0-beta.3 (current @ ~/path/to/project.json)
+        //         binary tools: ember
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+
+        //     ember-cli@3.10.1
+        //         binary tools: ember
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+        //     ember-cli@3.8.2 (default)
+        //         binary tools: ember
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm";
+
+        //             let packages = [
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version::from((3, 10, 1)),
+        //                     source: Source::None,
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version::from((3, 8, 2)),
+        //                     source: Source::Default,
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version {
+        //                         major: 3,
+        //                         minor: 11,
+        //                         patch: 0,
+        //                         pre: vec![Identifier::AlphaNumeric("-beta.3".to_string())],
+        //                         build: vec![],
+        //                     },
+        //                     source: Source::Project(PROJECT_PATH.clone()),
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //             ];
+
+        //             assert_eq!(display_packages(&packages), expected);
+        //         }
+        //     }
+
+        //     mod tools {
+        //         use super::*;
+        //         use crate::command::list::{Package, Source};
+        //         use semver::{Identifier, Version};
+
+        //         #[test]
+        //         fn none() {
+        //             let expected = "⚡️ No tools or packages named `ember` installed.
+
+        // You can safely install packages by running `volta install <package name>`.
+        // See `volta help install` for details and more options.";
+
+        //             assert_eq!(display_tool("ember", &[]), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_default() {
+        //             let expected = "⚡️ tool `ember` available from:
+
+        //     ember-cli@3.10.1 (default)
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm";
+
+        //             let packages = [Package {
+        //                 name: "ember-cli".to_string(),
+        //                 version: Version::from((3, 10, 1)),
+        //                 source: Source::Default,
+        //                 node: NODE_12.clone(),
+        //                 tools: vec!["ember".to_string()],
+        //             }];
+
+        //             assert_eq!(display_tool("ember", &packages), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_project() {
+        //             let expected = "⚡️ tool `ember` available from:
+
+        //     ember-cli@3.10.1 (current @ ~/path/to/project.json)
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm";
+
+        //             let packages = [Package {
+        //                 name: "ember-cli".to_string(),
+        //                 version: Version::from((3, 10, 1)),
+        //                 source: Source::Project(PROJECT_PATH.clone()),
+        //                 node: NODE_12.clone(),
+        //                 tools: vec!["ember".to_string()],
+        //             }];
+
+        //             assert_eq!(display_tool("ember", &packages), expected);
+        //         }
+
+        //         #[test]
+        //         fn single_fetched() {
+        //             let expected = "⚡️ tool `ember` available from:
+
+        //     ember-cli@3.10.1
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+        // To make it available to execute, run `volta install ember-cli@3.10.1`.
+        // See `volta help install` for details and more options.";
+
+        //             let packages = [Package {
+        //                 name: "ember-cli".to_string(),
+        //                 version: Version::from((3, 10, 1)),
+        //                 source: Source::None,
+        //                 node: NODE_12.clone(),
+        //                 tools: vec!["ember".to_string()],
+        //             }];
+
+        //             assert_eq!(display_tool("ember", &packages), expected);
+        //         }
+
+        //         #[test]
+        //         fn multi_fetched() {
+        //             let expected = "⚡️ tool `ember` available from:
+
+        //     ember-cli@3.10.1
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+        //     ember-cli@3.8.2
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+        // To make it available to execute, run `volta install ember-cli@<version>`.
+        // See `volta help install` for details and more options.";
+
+        //             let packages = [
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version::from((3, 10, 1)),
+        //                     source: Source::None,
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version::from((3, 8, 2)),
+        //                     source: Source::None,
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //             ];
+
+        //             assert_eq!(display_tool("ember", &packages), expected);
+        //         }
+
+        //         #[test]
+        //         fn multi() {
+        //             let expected = "⚡️ tool `ember` available from:
+        //     ember-cli@3.11.0-beta.3 (current @ ~/path/to/project.json)
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+
+        //     ember-cli@3.10.1
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm
+        //     ember-cli@3.8.2 (default)
+        //         platform:
+        //             runtime: node@v12.2.0
+        //             package manager: built-in npm";
+
+        //             let packages = [
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version::from((3, 10, 1)),
+        //                     source: Source::None,
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version::from((3, 8, 2)),
+        //                     source: Source::Default,
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "ember-cli".to_string(),
+        //                     version: Version {
+        //                         major: 3,
+        //                         minor: 11,
+        //                         patch: 0,
+        //                         pre: vec![Identifier::AlphaNumeric("-beta.3".to_string())],
+        //                         build: vec![],
+        //                     },
+        //                     source: Source::Project(PROJECT_PATH.clone()),
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["ember".to_string()],
+        //                 },
+        //             ];
+
+        //             assert_eq!(display_tool("ember", &packages), expected);
+        //         }
+        //     }
+
+        //     mod all {
+        //         use super::*;
+        //         use crate::command::list::PackageManagerKind;
+        //         use semver::Identifier;
+
+        //         #[test]
+        //         fn empty() {
+        //             let runtimes = [];
+        //             let package_managers = [];
+        //             let packages = [];
+
+        //             assert_eq!(
+        //                 display_all(&runtimes, &package_managers, &packages),
+        //                 NO_RUNTIME
+        //             );
+        //         }
+
+        //         #[test]
+        //         fn full() {
+        //             let expected = "⚡️ Default toolchain:
+        //     Node runtimes:
+        //         v12.2.0 (current @ ~/path/to/project.json)
+        //         v11.9.0
+        //         v10.15.3 (default)
+        //     Package managers:
+        //         Yarn:
+        //             v1.17.0 (current @ ~/path/to/project.json)
+        //             v1.16.0 (default)
+        //             v1.4.0
+        //     Tools:
+        //         ember-cli:
+        //             v3.11.0-beta.3
+        //                 binaries: ember
+        //                 platform:
+        //                     runtime: node@12.2.0
+        //                     package manager: built-in npm
+        //             v3.10.1 (current @ ~/path/to/project.json):
+        //                 binaries: ember
+        //                 platform:
+        //                     runtime: node@12.2.0
+        //                     package manager: built-in npm
+        //             v3.8.2 (default):
+        //                 binaries: ember
+        //                 platform:
+        //                     runtime: node@12.2.0
+        //                     package manager: built-in npm
+        //         typescript:
+        //             v3.5.1 (current @ ~/path/to/project.json):
+        //                 binaries:
+        //                 platform:
+        //                     runtime: node@12.2.0
+        //                     package manager: built-in npm
+        //             v3.4.3 (default):
+        //                 binaries:
+        //                 platform:
+        //                     runtime: node@12.2.0
+        //                     package manager: built-in npm
+        //             ";
+
+        //             let runtimes = [
+        //                 Node {
+        //                     source: Source::Project(PROJECT_PATH.clone()),
+        //                     version: NODE_12.clone(),
+        //                 },
+        //                 Node {
+        //                     source: Source::None,
+        //                     version: NODE_11.clone(),
+        //                 },
+        //                 Node {
+        //                     source: Source::Default,
+        //                     version: NODE_10.clone(),
+        //                 },
+        //             ];
+
+        //             let package_managers = [
+        //                 PackageManager {
+        //                     kind: PackageManagerKind::Yarn,
+        //                     source: Source::Default,
+        //                     version: YARN_VERSION.clone(),
+        //                 },
+        //                 PackageManager {
+        //                     kind: PackageManagerKind::Yarn,
+        //                     source: Source::Project(PROJECT_PATH.clone()),
+        //                     version: Version::from((1, 17, 0)),
+        //                 },
+        //                 PackageManager {
+        //                     kind: PackageManagerKind::Npm,
+        //                     source: Source::None,
+        //                     version: Version::from((1, 4, 0)),
+        //                 },
+        //             ];
+
+        //             let packages = [
+        //                 Package {
+        //                     name: "typescript".to_string(),
+        //                     source: Source::Default,
+        //                     version: Version::from((3, 4, 3)),
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["tsc".to_string(), "tsserver".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "typescript".to_string(),
+        //                     source: Source::Project(PROJECT_PATH.clone()),
+        //                     version: Version::from((3, 5, 1)),
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["tsc".to_string(), "tsserver".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "ember".to_string(),
+        //                     source: Source::None,
+        //                     version: Version {
+        //                         major: 3,
+        //                         minor: 11,
+        //                         patch: 0,
+        //                         pre: vec![Identifier::AlphaNumeric("-beta.3".to_string())],
+        //                         build: vec![],
+        //                     },
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["tsc".to_string(), "tsserver".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "ember".to_string(),
+        //                     source: Source::Project(PROJECT_PATH.clone()),
+        //                     version: Version::from((3, 10, 1)),
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["tsc".to_string(), "tsserver".to_string()],
+        //                 },
+        //                 Package {
+        //                     name: "ember".to_string(),
+        //                     source: Source::Default,
+        //                     version: Version::from((3, 8, 2)),
+        //                     node: NODE_12.clone(),
+        //                     tools: vec!["tsc".to_string(), "tsserver".to_string()],
+        //                 },
+        //             ];
+        // }
     }
 }

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -83,7 +83,7 @@ fn display_active(
             let width = text_width().unwrap_or(0);
             let runtime_version: String = Wrapper::new(width)
                 .initial_indent(INDENTATION)
-                .fill(&format!("node: {}", list_runtime(runtime)));
+                .fill(&format!("Node: {}", list_runtime(runtime)));
             let package_versions = if packages.is_empty() {
                 Wrapper::new(width)
                     .initial_indent(INDENTATION)
@@ -720,7 +720,6 @@ See options for more detailed reports by running `volta list --help`.";
 
     mod package_managers {
         use super::*;
-        use crate::command::list::Subcommand;
         use crate::command::list::{PackageManager, PackageManagerKind, Source};
 
         #[test]
@@ -1103,7 +1102,6 @@ See `volta help install` for details and more options.";
     mod all {
         use super::*;
         use crate::command::list::{PackageDetails, PackageManagerKind};
-        use semver::Identifier;
 
         #[test]
         fn empty() {

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -8,8 +8,8 @@ use super::{Node, Package, PackageManager, Toolchain};
 
 use lazy_static::lazy_static;
 
-static INDENTATION: &'static str = "    ";
-static NO_RUNTIME: &'static str = "⚡️ No Node runtimes installed!
+static INDENTATION: &str = "    ";
+static NO_RUNTIME: &str = "⚡️ No Node runtimes installed!
 
     You can install a runtime by running `volta install node`. See `volta help install` for
     details and more options.";

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -41,13 +41,41 @@ pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
 /// Accepts the components *from* the toolchain rather than the item itself so
 /// that
 fn display_active(
-    node: &Option<Node>,
-    package_manager: &Option<PackageManager>,
+    node: &Option<Box<Node>>,
+    package_manager: &Option<Box<PackageManager>>,
     packages: &[Package],
 ) -> String {
     match (node, package_manager, packages) {
         (None, _, _) => NO_RUNTIME.to_string(),
-        (Some(node), Some(package_manager), packages) => unimplemented!(),
+        (Some(node), Some(package_manager), packages) => {
+            let width = text_width().unwrap_or(0);
+            let node_version: String = Wrapper::new(width)
+                .initial_indent(INDENTATION)
+                .subsequent_indent(INDENTATION)
+                .fill(&format!("Node: {} {}", node.version, node.source));
+            let package_manager_version: String = Wrapper::new(width)
+                .initial_indent(INDENTATION)
+                .subsequent_indent(INDENTATION)
+                .fill(&format!(
+                    "{}: {} {}",
+                    package_manager.kind, package_manager.version, package_manager.source
+                ));
+            let package_versions = Wrapper::new(width)
+                .initial_indent(INDENTATION)
+                .subsequent_indent(INDENTATION)
+                .fill(
+                    &packages
+                        .iter()
+                        .map(|package| format!("v{}{}", package., package))
+                        .collect::<Vec<String>>()
+                        .join("\n"),
+                );
+
+            format!(
+                "⚡️ Currently active tools:\n\n{}\n{}\n{}",
+                node_version, package_manager_version, package_versions
+            )
+        }
         _ => unimplemented!(),
     }
 }

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -312,11 +312,7 @@ impl Command for List {
         };
 
         if let Some(string) = format(&toolchain) {
-            // TODO: #523 -- just `println!("{}", string)` once `human` implemented
-            match self.output_format() {
-                Format::Plain => println!("{}", string),
-                Format::Human => println!("{}", string),
-            }
+            println!("{}", string)
         };
 
         session.add_event_end(ActivityKind::List, ExitCode::Success);

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -1,4 +1,4 @@
-// mod human;
+mod human;
 mod plain;
 mod toolchain;
 
@@ -294,7 +294,7 @@ impl Command for List {
         let project = session.project()?;
         let default_platform = session.default_platform()?;
         let format = match self.output_format() {
-            Format::Human => human_fallback,
+            Format::Human => human::format,
             Format::Plain => plain::format,
         };
 
@@ -324,7 +324,7 @@ impl Command for List {
             // TODO: #523 -- just `println!("{}", string)` once `human` implemented
             match self.output_format() {
                 Format::Plain => println!("{}", string),
-                Format::Human => warn!("{}", string),
+                Format::Human => println!("{}", string),
             }
         };
 

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -4,7 +4,6 @@ mod toolchain;
 
 use std::{fmt, path::PathBuf, str::FromStr};
 
-use log::warn;
 use semver::Version;
 use structopt::StructOpt;
 
@@ -276,14 +275,6 @@ impl List {
     fn subcommand(&self) -> Option<Subcommand> {
         self.subcommand.as_ref().map(|s| s.as_str().into())
     }
-}
-
-fn human_fallback(_toolchain: &Toolchain) -> Option<String> {
-    Some(String::from(
-        "The `--format=human` printer is not yet implemented. For now, you can \
-         use `volta list --format=plain`.\n\n\
-         To track progress on this task, see https://github.com/volta-cli/volta/issues/523",
-    ))
 }
 
 impl Command for List {


### PR DESCRIPTION
This PR is the implementation of @chriskrycho 's RFC https://github.com/volta-cli/rfcs/blob/info-commands/text/0000-informational-commands.md

Since the basic code structure and tests has been completed, I tried my best to follow the original design as much as possible. However, I noticed a few places that I have to change:

### volta list <package>

From the RFC, command `volta list package` should print out the header message as `<package> versions in toolchain:`. However, since we don't have a way to get the package name from CLI argument, I'm just showing a generic message here: `⚡️ Package versions in your toolchain:`.

---

### volta list all

From the RFC, when listing packages in `list all`, the packages should be grouped by package name and then version, like:

```
Packages:
        <package name>
            [<version> (default | current @ <project path>)
                binaries: [<binary name>]...
                platform:
                    runtime: node@<version>
                    package manager: built-in npm|<npm|yarn>@<version>]
            [<version> (fetched)]
```

In this PR I'm not doing the grouping and simply just print out every `Toolchain::Package`, since we won't get more than one default `Package` so that the list won't bee too long, also having another group with indentations looks wired somehow in my screen.

On the other hand, I also like the way to group different version by package name, which makes the output more clear. I'm here asking opinions about this, if we still want to keep the grouping, I'm looking for suggestions about some good ways to do the mapping implementation.

---

### Package availability

As far as I understand, `volta list <package>` should give me all the version installed for that package. For example, if I have ember-cli@3.12.0 and ember-cli@3.13.0, I will have this via `volta list ember-cli`:

```
ember-cli@3.13.0 (default)
        binary tools: ember
        platform:
            runtime: node@12.2.0
            package manager: npm@built-in
    ember-cli@3.12.0
        binary tools: ember
        platform:
            runtime: node@12.2.0
            package manager: npm@built-in";
```

However, I noticed that for a specific `User` package, I always only get the current default one, not sure if this is by design, or if I missed something. I tried using `volta list <package> --format=plain` and seems have the same result.

---

### Others

I changed some minor text/formatting in the codebase, especially in the test section.

---

This PR definitely needs some cleanup work, since I'm fairly new to the codebase, I think it's a good idea to post the draft first, then we can start more discussion here.

Also I'm still in the process of learn Rust, if there is anything wrong please let me know. Appreciate!