### PR TITLE
Fix clippy warnings about nth(0)

### DIFF
--- a/crates/test-support/src/matchers.rs
+++ b/crates/test-support/src/matchers.rs
@@ -592,7 +592,7 @@ fn find_mismatch<'a>(expected: &'a Value, actual: &'a Value) -> Option<(&'a Valu
             l.values()
                 .zip(r.values())
                 .filter_map(|(l, r)| find_mismatch(l, r))
-                .nth(0)
+                .next()
         }
         (&Null, &Null) => None,
         // magic string literal "{...}" acts as wildcard for any sub-JSON

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -157,7 +157,7 @@ impl fmt::Debug for ToolCommand {
 }
 
 fn get_tool_name(args: &mut ArgsOs) -> Fallible<OsString> {
-    args.nth(0)
+    args.next()
         .and_then(|arg0| Path::new(&arg0).file_name().map(tool_name_from_file_name))
         .ok_or_else(|| ErrorDetails::CouldNotDetermineTool.into())
 }


### PR DESCRIPTION
With the latest `clippy` release, there are now warnings about calling `nth(0)` on an iterator, which is equivalent to calling `next()`.

Updated the couple of locations where we called `nth(0)` to use `next()` instead.