### PR TITLE
Ensure Scoped Packages are cataloged by `volta list` 

### DIFF
--- a/crates/volta-core/src/inventory.rs
+++ b/crates/volta-core/src/inventory.rs
@@ -49,7 +49,7 @@ pub fn package_configs() -> Fallible<BTreeSet<PackageConfig>> {
     let package_dir = volta_home()?.default_package_dir();
 
     WalkDir::new(&package_dir)
-        .max_depth(1)
+        .max_depth(2)
         .into_iter()
         // Ignore any items which didn't resolve as `DirEntry` correctly.
         // There is no point trying to do anything with those, and no error


### PR DESCRIPTION
Closes #700 

Info
-----
* To find all installed packages, we were walking the package config directory with a `max_depth` set to `1`.
* Per the [WalkDir docs](https://docs.rs/walkdir/2.3.1/walkdir/struct.WalkDir.html#method.max_depth), `max_depth(1)` means that we only look at the direct descendants of the directory we started at, so we won't look at any file in subdirectories.
* However, when we install a scoped package, it winds up in a subdirectory as a result of the name having a `/` in it.
* This means `volta list` was not correctly showing scoped packages at all.

Changes
-----
* Updated to use `max_depth(2)`, which will find the children of subdirectories as well. We shouldn't need more than one additional directory, since `npm` forbids packages having a `/` in them, except for the specific case of scoped packages, which have exactly 1.

Tested
-----
* Local testing to confirm that scoped packages are included in the output of `volta list`