### PR TITLE
[run] [Large] Rethinking of Platform / Image Sources

### DIFF
--- a/crates/archive/src/tarball.rs
+++ b/crates/archive/src/tarball.rs
@@ -10,10 +10,8 @@ use flate2::read::GzDecoder;
 use fs_utils::ensure_containing_dir_exists;
 use headers_011::Headers011;
 use progress_read::ProgressRead;
-use reqwest;
 use reqwest::hyper_011::header::{AcceptRanges, ByteRangeSpec, ContentLength, Range, RangeUnit};
 use reqwest::Response;
-use tar;
 use tee::TeeReader;
 
 use super::Archive;

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -6,11 +6,8 @@ use std::io::copy;
 use std::path::Path;
 
 use progress_read::ProgressRead;
-use reqwest;
 use verbatim::PathExt;
 use zip_rs::ZipArchive;
-
-use failure;
 
 use super::Archive;
 use super::Origin;

--- a/crates/headers-011/src/lib.rs
+++ b/crates/headers-011/src/lib.rs
@@ -1,4 +1,3 @@
-use reqwest;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::hyper_011::header::Header;
 

--- a/crates/volta-core/src/event.rs
+++ b/crates/volta-core/src/event.rs
@@ -1,7 +1,5 @@
 //! Events for the sessions in executables and shims and everything
 
-use os_info;
-
 use std::env;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/crates/volta-core/src/manifest/mod.rs
+++ b/crates/volta-core/src/manifest/mod.rs
@@ -4,10 +4,9 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{read_to_string, File};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 
 use crate::error::ErrorDetails;
-use crate::platform::ProjectPlatformSpec;
+use crate::platform::PlatformSpec;
 use detect_indent;
 use serde::Serialize;
 use serde_json;
