### PR TITLE
[npm] [Small] Support Custom and Bundled npm in Image

### DIFF
--- a/crates/volta-core/src/platform/test.rs
+++ b/crates/volta-core/src/platform/test.rs
@@ -25,52 +25,69 @@ fn test_image_path() {
         ),
     );
 
-    let node_bin = volta_home()
-        .unwrap()
-        .root()
-        .join("tools")
-        .join("image")
-        .join("node")
-        .join("1.2.3")
-        .join("bin");
-    let expected_node_bin = node_bin.as_path().to_str().unwrap();
+    let node_bin = volta_home().unwrap().node_image_bin_dir("1.2.3");
+    let expected_node_bin = node_bin.to_str().unwrap();
 
-    let yarn_bin = volta_home()
-        .unwrap()
-        .root()
-        .join("tools")
-        .join("image")
-        .join("yarn")
-        .join("4.5.7")
-        .join("bin");
-    let expected_yarn_bin = yarn_bin.as_path().to_str().unwrap();
+    let npm_bin = volta_home().unwrap().npm_image_bin_dir("6.4.3");
+    let expected_npm_bin = npm_bin.to_str().unwrap();
+
+    let yarn_bin = volta_home().unwrap().yarn_image_bin_dir("4.5.7");
+    let expected_yarn_bin = yarn_bin.to_str().unwrap();
 
     let v123 = Version::parse("1.2.3").unwrap();
     let v457 = Version::parse("4.5.7").unwrap();
     let v643 = Version::parse("6.4.3").unwrap();
 
