### PR TITLE
Support armv7l architecture (for Raspberry Pi)

### DIFF
--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -43,6 +43,9 @@ cfg_if! {
     } else if #[cfg(target_arch = "aarch64")] {
         /// The system architecture component of a Node distro's name.
         pub const NODE_DISTRO_ARCH: &str = "arm64";
+    } else if #[cfg(target_arch = "arm")] {
+        /// The system architecture component of a Node distro's name.
+        pub const NODE_DISTRO_ARCH: &str = "armv7l";
     } else {
         compile_error!("Unsupported target_arch variant (expected 'x86', 'x64', or 'aarch64').");
     }


### PR DESCRIPTION
I wanted to run some node scripts on my raspberry pi so I got this working tonight.

The Pi 3b is on armv7l arch:
```
$ uname -a
Linux raspberrypi 4.19.97-v7+ #1294 SMP Thu Jan 30 13:15:58 GMT 2020 armv7l GNU/Linux
```
I had to compile using nightly, and that worked fine
```
$ ./dev/unix/volta-install.sh --release
```

Then everything else just worked
```
$ volta install node
success: installed and set node@12.16.2 (with npm@6.14.4) as default

$ node --version
v12.16.2

$ node  -e "console.log(process.platform, process.arch)"
linux arm

$ volta install yarn
success: installed and set yarn@1.22.4 as default

$ yarn --version
1.22.4

$ volta install cowsay
success: installed cowsay@1.4.0 with executables: cowthink, cowsay

$ cowsay ⚡️⚡️⚡️
 ________
< ⚡️⚡️⚡️ >
 --------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||
```

## Testing

The unit tests pass ✅
```
cargo test --package volta-core --package volta-fail --package archive --package volta-fail-derive --package progress-read --package volta-layout --package volta-layout-macro -- --test-threads=1
```

I was not able to run the other tests. Both of these are hanging on the build step before running the tests. Not sure what is happening there
```
cargo test --features mock-network

cargo test --test smoke --features smoke-tests -- --test-threads 1
```