@@ -18,7 +17,7 @@ pub(crate) mod serial;
 /// A Node manifest file.
 pub struct Manifest {
     /// The platform image specified by the `volta` section.
-    pub platform: Option<Rc<ProjectPlatformSpec>>,
+    pub platform: Option<PlatformSpec>,
     /// The `dependencies` section.
     pub dependencies: HashMap<String, String>,
     /// The `devDependencies` section.
@@ -42,8 +41,8 @@ impl Manifest {
     }
 
     /// Returns a reference to the platform image specified by manifest, if any.
-    pub fn platform(&self) -> Option<Rc<ProjectPlatformSpec>> {
-        self.platform.as_ref().cloned()
+    pub fn platform(&self) -> Option<&PlatformSpec> {
+        self.platform.as_ref()
     }
 
     /// Gets the names of all the direct dependencies in the manifest.
@@ -56,8 +55,8 @@ impl Manifest {
     }
 
     /// Updates the pinned platform information
-    pub fn update_platform(&mut self, platform: ProjectPlatformSpec) {
-        self.platform = Some(Rc::new(platform));
+    pub fn update_platform(&mut self, platform: PlatformSpec) {
+        self.platform = Some(platform);
     }
 
     /// Updates the `volta` key in the specified `package.json` to match the current Manifest
@@ -81,7 +80,7 @@ impl Manifest {
 
             // update the "volta" key
             if let Some(platform) = self.platform() {
-                let volta_value = serde_json::to_value(serial::ToolchainSpec::from(platform))
+                let volta_value = serde_json::to_value(serial::ToolchainSpec::of(platform))
                     .with_context(|_| ErrorDetails::StringifyToolchainError)?;
                 map.insert("volta".to_string(), volta_value);
             } else {

--- a/crates/volta-core/src/manifest/mod.rs
+++ b/crates/volta-core/src/manifest/mod.rs
@@ -7,9 +7,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::ErrorDetails;
 use crate::platform::PlatformSpec;
-use detect_indent;
 use serde::Serialize;
-use serde_json;
 use volta_fail::{Fallible, ResultExt};
 
 pub(crate) mod serial;

--- a/crates/volta-core/src/manifest/serial.rs
+++ b/crates/volta-core/src/manifest/serial.rs
@@ -9,7 +9,6 @@ use super::super::{manifest, platform};
 use crate::version::parse_version;
 use log::warn;
 use semver::Version;
-use serde;
 use serde::de::{Deserialize, Deserializer, Error, MapAccess, Visitor};
 use serde_json::value::Value;
 use volta_fail::Fallible;
@@ -270,7 +269,6 @@ where
 pub mod tests {
 
     use super::{BinMap, Engines, Manifest, RawBinManifest};
-    use serde_json;
     use std::collections::HashMap;
 
     #[test]

--- a/crates/volta-core/src/monitor.rs
+++ b/crates/volta-core/src/monitor.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 use std::process::{Child, Stdio};
 
 use log::error;
-use serde_json;
 
 use crate::command::create_command;
 use crate::event::Event;

--- a/crates/volta-core/src/platform/test.rs
+++ b/crates/volta-core/src/platform/test.rs
@@ -3,7 +3,6 @@ use crate::layout::volta_home;
 #[cfg(windows)]
 use crate::layout::volta_install;
 use semver::Version;
-use std;
 #[cfg(windows)]
 use std::path::PathBuf;
 

--- a/crates/volta-core/src/project.rs
+++ b/crates/volta-core/src/project.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use std::env;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use std::rc::Rc;
 use std::str::FromStr;
 
 use lazycell::LazyCell;
@@ -14,7 +13,7 @@ use semver::Version;
 use crate::error::ErrorDetails;
 use crate::layout::volta_home;
 use crate::manifest::Manifest;
-use crate::platform::ProjectPlatformSpec;
+use crate::platform::PlatformSpec;
 use crate::tool::BinConfig;
 use log::debug;
 use volta_fail::{Fallible, ResultExt};
@@ -103,7 +102,7 @@ impl Project {
     }
 
     /// Returns the pinned platform image, if any.
-    pub fn platform(&self) -> Option<Rc<ProjectPlatformSpec>> {
+    pub fn platform(&self) -> Option<&PlatformSpec> {
         self.manifest.platform()
     }
 
@@ -180,7 +179,7 @@ impl Project {
 
     /// Writes the specified version of Node to the `volta.node` key in package.json.
     pub fn pin_node(&mut self, version: &Version) -> Fallible<()> {
-        let updated_platform = ProjectPlatformSpec {
+        let updated_platform = PlatformSpec {
             node: version.clone(),
             npm: self.manifest.platform().and_then(|p| p.npm.clone()),
             yarn: self.manifest.platform().and_then(|p| p.yarn.clone()),
@@ -193,7 +192,7 @@ impl Project {
     /// Writes the specified version of Yarn to the `volta.yarn` key in package.json.
     pub fn pin_yarn(&mut self, yarn: Option<Version>) -> Fallible<()> {
         if let Some(platform) = self.manifest.platform() {
-            let updated_platform = ProjectPlatformSpec {
+            let updated_platform = PlatformSpec {
                 node: platform.node.clone(),
                 npm: platform.npm.clone(),
                 yarn,
@@ -209,7 +208,7 @@ impl Project {
     /// Writes the specified version of Npm to the `volta.npm` key in package.json.
     pub fn pin_npm(&mut self, npm: Option<Version>) -> Fallible<()> {
         if let Some(platform) = self.manifest.platform() {
-            let updated_platform = ProjectPlatformSpec {
+            let updated_platform = PlatformSpec {
                 node: platform.node.clone(),
                 npm,
                 yarn: platform.yarn.clone(),

--- a/crates/volta-core/src/run/node.rs
+++ b/crates/volta-core/src/run/node.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 
 use super::{debug_tool_message, ToolCommand};
 use crate::error::ErrorDetails;
+use crate::platform::Platform;
 use crate::session::{ActivityKind, Session};
 
 use log::debug;
@@ -10,9 +11,9 @@ use volta_fail::Fallible;
 pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
     session.add_event_start(ActivityKind::Node);
 
-    match session.current_platform()? {
+    match Platform::current(session)? {
         Some(platform) => {
-            debug_tool_message("node", &platform.node());
+            debug_tool_message("node", &platform.node);
 
             let image = platform.checkout(session)?;
             let path = image.path()?;

--- a/crates/volta-core/src/run/npm.rs
+++ b/crates/volta-core/src/run/npm.rs
@@ -3,6 +3,7 @@ use std::ffi::OsStr;
 
 use super::{debug_tool_message, intercept_global_installs, CommandArg, ToolCommand};
 use crate::error::ErrorDetails;
+use crate::platform::Platform;
 use crate::session::{ActivityKind, Session};
 
 use log::debug;
@@ -11,7 +12,7 @@ use volta_fail::{throw, Fallible};
 pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
     session.add_event_start(ActivityKind::Npm);
 
-    match session.current_platform()? {
+    match Platform::current(session)? {
         Some(platform) => {
             if intercept_global_installs() {
                 if let CommandArg::GlobalAdd(package) = check_npm_install() {

--- a/crates/volta-core/src/run/npx.rs
+++ b/crates/volta-core/src/run/npx.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 
 use super::{debug_tool_message, ToolCommand};
 use crate::error::ErrorDetails;
+use crate::platform::Platform;
 use crate::session::{ActivityKind, Session};
 use crate::version::parse_version;
 
@@ -11,7 +12,7 @@ use volta_fail::Fallible;
 pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
     session.add_event_start(ActivityKind::Npx);
 
-    match session.current_platform()? {
+    match Platform::current(session)? {
         Some(platform) => {
             let image = platform.checkout(session)?;
 

--- a/crates/volta-core/src/run/yarn.rs
+++ b/crates/volta-core/src/run/yarn.rs
@@ -1,10 +1,9 @@
 use std::env::args_os;
 use std::ffi::OsStr;
-use std::rc::Rc;
 
 use super::{debug_tool_message, intercept_global_installs, CommandArg, ToolCommand};
 use crate::error::ErrorDetails;
-use crate::platform::{PlatformSpec, Source};
+use crate::platform::{Platform, Source};
 use crate::session::{ActivityKind, Session};
 
 use log::debug;
@@ -22,7 +21,7 @@ pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
             }
 
             // Note: If we've gotten this far, we know there is a yarn version set
-            debug_tool_message("yarn", &platform.yarn().unwrap());
+            debug_tool_message("yarn", platform.yarn.as_ref().unwrap());
 
             let image = platform.checkout(session)?;
             let path = image.path()?;
@@ -36,11 +35,11 @@ pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
 }
 
 /// Determine the correct platform (project or default) and check if yarn is set for that platform
-fn get_yarn_platform(session: &mut Session) -> Fallible<Option<Rc<dyn PlatformSpec>>> {
-    match session.current_platform()? {
-        Some(platform) => match platform.yarn() {
+fn get_yarn_platform(session: &mut Session) -> Fallible<Option<Platform>> {
+    match Platform::current(session)? {
+        Some(platform) => match &platform.yarn {
             Some(_) => Ok(Some(platform)),
-            None => match platform.node().source {
+            None => match platform.node.source {
                 Source::Project => Err(ErrorDetails::NoProjectYarn.into()),
                 Source::Default | Source::Binary => Err(ErrorDetails::NoDefaultYarn.into()),
             },

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -4,11 +4,10 @@
 
 use std::fmt::{self, Display, Formatter};
 use std::process::exit;
-use std::rc::Rc;
 
 use crate::event::EventLog;
 use crate::hook::{HookConfig, LazyHookConfig, Publish};
-use crate::platform::{DefaultPlatformSpec, PlatformSpec, ProjectPlatformSpec};
+use crate::platform::PlatformSpec;
 use crate::project::{LazyProject, Project};
 use crate::toolchain::{LazyToolchain, Toolchain};
 
@@ -103,38 +102,13 @@ impl Session {
         self.project.get_mut()
     }
 
-    /// Returns the user's currently active platform, if any
-    ///
-    /// Active platform is determined by first looking at the Project Platform
-    ///
-    /// - If it exists and has a Yarn version, then we use the project platform
-    /// - If it exists but doesn't have a Yarn version, then we merge the two,
-    ///   pulling Yarn from the user default platform, if available
-    /// - If there is no Project platform, then we use the user Default Platform
-    pub fn current_platform(&self) -> Fallible<Option<Rc<dyn PlatformSpec>>> {
-        match self.project_platform()? {
-            Some(platform) => {
-                if platform.yarn.is_none() {
-                    if let Some(default) = self.default_platform()? {
-                        return Ok(Some(platform.merge(default)));
-                    }
-                }
-                Ok(Some(platform))
-            }
-            None => match self.default_platform()? {
-                Some(platform) => Ok(Some(platform)),
-                None => Ok(None),
-            },
-        }
-    }
-
     /// Returns the user's default platform, if any
-    pub fn default_platform(&self) -> Fallible<Option<Rc<DefaultPlatformSpec>>> {
+    pub fn default_platform(&self) -> Fallible<Option<&PlatformSpec>> {
         self.toolchain.get().map(Toolchain::platform)
     }
 
     /// Returns the current project's pinned platform image, if any.
-    pub fn project_platform(&self) -> Fallible<Option<Rc<ProjectPlatformSpec>>> {
+    pub fn project_platform(&self) -> Fallible<Option<&PlatformSpec>> {
         if let Some(ref project) = self.project()? {
             return Ok(project.platform());
         }

--- a/crates/volta-core/src/style.rs
+++ b/crates/volta-core/src/style.rs
@@ -4,7 +4,6 @@ use cfg_if::cfg_if;
 use console::{style, StyledObject};
 use failure::Fail;
 use indicatif::{ProgressBar, ProgressStyle};
-use term_size;
 
 pub const MAX_WIDTH: usize = 100;
 const MAX_PROGRESS_WIDTH: usize = 40;

--- a/crates/volta-core/src/tool/node/resolve.rs
+++ b/crates/volta-core/src/tool/node/resolve.rs
@@ -20,7 +20,6 @@ use cfg_if::cfg_if;
 use fs_utils::ensure_containing_dir_exists;
 use headers_011::Headers011;
 use log::debug;
-use reqwest;
 use reqwest::hyper_011::header::{CacheControl, CacheDirective, Expires, HttpDate};
 use semver::{Version, VersionReq};
 use volta_fail::{Fallible, ResultExt};

--- a/crates/volta-core/src/tool/package/install.rs
+++ b/crates/volta-core/src/tool/package/install.rs
@@ -15,7 +15,7 @@ use crate::error::ErrorDetails;
 use crate::fs::set_executable;
 use crate::layout::volta_home;
 use crate::manifest::BinManifest;
-use crate::platform::{BinaryPlatformSpec, Image, PlatformSpec};
+use crate::platform::{Image, PlatformSpec};
 use crate::session::Session;
 use crate::shim;
 use crate::style::{progress_spinner, tool_version};
@@ -66,7 +66,7 @@ pub struct PackageConfig {
     /// The package version
     pub version: Version,
     /// The platform used to install this package
-    pub platform: BinaryPlatformSpec,
+    pub platform: PlatformSpec,
     /// The binaries installed by this package
     pub bins: Vec<String>,
 }
@@ -104,7 +104,7 @@ pub struct BinConfig {
     /// The relative path of the binary in the installed package
     pub path: String,
     /// The platform used to install this binary
-    pub platform: BinaryPlatformSpec,
+    pub platform: PlatformSpec,
     /// The loader information for the script, if any
     pub loader: Option<BinLoader>,
 }
@@ -130,12 +130,12 @@ pub fn install(
     let display = tool_version(name, version);
 
     let engine = determine_engine(&package_dir, &display)?;
-    let platform = BinaryPlatformSpec {
+    let platform = PlatformSpec {
         node: node::resolve(engine, session)?,
         npm: None,
         yarn: None,
     };
-    let image = platform.checkout(session)?;
+    let image = platform.as_binary().checkout(session)?;
 
     install_dependencies(&package_dir, image, &display)?;
     write_configs(name, version, &platform, &bin_map)?;
@@ -165,7 +165,7 @@ fn determine_engine(package_dir: &Path, display: &str) -> Fallible<VersionSpec> 
 fn write_configs(
     name: &str,
     version: &Version,
-    platform: &BinaryPlatformSpec,
+    platform: &PlatformSpec,
     bins: &HashMap<String, String>,
 ) -> Fallible<()> {
     super::serial::RawPackageConfig::from(PackageConfig {

--- a/crates/volta-core/src/tool/package/serial.rs
+++ b/crates/volta-core/src/tool/package/serial.rs
@@ -149,7 +149,7 @@ impl TryFrom<RawPackageConfig> for PackageConfig {
     fn try_from(raw: RawPackageConfig) -> Fallible<PackageConfig> {
         let platform = raw
             .platform
-            .into_binary_platform()
+            .into_platform()
             .ok_or(ErrorDetails::NoBinPlatform {
                 binary: raw.name.clone(),
             })?;
@@ -177,7 +177,7 @@ impl From<PackageConfig> for RawPackageConfig {
         RawPackageConfig {
             name: full.name,
             version: full.version,
-            platform: full.platform.to_serial(),
+            platform: toolchain::serial::Platform::of(&full.platform),
             bins: full.bins,
         }
     }
@@ -239,7 +239,7 @@ impl TryFrom<RawBinConfig> for BinConfig {
     fn try_from(raw: RawBinConfig) -> Fallible<BinConfig> {
         let platform = raw
             .platform
-            .into_binary_platform()
+            .into_platform()
             .ok_or(ErrorDetails::NoBinPlatform {
                 binary: raw.name.clone(),
             })?;
@@ -261,7 +261,7 @@ impl From<BinConfig> for RawBinConfig {
             package: full.package,
             version: full.version,
             path: full.path,
-            platform: full.platform.to_serial(),
+            platform: toolchain::serial::Platform::of(&full.platform),
             loader: full.loader.map(Into::into),
         }
     }

--- a/crates/volta-core/src/toolchain/serial.rs
+++ b/crates/volta-core/src/toolchain/serial.rs
@@ -3,7 +3,6 @@ use crate::platform::PlatformSpec;
 use crate::version::{option_version_serde, version_serde};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use serde_json;
 use volta_fail::{Fallible, ResultExt};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq)]

--- a/crates/volta-fail-derive/src/lib.rs
+++ b/crates/volta-fail-derive/src/lib.rs
@@ -2,7 +2,6 @@
 extern crate proc_macro;
 
 use quote::*;
-use syn;
 
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};

--- a/crates/volta-layout-macro/src/ast.rs
+++ b/crates/volta-layout-macro/src/ast.rs
@@ -1,7 +1,6 @@
 use crate::ir::{Entry, Ir};
 use proc_macro2::TokenStream;
 use std::collections::HashMap;
-use syn;
 use syn::parse::{self, Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::{braced, Attribute, Ident, LitStr, Token, Visibility};

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -296,11 +296,11 @@ impl Command for List {
 
         let toolchain = match self.subcommand() {
             // For no subcommand, show the user's current toolchain
-            None => Toolchain::active(project, &default_platform)?,
-            Some(Subcommand::All) => Toolchain::all(project, &default_platform)?,
-            Some(Subcommand::Node) => Toolchain::node(project, &default_platform, &filter)?,
-            Some(Subcommand::Npm) => Toolchain::npm(project, &default_platform, &filter)?,
-            Some(Subcommand::Yarn) => Toolchain::yarn(project, &default_platform, &filter)?,
+            None => Toolchain::active(project, default_platform)?,
+            Some(Subcommand::All) => Toolchain::all(project, default_platform)?,
+            Some(Subcommand::Node) => Toolchain::node(project, default_platform, &filter)?,
+            Some(Subcommand::Npm) => Toolchain::npm(project, default_platform, &filter)?,
+            Some(Subcommand::Yarn) => Toolchain::yarn(project, default_platform, &filter)?,
             Some(Subcommand::PackageOrTool { name }) => {
                 Toolchain::package_or_tool(&name, project, &filter)?
             }

--- a/src/command/list/toolchain.rs
+++ b/src/command/list/toolchain.rs
@@ -52,9 +52,9 @@ impl Lookup {
         }
     }
 
-    fn version_source<'p>(
+    fn version_source(
         self,
-        project: Option<&'p Project>,
+        project: Option<&Project>,
         default_platform: Option<&PlatformSpec>,
         version: &Version,
     ) -> Source {

--- a/src/command/which.rs
+++ b/src/command/which.rs
@@ -5,7 +5,7 @@ use structopt::StructOpt;
 use which::which_in;
 
 use volta_core::error::ErrorDetails;
-use volta_core::platform::System;
+use volta_core::platform::{Platform, System};
 use volta_core::run::binary::DefaultBinary;
 use volta_core::session::{ActivityKind, Session};
 use volta_fail::{ExitCode, Fallible, ResultExt};
@@ -54,8 +54,7 @@ impl Command for Which {
         // Treat any error with obtaining the current platform image as if the image doesn't exist
         // However, errors in obtaining the current working directory or the System path should
         // still be treated as errors.
-        let path = match session
-            .current_platform()
+        let path = match Platform::current(session)
             .unwrap_or(None)
             .and_then(|platform| platform.checkout(session).ok())
             .and_then(|image| image.path().ok())


### PR DESCRIPTION
Info
-----
In #626, we updated the model of `PlatformSpec` to support sources for individual Tools, instead of an overall source for the `PlatformSpec` as a whole. In order to make things ergonomic for both producers and consumers of `PlatformSpec` types, we used a trait and different implementations of that trait. However, while this solved the problem, work on `volta run` revealed some lingering ergonomic issues.

The core issue is that our model had 2 concepts combined into 1: `PlatformSpec` represents _either_ a single source of truth (e.g. from `package.json`) _or_ a ready-to-use merged platform (e.g. from `Session::current_platform`). While these two are _related_ (and often one comes directly from the other), they are not the _same_. Trying to support both concepts at the same time lead to a lot of effective duplication because we had `PlatformSpec` implementations that represented single sources of truth _and_ those that represented merged platforms. Furthermore, there is nothing _inherently_ different between `ProjectPlatformSpec` and `DefaultPlatformSpec`, the difference is _where the data came from_.

The core of this refactor is splitting these concepts into two separate structs: `PlatformSpec`, which represents the data loaded from a config file (whether Default, Project or Binary is immaterial) and `Platform`, which represents a real platform (with sources) derived from one or more `PlatformSpec`s. This separation allows us to greatly simplify the creation of `PlatformSpec` instances and then combine them as needed into a single `Platform` (which can then be converted into an `Image` for use by `Platform::checkout`).

Technical Notes
-----
* Previously, the data from the appropriate `PlatformSpec` was `clone`d during the `checkout` operation, as a result of `PlatformSpec` not being owned. Now the `clone` happens when converting form a `PlatformSpec` to a `Platform`, which is then consumed during `checkout`, so we still have the same amount of `clone` operations.
* In some internal use-cases, we can actually construct a `Platform` directly, avoiding the need to `clone` data at all.
* Separating `PlatformSpec` from `Platform` allowed the removal of `Rc<PlatformSpec>` everywhere, instead relying on normal references.
* This also allowed the `set_active_{node,npm,yarn}` methods to be simplified, since we now have full ownership of the `PlatformSpec` and can directly apply changes.
* `Session::current_platform` was moved into an associated function `Platform::current`, which collects the data it needs from `Session` to build a `Platform` object. This will improve the implementation of `volta run`, which involves data coming from the command line, not from the `Session` object.
* This change results in a small reduction in binary size (~5-10 KB)

Tested
-----
* No functionality should change, this is purely an ergonomic refactor.
* All existing tests pass.