-    let no_yarn_image = Image {
+    let only_node = Image {
         node: Sourced::with_default(v123.clone()),
-        npm: Sourced::with_default(v643.clone()),
+        npm: None,
         yarn: None,
     };
 
     assert_eq!(
-        no_yarn_image.path().unwrap().into_string().unwrap(),
+        only_node.path().unwrap().into_string().unwrap(),
         format!("{}:/usr/bin:/blah:/doesnt/matter/bin", expected_node_bin),
     );
 
-    let with_yarn_image = Image {
+    let node_npm = Image {
+        node: Sourced::with_default(v123.clone()),
+        npm: Some(Sourced::with_default(v643.clone())),
+        yarn: None,
+    };
+
+    assert_eq!(
+        node_npm.path().unwrap().into_string().unwrap(),
+        format!(
+            "{}:{}:/usr/bin:/blah:/doesnt/matter/bin",
+            expected_npm_bin, expected_node_bin
+        ),
+    );
+
+    let node_yarn = Image {
+        node: Sourced::with_default(v123.clone()),
+        npm: None,
+        yarn: Some(Sourced::with_default(v457.clone())),
+    };
+
+    assert_eq!(
+        node_yarn.path().unwrap().into_string().unwrap(),
+        format!(
+            "{}:{}:/usr/bin:/blah:/doesnt/matter/bin",
+            expected_yarn_bin, expected_node_bin
+        ),
+    );
+
+    let node_npm_yarn = Image {
         node: Sourced::with_default(v123),
-        npm: Sourced::with_default(v643),
+        npm: Some(Sourced::with_default(v643)),
         yarn: Some(Sourced::with_default(v457)),
     };
 
     assert_eq!(
-        with_yarn_image.path().unwrap().into_string().unwrap(),
+        node_npm_yarn.path().unwrap().into_string().unwrap(),
         format!(
-            "{}:{}:/usr/bin:/blah:/doesnt/matter/bin",
-            expected_node_bin, expected_yarn_bin
+            "{}:{}:{}:/usr/bin:/blah:/doesnt/matter/bin",
+            expected_npm_bin, expected_yarn_bin, expected_node_bin
         ),
     );
 }
@@ -90,51 +107,69 @@ fn test_image_path() {
 
     std::env::set_var("PATH", path_with_shims);
 
-    let node_bin = volta_home()
-        .unwrap()
-        .root()
-        .join("tools")
-        .join("image")
-        .join("node")
-        .join("1.2.3");
-    let expected_node_bin = node_bin.as_path().to_str().unwrap();
+    let node_bin = volta_home().unwrap().node_image_bin_dir("1.2.3");
+    let expected_node_bin = node_bin.to_str().unwrap();
 
-    let yarn_bin = volta_home()
-        .unwrap()
-        .root()
-        .join("tools")
-        .join("image")
-        .join("yarn")
-        .join("4.5.7")
-        .join("bin");
-    let expected_yarn_bin = yarn_bin.as_path().to_str().unwrap();
+    let npm_bin = volta_home().unwrap().npm_image_bin_dir("6.4.3");
+    let expected_npm_bin = npm_bin.to_str().unwrap();
+
+    let yarn_bin = volta_home().unwrap().yarn_image_bin_dir("4.5.7");
+    let expected_yarn_bin = yarn_bin.to_str().unwrap();
 
     let v123 = Version::parse("1.2.3").unwrap();
     let v457 = Version::parse("4.5.7").unwrap();
     let v643 = Version::parse("6.4.3").unwrap();
 
-    let no_yarn_image = Image {
+    let only_node = Image {
         node: Sourced::with_default(v123.clone()),
-        npm: Sourced::with_default(v643.clone()),
+        npm: None,
         yarn: None,
     };
 
     assert_eq!(
-        no_yarn_image.path().unwrap().into_string().unwrap(),
+        only_node.path().unwrap().into_string().unwrap(),
         format!("{};C:\\\\somebin;D:\\\\ProbramFlies", expected_node_bin),
     );
 
-    let with_yarn_image = Image {
+    let node_npm = Image {
+        node: Sourced::with_default(v123.clone()),
+        npm: Some(Sourced::with_default(v643.clone())),
+        yarn: None,
+    };
+
+    assert_eq!(
+        node_npm.path().unwrap().into_string().unwrap(),
+        format!(
+            "{};{};C:\\\\somebin;D:\\\\ProbramFlies",
+            expected_npm_bin, expected_node_bin
+        ),
+    );
+
+    let node_yarn = Image {
+        node: Sourced::with_default(v123.clone()),
+        npm: None,
+        yarn: Some(Sourced::with_default(v457.clone())),
+    };
+
+    assert_eq!(
+        node_yarn.path().unwrap().into_string().unwrap(),
+        format!(
+            "{};{};C:\\\\somebin;D:\\\\ProbramFlies",
+            expected_yarn_bin, expected_node_bin
+        ),
+    );
+
+    let node_npm_yarn = Image {
         node: Sourced::with_default(v123),
-        npm: Sourced::with_default(v643),
+        npm: Some(Sourced::with_default(v643)),
         yarn: Some(Sourced::with_default(v457)),
     };
 
     assert_eq!(
-        with_yarn_image.path().unwrap().into_string().unwrap(),
+        node_npm_yarn.path().unwrap().into_string().unwrap(),
         format!(
-            "{};{};C:\\\\somebin;D:\\\\ProbramFlies",
-            expected_node_bin, expected_yarn_bin
+            "{};{};{};C:\\\\somebin;D:\\\\ProbramFlies",
+            expected_npm_bin, expected_yarn_bin, expected_node_bin
         ),
     );
 }

--- a/crates/volta-core/src/run/npm.rs
+++ b/crates/volta-core/src/run/npm.rs
@@ -21,7 +21,7 @@ pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
             let image = platform.checkout(session)?;
             let path = image.path()?;
 
-            debug_tool_message("npm", &image.npm);
+            debug_tool_message("npm", &image.resolve_npm()?);
 
             Ok(ToolCommand::direct(OsStr::new("npm"), &path))
         }

--- a/crates/volta-core/src/run/npx.rs
+++ b/crates/volta-core/src/run/npx.rs
@@ -18,14 +18,15 @@ pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
             // npx was only included with npm 5.2.0 and higher. If the npm version is less than that, we
             // should include a helpful error message
             let required_npm = parse_version("5.2.0")?;
-            if image.npm.value >= required_npm {
+            let active_npm = image.resolve_npm()?;
+            if active_npm.value >= required_npm {
                 let path = image.path()?;
 
-                debug_tool_message("npx", &image.npm);
+                debug_tool_message("npx", &active_npm);
                 Ok(ToolCommand::direct(OsStr::new("npx"), &path))
             } else {
                 Err(ErrorDetails::NpxNotAvailable {
-                    version: image.npm.value.to_string(),
+                    version: active_npm.value.to_string(),
                 }
                 .into())
             }


### PR DESCRIPTION
Info
-----
* To support custom `npm` versions, we need `Image` to be aware of the difference between custom and bundled `npm`
* We also need to ensure that the path to a custom `npm` version is earlier in the PATH than the path to the `node` directory, otherwise the bundled version will always win.
* We still need to maintain the ability to look up the actual `npm` version if needed, even if it is bundled.

Changes
-----
* Updated `Image` to hold an `Option` for `npm`, noting that `None` represents the version bundled with Node
* Updated `Image::bins` to properly order the bins to support custom `npm` (ensuring that `npm` is before `node` in the list)
* Added a `resolve_npm` method to `Image`, so that the explicit version can be looked up (including resolving the bundled version, if necessary).
* Updated `run::npm` and `run::npx` to correctly determine the `npm` version using `resolve_npm`

Tested
-----
* Updated tests to cover all possible combinations of tools in an `Image`
* All existing tests pass