### PR TITLE
[Small] Ensure error details are written to the terminal in CI environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ci_info"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "envmnt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "envmnt"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fsio 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "envoy"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +666,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "fs-utils"
 version = "0.1.0"
+
+[[package]]
+name = "fsio"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fuchsia-cprng"
@@ -2378,6 +2400,7 @@ version = "0.7.2"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ci_info 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "envoy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2412,6 +2435,7 @@ dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ci_info 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmdline_words_parser 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2653,6 +2677,7 @@ dependencies = [
 "checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
 "checksum chomp 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9f74ad218e66339b11fd23f693fb8f1d621e80ba6ac218297be26073365d163d"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
+"checksum ci_info 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b407009a4a51ae109dbdfcd7b6e4de38d148f37fad512b8c4623c642c4045e68"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clicolors-control 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f84dec9bc083ce2503908cd305af98bd363da6f54bf8d4bf0ac14ee749ad5d1"
 "checksum clicolors-control 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "73abfd4c73d003a674ce5d2933fca6ce6c42480ea84a5ffe0a2dc39ed56300f9"
@@ -2689,6 +2714,7 @@ dependencies = [
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encode_unicode 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90b2c9496c001e8cb61827acdefad780795c42264c137744cae6f7d9e3450abd"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
+"checksum envmnt 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d779a6b692f4df25a68178f49ddc4629331092aaf025d03f2c633e58e217f37f"
 "checksum envoy 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb34b6240ca977e7ab7dff6f060f9cb9a8f92c7745fe9e292b9443944d1aa768"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
@@ -2699,6 +2725,7 @@ dependencies = [
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+"checksum fsio 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2131cb03096f67334dfba2f0bc46afc5564b08a919d042c6e217e2665741fc54"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,5 +51,6 @@ winreg = "0.6.0"
 [dev-dependencies]
 hamcrest2 = "0.3.0"
 envoy = "0.1.3"
+ci_info = "0.10.0"
 
 [workspace]

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -52,6 +52,7 @@ walkdir = "2.2.9"
 volta-layout = { path = "../volta-layout" }
 double-checked-cell = "2.0.2"
 dunce = "1.0.0"
+ci_info = "0.10.0"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.6.0"

--- a/crates/volta-core/src/error/reporter.rs
+++ b/crates/volta-core/src/error/reporter.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use crate::layout::volta_home;
 use crate::style::format_error_cause;
 use chrono::Local;
+use ci_info::is_ci;
 use failure::Error;
 use fs_utils::ensure_containing_dir_exists;
 use log::{debug, error};
@@ -18,17 +19,25 @@ pub fn report_error(volta_version: &str, err: &VoltaError) {
     error!("{}", message);
 
     if let Some(details) = compose_error_details(err) {
-        debug!("{}", details);
+        if is_ci() {
+            // In CI, we write the error details to the log so that they are available in the CI logs
+            // A log file may not even exist by the time the user is reviewing a failure
+            error!("{}", details);
+        } else {
+            // Outside of CI, we write the error details as Debug (Verbose) information
+            // And we write an actual error log that the user can review
+            debug!("{}", details);
 
-        // Note: Writing the error log info directly to stderr as it is a message for the user
-        // Any custom logs will have all of the details already, so showing a message about writing
-        // the error log would be redundant
-        match write_error_log(volta_version, message, details) {
-            Ok(log_file) => {
-                eprintln!("Error details written to {}", log_file.to_string_lossy());
-            }
-            Err(_) => {
-                eprintln!("Unable to write error log!");
+            // Note: Writing the error log info directly to stderr as it is a message for the user
+            // Any custom logs will have all of the details already, so showing a message about writing
+            // the error log would be redundant
+            match write_error_log(volta_version, message, details) {
+                Ok(log_file) => {
+                    eprintln!("Error details written to {}", log_file.to_string_lossy());
+                }
+                Err(_) => {
+                    eprintln!("Unable to write error log!");
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #677 

Info
-----
* In CI environments, writing the error details into a log file isn't helpful, as the file is often deleted along with everything else when the run is complete.
* Instead, we should write error details directly to the console when in CI, so that they are available when reviewing the console logs later.

Changes
-----
* Updated `error::reporter.rs` to print any additional error details out to the console in CI environments.

Tested
-----
* Updated error reporting tests to mock the CI environment as needed.
* Added tests to confirm the error information is written out in CI (with mocks, so they work locally as well).
* All tests pass.