### PR TITLE
[Tiny] Prevent writing color codes to error logs and help

### DIFF
--- a/crates/volta-core/src/error/reporter.rs
+++ b/crates/volta-core/src/error/reporter.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use crate::layout::volta_home;
 use crate::style::format_error_cause;
 use chrono::Local;
+use console::strip_ansi_codes;
 use failure::Error;
 use fs_utils::ensure_containing_dir_exists;
 use log::{debug, error};
@@ -51,9 +52,9 @@ fn write_error_log(
     writeln!(log_file, "{}", collect_arguments())?;
     writeln!(log_file, "Volta v{}", volta_version)?;
     writeln!(log_file)?;
-    writeln!(log_file, "{}", message)?;
+    writeln!(log_file, "{}", strip_ansi_codes(&message))?;
     writeln!(log_file)?;
-    writeln!(log_file, "{}", details)?;
+    writeln!(log_file, "{}", strip_ansi_codes(&details))?;
 
     Ok(log_file_path)
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -14,7 +14,7 @@ use volta_fail::{ExitCode, Fallible};
     To install a tool in your toolchain, use `volta install`.
     To pin your project's runtime or package manager, use `volta pin`.",
     raw(global_setting = "structopt::clap::AppSettings::ColoredHelp"),
-    raw(global_setting = "structopt::clap::AppSettings::ColorAlways"),
+    raw(global_setting = "structopt::clap::AppSettings::ColorAuto"),
     raw(global_setting = "structopt::clap::AppSettings::DeriveDisplayOrder"),
     raw(global_setting = "structopt::clap::AppSettings::DisableVersion"),
     raw(global_setting = "structopt::clap::AppSettings::DontCollapseArgsInUsage"),


### PR DESCRIPTION
Closes #675 

Info
-----
* Most of our colorized output is already run through the `console` crate, which auto-detects whether or not we should use colors based on the terminal.
* However, our help output was always using colors
* Additionally, we shouldn't write color codes into a file when writing the error log.

Changes
-----
* Updated the root StructOpt definition to use `clap::AppSettings::ColorAuto` instead of `clap::AppSettings::ColorAlways`, so that the output will be colorized based on whether or not the terminal is interactive.
* Added calls to `strip_ansi_codes` when writing the error log, so that we avoid writing any color / style codes into the error file.

Tested
-----
* Confirmed that `volta help | pbcopy` doesn't include any ANSI codes
* Confirmed that ANSI codes are no longer written into the error log.