### PR TITLE
Decouple args from ToolCommand constructors

### DIFF
--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -36,43 +36,38 @@ pub fn execute_tool(session: &mut Session) -> Fallible<ExitStatus> {
     let mut args = args_os();
     let exe = get_tool_name(&mut args)?;
 
-    let command = if env::var_os(VOLTA_BYPASS).is_some() {
+    let mut command = if env::var_os(VOLTA_BYPASS).is_some() {
         ToolCommand::passthrough(
             &exe,
-            args,
             ErrorDetails::BypassError {
                 command: exe.to_string_lossy().to_string(),
             },
         )?
     } else {
-        match &exe.to_str() {
+        match exe.to_str() {
             Some("volta-shim") => throw!(ErrorDetails::RunShimDirectly),
-            Some("node") => node::command(args, session)?,
-            Some("npm") => npm::command(args, session)?,
-            Some("npx") => npx::command(args, session)?,
-            Some("yarn") => yarn::command(args, session)?,
-            _ => binary::command(exe, args, session)?,
+            Some("node") => node::command(session)?,
+            Some("npm") => npm::command(session)?,
+            Some("npx") => npx::command(session)?,
+            Some("yarn") => yarn::command(session)?,
+            _ => binary::command(&exe, session)?,
         }
     };
+
+    command.args(args);
 
     pass_control_to_shim();
     command.status()
 }
 
-fn debug_tool_message<T>(tool: &str, version: &Sourced<T>)
-where
-    T: std::fmt::Display + Sized,
-{
-    debug!(
-        "Using {} from {} configuration",
-        tool_version(tool, &version.value),
-        version.source,
-    )
-}
-
-/// Represents the command to execute a tool
+/// Process builder for launching a Volta-managed tool
+///
+/// This is a thin wrapper around std::process::Command, providing a few QoL improvements:
+///
+/// * `ErrorDetails` error type on `status` and `output` methods, determined based on the context
+/// * Helper methods for constructing a type with the appropriate context
 pub(crate) struct ToolCommand {
-    /// The command that will execute a tool with the right PATH context
+    /// The wrapped Command
     command: Command,
 
     /// The Volta error with which to wrap any failure.
@@ -84,23 +79,17 @@ pub(crate) struct ToolCommand {
 
 impl ToolCommand {
     /// Build a ToolCommand that is directly calling a tool in the Volta directory
-    fn direct<A>(exe: &OsStr, args: A, path_var: &OsStr) -> Self
-    where
-        A: IntoIterator<Item = OsString>,
-    {
+    fn direct(exe: &OsStr, path_var: &OsStr) -> Self {
         ToolCommand {
-            command: command_for(exe, args, path_var),
+            command: command_in(exe, path_var),
             on_failure: ErrorDetails::BinaryExecError,
         }
     }
 
     /// Build a ToolCommand that is calling a binary in the current project's `node_modules/bin`
-    fn project_local<A>(exe: &OsStr, args: A, path_var: &OsStr) -> Self
-    where
-        A: IntoIterator<Item = OsString>,
-    {
+    fn project_local(exe: &OsStr, path_var: &OsStr) -> Self {
         ToolCommand {
-            command: command_for(exe, args, path_var),
+            command: command_in(exe, path_var),
             on_failure: ErrorDetails::ProjectLocalBinaryExecError {
                 command: exe.to_string_lossy().to_string(),
             },
@@ -112,15 +101,26 @@ impl ToolCommand {
     /// This will allow the existing system to resolve the tool, if possible. If that still fails,
     /// then we show `default_error` as the friendly error to the user, directing them how to
     /// resolve the issue (e.g. run `volta install node` to enable `node`)
-    fn passthrough<A>(exe: &OsStr, args: A, default_error: ErrorDetails) -> Fallible<Self>
-    where
-        A: IntoIterator<Item = OsString>,
-    {
+    fn passthrough(exe: &OsStr, default_error: ErrorDetails) -> Fallible<Self> {
         let path = System::path()?;
         Ok(ToolCommand {
-            command: command_for(exe, args, &path),
+            command: command_in(exe, &path),
             on_failure: default_error,
         })
+    }
+
+    pub(crate) fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut ToolCommand {
+        self.command.arg(arg);
+        self
+    }
+
+    pub(crate) fn args<I, S>(&mut self, args: I) -> &mut ToolCommand
+    where
+        S: AsRef<OsStr>,
+        I: IntoIterator<Item = S>,
+    {
+        self.command.args(args);
+        self
     }
 
     pub(crate) fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut ToolCommand {
@@ -164,17 +164,27 @@ fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
     }
 }
 
-fn command_for<A>(exe: &OsStr, args: A, path_var: &OsStr) -> Command
-where
-    A: IntoIterator<Item = OsString>,
-{
+fn command_in(exe: &OsStr, path_var: &OsStr) -> Command {
     let mut command = create_command(exe);
-    command.args(args);
     command.env("PATH", path_var);
     command
 }
 
+/// Determine if we should intercept global installs or not
+///
+/// Setting the VOLTA_UNSAFE_GLOBAL environment variable will disable interception of global installs
 fn intercept_global_installs() -> bool {
-    // We should only intercept global installs if the VOLTA_UNSAFE_GLOBAL variable is not set
     env::var_os(UNSAFE_GLOBAL).is_none()
+}
+
+/// Write the tool version and source to the debug log
+fn debug_tool_message<T>(tool: &str, version: &Sourced<T>)
+where
+    T: std::fmt::Display + Sized,
+{
+    debug!(
+        "Using {} from {} configuration",
+        tool_version(tool, &version.value),
+        version.source,
+    )
 }

--- a/crates/volta-core/src/run/node.rs
+++ b/crates/volta-core/src/run/node.rs
@@ -1,4 +1,4 @@
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
 
 use super::{debug_tool_message, ToolCommand};
 use crate::error::ErrorDetails;
@@ -7,10 +7,7 @@ use crate::session::{ActivityKind, Session};
 use log::debug;
 use volta_fail::Fallible;
 
-pub(crate) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
-where
-    A: IntoIterator<Item = OsString>,
-{
+pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
     session.add_event_start(ActivityKind::Node);
 
     match session.current_platform()? {
@@ -19,11 +16,11 @@ where
 
             let image = platform.checkout(session)?;
             let path = image.path()?;
-            Ok(ToolCommand::direct(OsStr::new("node"), args, &path))
+            Ok(ToolCommand::direct(OsStr::new("node"), &path))
         }
         None => {
             debug!("Could not find Volta-managed node, delegating to system");
-            ToolCommand::passthrough(OsStr::new("node"), args, ErrorDetails::NoPlatform)
+            ToolCommand::passthrough(OsStr::new("node"), ErrorDetails::NoPlatform)
         }
     }
 }

--- a/crates/volta-core/src/run/npm.rs
+++ b/crates/volta-core/src/run/npm.rs
@@ -1,5 +1,5 @@
 use std::env::args_os;
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
 
 use super::{debug_tool_message, intercept_global_installs, CommandArg, ToolCommand};
 use crate::error::ErrorDetails;
@@ -8,10 +8,7 @@ use crate::session::{ActivityKind, Session};
 use log::debug;
 use volta_fail::{throw, Fallible};
 
-pub(crate) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
-where
-    A: IntoIterator<Item = OsString>,
-{
+pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
     session.add_event_start(ActivityKind::Npm);
 
     match session.current_platform()? {
@@ -26,11 +23,11 @@ where
 
             debug_tool_message("npm", &image.npm);
 
-            Ok(ToolCommand::direct(OsStr::new("npm"), args, &path))
+            Ok(ToolCommand::direct(OsStr::new("npm"), &path))
         }
         None => {
             debug!("Could not find Volta-managed npm, delegating to system");
-            ToolCommand::passthrough(OsStr::new("npm"), args, ErrorDetails::NoPlatform)
+            ToolCommand::passthrough(OsStr::new("npm"), ErrorDetails::NoPlatform)
         }
     }
 }
@@ -38,13 +35,13 @@ where
 fn check_npm_install() -> CommandArg {
     // npm global installs will have `-g` or `--global` somewhere in the
     // argument list
-    if !args_os().any(|arg| arg == OsString::from("-g") || arg == OsString::from("--global")) {
+    if !args_os().any(|arg| arg == "-g" || arg == "--global") {
         return CommandArg::NotGlobalAdd;
     }
 
     // Get the same set of args again to iterate over, this time with the
     // command itself skipped and all flags excluded entirely. The first item
-    // in that skipped, filter iterator is the command itself.
+    // in that skipped, filtered iterator is the npm command.
     let mut args = args_os().skip(1).filter(|arg| match arg.to_str() {
         Some(arg) => !arg.starts_with('-'),
         None => true,
@@ -53,15 +50,12 @@ fn check_npm_install() -> CommandArg {
 
     // They will be specified by the command `i`, `install`, `add` or `isntall`.
     // See https://github.com/npm/cli/blob/latest/lib/config/cmd-list.js
-    if command == Some(OsString::from("install"))
-        || command == Some(OsString::from("i"))
-        || command == Some(OsString::from("isntall"))
-        || command == Some(OsString::from("add"))
-    {
-        // `args` here picks up from where the command lookup left off, so
-        // will be the name of the package passed to the command.
-        CommandArg::GlobalAdd(args.next())
-    } else {
-        CommandArg::NotGlobalAdd
+    match command {
+        Some(cmd) if cmd == "install" || cmd == "i" || cmd == "isntall" || cmd == "add" => {
+            // `args` here picks up from where the command lookup left off, so
+            // will be the name of the package passed to the command.
+            CommandArg::GlobalAdd(args.next())
+        }
+        _ => CommandArg::NotGlobalAdd,
     }
 }

--- a/crates/volta-core/src/run/npx.rs
+++ b/crates/volta-core/src/run/npx.rs
@@ -1,4 +1,4 @@
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsStr;
 
 use super::{debug_tool_message, ToolCommand};
 use crate::error::ErrorDetails;
@@ -8,10 +8,7 @@ use crate::version::parse_version;
 use log::debug;
 use volta_fail::Fallible;
 
-pub(crate) fn command<A>(args: A, session: &mut Session) -> Fallible<ToolCommand>
-where
-    A: IntoIterator<Item = OsString>,
-{
+pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
     session.add_event_start(ActivityKind::Npx);
 
     match session.current_platform()? {
@@ -25,7 +22,7 @@ where
                 let path = image.path()?;
 
                 debug_tool_message("npx", &image.npm);
-                Ok(ToolCommand::direct(OsStr::new("npx"), args, &path))
+                Ok(ToolCommand::direct(OsStr::new("npx"), &path))
             } else {
                 Err(ErrorDetails::NpxNotAvailable {
                     version: image.npm.value.to_string(),
@@ -35,7 +32,7 @@ where
         }
         None => {
             debug!("Could not find Volta-managed npx, delegating to system");
-            ToolCommand::passthrough(OsStr::new("npx"), args, ErrorDetails::NoPlatform)
+            ToolCommand::passthrough(OsStr::new("npx"), ErrorDetails::NoPlatform)
         }
     }
 }

--- a/crates/volta-core/src/tool/package/fetch.rs
+++ b/crates/volta-core/src/tool/package/fetch.rs
@@ -1,6 +1,5 @@
 //! Provides fetcher for 3rd-party packages
 
-use std::ffi::OsString;
 use std::fs::{rename, write, File};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -164,12 +163,10 @@ fn npm_pack_command_for(
     session: &mut Session,
     current_dir: &Path,
 ) -> Fallible<ToolCommand> {
-    let args = vec![
-        OsString::from("pack"),
-        OsString::from("--no-update-notifier"),
-        OsString::from(format!("{}@{}", name, version)),
-    ];
-    let mut command = run::npm::command(args, session)?;
+    let mut command = run::npm::command(session)?;
+    command.arg("pack");
+    command.arg("--no-update-notifier");
+    command.arg(format!("{}@{}", name, version));
     command.current_dir(current_dir);
     Ok(command)
 }

--- a/crates/volta-core/src/tool/package/resolve.rs
+++ b/crates/volta-core/src/tool/package/resolve.rs
@@ -1,7 +1,6 @@
 //! Provides resolution of 3rd-party packages into specific versions, using the npm repository
 
 use std::collections::HashMap;
-use std::ffi::OsString;
 
 use crate::error::ErrorDetails;
 use crate::hook::ToolHooks;
@@ -178,12 +177,11 @@ fn npm_view_query(name: &str, version: &str, session: &mut Session) -> Fallible<
 
 // build a command to run `npm view` with json output
 fn npm_view_command_for(name: &str, version: &str, session: &mut Session) -> Fallible<ToolCommand> {
-    let args = vec![
-        OsString::from("view"),
-        OsString::from("--json"),
-        OsString::from(format!("{}@{}", name, version)),
-    ];
-    run::npm::command(args, session)
+    let mut command = run::npm::command(session)?;
+    command.arg("view");
+    command.arg("--json");
+    command.arg(format!("{}@{}", name, version));
+    Ok(command)
 }
 
 // fetch metadata for the input url


### PR DESCRIPTION
Info
-----
* As part of investigating how to implement `volta run`, it became clear that the `ToolCommand` constructors were doing too much work.
* By setting all of the args on the constructor, we needed to know all of the args at a single time, which meant that the `args` had to be passed to each Tool's `run` method, even though the only thing they were used for was to then pass along to the `ToolCommand`.
* We also already had wrapper behavior for the `current_dir` method, so it made sense to add `args` behavior in a similar way.

Changes
-----
* Updated `ToolCommand` to support `arg` and `args` methods (passing them to the eventual command)
* Updated `execute_tool` to pass the args directly to the command after it is constructed.
* Updated `binary::command` to pass its args before returning, which results in them being first in the argument list (as required).
* Updated `node`, `npm`, `npx`, and `yarn` modules to no longer need the `args` parameter.

Tested
-----
* This shouldn't result in any changes to the logic, just a change in code organization and structure.
* All existing behavior tests pass.