### PR TITLE
[run] [Large] Implement `volta run` command

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -193,6 +193,9 @@ pub enum ErrorDetails {
         command: String,
     },
 
+    /// Thrown when Yarn is not set at the command-line
+    NoCommandLineYarn,
+
     /// Thrown when there is no Node version matching a requested semver specifier.
     NodeVersionNotFound {
         matching: String,
@@ -818,6 +821,12 @@ Please uninstall and re-install the package that provides that executable.",
 Please ensure you have a Node version selected with `volta {} node` (see `volta help {0}` for more info).",
                 command
             ),
+            ErrorDetails::NoCommandLineYarn => write!(
+                f,
+                "No Yarn version specified.
+
+Use `volta run --yarn` to select a version (see `volta help run` for more info)."
+            ),
             ErrorDetails::NodeVersionNotFound { matching } => write!(
                 f,
                 r#"Could not find Node version matching "{}" in the version registry.
@@ -1436,6 +1445,7 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::InvalidToolName { .. } => ExitCode::InvalidArguments,
             ErrorDetails::NoBinPlatform { .. } => ExitCode::ExecutionFailure,
             ErrorDetails::NoBundledNpm { .. } => ExitCode::ConfigurationError,
+            ErrorDetails::NoCommandLineYarn => ExitCode::ConfigurationError,
             ErrorDetails::NodeVersionNotFound { .. } => ExitCode::NoVersionMatch,
             ErrorDetails::NoGlobalInstalls { .. } => ExitCode::InvalidArguments,
             ErrorDetails::NoHomeEnvironmentVar => ExitCode::EnvironmentError,

--- a/crates/volta-core/src/platform/mod.rs
+++ b/crates/volta-core/src/platform/mod.rs
@@ -19,6 +19,7 @@ pub use system::System;
 
 /// The source with which a version is associated
 #[derive(Clone, Copy)]
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub enum Source {
     /// Represents a version from the user default platform
     Default,
@@ -113,6 +114,7 @@ where
 }
 
 /// Represents 3 possible states: Having a value, not having a value, and inheriting a value
+#[cfg_attr(test, derive(Eq, PartialEq, Debug))]
 pub enum InheritOption<T> {
     Some(T),
     None,

--- a/crates/volta-core/src/platform/mod.rs
+++ b/crates/volta-core/src/platform/mod.rs
@@ -18,7 +18,7 @@ pub use image::Image;
 pub use system::System;
 
 /// The source with which a version is associated
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy)]
 pub enum Source {
     /// Represents a version from the user default platform
     Default,
@@ -28,6 +28,9 @@ pub enum Source {
 
     /// Represents a version from a pinned Binary platform
     Binary,
+
+    /// Represents a version from the command line (via `volta run`)
+    CommandLine,
 }
 
 impl fmt::Display for Source {
@@ -36,6 +39,7 @@ impl fmt::Display for Source {
             Source::Default => write!(f, "default"),
             Source::Project => write!(f, "project"),
             Source::Binary => write!(f, "binary"),
+            Source::CommandLine => write!(f, "command-line"),
         }
     }
 }
@@ -64,6 +68,13 @@ impl<T> Sourced<T> {
         Sourced {
             value,
             source: Source::Binary,
+        }
+    }
+
+    pub fn with_command_line(value: T) -> Self {
+        Sourced {
+            value,
+            source: Source::CommandLine,
         }
     }
 }
@@ -101,6 +112,48 @@ where
     }
 }
 
+/// Represents 3 possible states: Having a value, not having a value, and inheriting a value
+pub enum InheritOption<T> {
+    Some(T),
+    None,
+    Inherit,
+}
+
+impl<T> InheritOption<T> {
+    /// Applies a function to the contained value (if any)
+    pub fn map<U, F>(self, f: F) -> InheritOption<U>
+    where
+        F: FnOnce(T) -> U,
+    {
+        match self {
+            InheritOption::Some(value) => InheritOption::Some(f(value)),
+            InheritOption::None => InheritOption::None,
+            InheritOption::Inherit => InheritOption::Inherit,
+        }
+    }
+
+    /// Converts the `InheritOption` into a regular `Option` by inheriting from the provided value if needed
+    pub fn inherit(self, other: Option<T>) -> Option<T> {
+        match self {
+            InheritOption::Some(value) => Some(value),
+            InheritOption::None => None,
+            InheritOption::Inherit => other,
+        }
+    }
+}
+
+impl<T> From<InheritOption<T>> for Option<T> {
+    fn from(base: InheritOption<T>) -> Option<T> {
+        base.inherit(None)
+    }
+}
+
+impl<T> Default for InheritOption<T> {
+    fn default() -> Self {
+        InheritOption::Inherit
+    }
+}
+
 #[derive(Clone, PartialOrd, Ord, PartialEq, Eq)]
 /// Represents the specification of a single Platform, regardless of the source
 pub struct PlatformSpec {
@@ -134,6 +187,39 @@ impl PlatformSpec {
             node: Sourced::with_binary(self.node.clone()),
             npm: self.npm.clone().map(Sourced::with_binary),
             yarn: self.yarn.clone().map(Sourced::with_binary),
+        }
+    }
+}
+
+/// Represents a (maybe) platform with values from the command line
+#[derive(Default)]
+pub struct CliPlatform {
+    pub node: Option<Version>,
+    pub npm: InheritOption<Version>,
+    pub yarn: InheritOption<Version>,
+}
+
+impl CliPlatform {
+    /// Merges the `CliPlatform` with a `Platform`, inheriting from the base where needed
+    pub fn merge(self, base: Platform) -> Platform {
+        Platform {
+            node: self.node.map_or(base.node, Sourced::with_command_line),
+            npm: self.npm.map(Sourced::with_command_line).inherit(base.npm),
+            yarn: self.yarn.map(Sourced::with_command_line).inherit(base.yarn),
+        }
+    }
+}
+
+impl From<CliPlatform> for Option<Platform> {
+    /// Converts the `CliPlatform` into a possible Platform without a base from which to inherit
+    fn from(base: CliPlatform) -> Option<Platform> {
+        match base.node {
+            None => None,
+            Some(node) => Some(Platform {
+                node: Sourced::with_command_line(node),
+                npm: base.npm.map(Sourced::with_command_line).into(),
+                yarn: base.yarn.map(Sourced::with_command_line).into(),
+            }),
         }
     }
 }
@@ -183,6 +269,14 @@ impl Platform {
                 Some(platform) => Ok(Some(platform.as_default())),
                 None => Ok(None),
             },
+        }
+    }
+
+    /// Returns the platform created by merging a `CliPartialPlatform` with the currently active platform
+    pub fn with_cli(cli: CliPlatform, session: &mut Session) -> Fallible<Option<Self>> {
+        match Self::current(session)? {
+            Some(current) => Ok(Some(cli.merge(current))),
+            None => Ok(cli.into()),
         }
     }
 

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -8,7 +8,7 @@ use std::process::{Command, ExitStatus, Output};
 
 use crate::command::create_command;
 use crate::error::ErrorDetails;
-use crate::platform::{Sourced, System};
+use crate::platform::{CliPlatform, Sourced, System};
 use crate::session::Session;
 use crate::signal::pass_control_to_shim;
 use crate::style::tool_version;
@@ -24,18 +24,28 @@ pub mod yarn;
 const VOLTA_BYPASS: &str = "VOLTA_BYPASS";
 const UNSAFE_GLOBAL: &str = "VOLTA_UNSAFE_GLOBAL";
 
-/// Distinguish global `add` commands in npm or yarn from all others.
-enum CommandArg {
-    /// The command is a *global* add command.
-    GlobalAdd(Option<OsString>),
-    /// The command is a local, i.e. non-global, add command.
-    NotGlobalAdd,
-}
-
-pub fn execute_tool(session: &mut Session) -> Fallible<ExitStatus> {
+pub fn execute_shim(session: &mut Session) -> Fallible<ExitStatus> {
     let mut args = args_os();
     let exe = get_tool_name(&mut args)?;
+    let envs: Vec<(String, String)> = Vec::new();
 
+    execute_tool(&exe, args, envs, CliPlatform::default(), session)
+}
+
+pub fn execute_tool<A, S, E, K, V>(
+    exe: &OsStr,
+    args: A,
+    envs: E,
+    cli: CliPlatform,
+    session: &mut Session,
+) -> Fallible<ExitStatus>
+where
+    A: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+    E: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
     let mut command = if env::var_os(VOLTA_BYPASS).is_some() {
         ToolCommand::passthrough(
             &exe,
@@ -46,15 +56,16 @@ pub fn execute_tool(session: &mut Session) -> Fallible<ExitStatus> {
     } else {
         match exe.to_str() {
             Some("volta-shim") => throw!(ErrorDetails::RunShimDirectly),
-            Some("node") => node::command(session)?,
-            Some("npm") => npm::command(session)?,
-            Some("npx") => npx::command(session)?,
-            Some("yarn") => yarn::command(session)?,
-            _ => binary::command(&exe, session)?,
+            Some("node") => node::command(cli, session)?,
+            Some("npm") => npm::command(cli, session)?,
+            Some("npx") => npx::command(cli, session)?,
+            Some("yarn") => yarn::command(cli, session)?,
+            _ => binary::command(exe, cli, session)?,
         }
     };
 
     command.args(args);
+    command.envs(envs);
 
     pass_control_to_shim();
     command.status()
@@ -129,6 +140,17 @@ impl ToolCommand {
         self
     }
 
+    /// Adds or updates multiple environment variables for the Command
+    pub(crate) fn envs<E, K, V>(&mut self, envs: E) -> &mut ToolCommand
+    where
+        E: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.command.envs(envs);
+        self
+    }
+
     /// Set the current working directory for the Command
     pub(crate) fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut ToolCommand {
         self.command.current_dir(dir);
@@ -189,6 +211,14 @@ fn command_with_path(exe: &OsStr, path_var: &OsStr) -> Command {
 /// Setting the VOLTA_UNSAFE_GLOBAL environment variable will disable interception of global installs
 fn intercept_global_installs() -> bool {
     env::var_os(UNSAFE_GLOBAL).is_none()
+}
+
+/// Distinguish global `add` commands in npm or yarn from all others.
+enum CommandArg {
+    /// The command is a *global* add command.
+    GlobalAdd(Option<OsString>),
+    /// The command is a local, i.e. non-global, add command.
+    NotGlobalAdd,
 }
 
 /// Write the tool version and source to the debug log

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -3,6 +3,7 @@
 use std::env::{self, args_os, ArgsOs};
 use std::ffi::{OsStr, OsString};
 use std::fmt;
+use std::iter::empty;
 use std::path::Path;
 use std::process::{Command, ExitStatus, Output};
 
@@ -27,7 +28,7 @@ const UNSAFE_GLOBAL: &str = "VOLTA_UNSAFE_GLOBAL";
 pub fn execute_shim(session: &mut Session) -> Fallible<ExitStatus> {
     let mut args = args_os();
     let exe = get_tool_name(&mut args)?;
-    let envs: Vec<(String, String)> = Vec::new();
+    let envs = empty::<(String, String)>();
 
     execute_tool(&exe, args, envs, CliPlatform::default(), session)
 }

--- a/crates/volta-core/src/run/node.rs
+++ b/crates/volta-core/src/run/node.rs
@@ -2,16 +2,16 @@ use std::ffi::OsStr;
 
 use super::{debug_tool_message, ToolCommand};
 use crate::error::ErrorDetails;
-use crate::platform::Platform;
+use crate::platform::{CliPlatform, Platform};
 use crate::session::{ActivityKind, Session};
 
 use log::debug;
 use volta_fail::Fallible;
 
-pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
+pub(crate) fn command(cli: CliPlatform, session: &mut Session) -> Fallible<ToolCommand> {
     session.add_event_start(ActivityKind::Node);
 
-    match Platform::current(session)? {
+    match Platform::with_cli(cli, session)? {
         Some(platform) => {
             debug_tool_message("node", &platform.node);
 

--- a/crates/volta-core/src/run/npm.rs
+++ b/crates/volta-core/src/run/npm.rs
@@ -3,16 +3,16 @@ use std::ffi::OsStr;
 
 use super::{debug_tool_message, intercept_global_installs, CommandArg, ToolCommand};
 use crate::error::ErrorDetails;
-use crate::platform::Platform;
+use crate::platform::{CliPlatform, Platform};
 use crate::session::{ActivityKind, Session};
 
 use log::debug;
 use volta_fail::{throw, Fallible};
 
-pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
+pub(crate) fn command(cli: CliPlatform, session: &mut Session) -> Fallible<ToolCommand> {
     session.add_event_start(ActivityKind::Npm);
 
-    match Platform::current(session)? {
+    match Platform::with_cli(cli, session)? {
         Some(platform) => {
             if intercept_global_installs() {
                 if let CommandArg::GlobalAdd(package) = check_npm_install() {

--- a/crates/volta-core/src/run/npx.rs
+++ b/crates/volta-core/src/run/npx.rs
@@ -2,17 +2,17 @@ use std::ffi::OsStr;
 
 use super::{debug_tool_message, ToolCommand};
 use crate::error::ErrorDetails;
-use crate::platform::Platform;
+use crate::platform::{CliPlatform, Platform};
 use crate::session::{ActivityKind, Session};
 use crate::version::parse_version;
 
 use log::debug;
 use volta_fail::Fallible;
 
-pub(crate) fn command(session: &mut Session) -> Fallible<ToolCommand> {
+pub(crate) fn command(cli: CliPlatform, session: &mut Session) -> Fallible<ToolCommand> {
     session.add_event_start(ActivityKind::Npx);
 
-    match Platform::current(session)? {
+    match Platform::with_cli(cli, session)? {
         Some(platform) => {
             let image = platform.checkout(session)?;
 

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -36,6 +36,7 @@ pub enum ActivityKind {
     Completions,
     Which,
     Setup,
+    Run,
 }
 
 impl Display for ActivityKind {
@@ -61,6 +62,7 @@ impl Display for ActivityKind {
             ActivityKind::Shim => "shim",
             ActivityKind::Completions => "completions",
             ActivityKind::Which => "which",
+            ActivityKind::Run => "run",
         };
         f.write_str(s)
     }

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -7,11 +7,11 @@ use crate::version::VersionSpec;
 use log::{debug, info};
 use volta_fail::Fallible;
 
-mod node;
-mod npm;
-mod package;
+pub mod node;
+pub mod npm;
+pub mod package;
 mod serial;
-mod yarn;
+pub mod yarn;
 
 pub use node::{
     load_default_npm_version, Node, NODE_DISTRO_ARCH, NODE_DISTRO_EXTENSION, NODE_DISTRO_OS,

--- a/crates/volta-core/src/tool/package/fetch.rs
+++ b/crates/volta-core/src/tool/package/fetch.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use crate::error::ErrorDetails;
 use crate::fs::{create_staging_dir, ensure_dir_does_not_exist, read_dir_eager, read_file};
 use crate::layout::volta_home;
+use crate::platform::CliPlatform;
 use crate::run::{self, ToolCommand};
 use crate::session::Session;
 use crate::style::{progress_bar, progress_spinner, tool_version};
@@ -163,7 +164,7 @@ fn npm_pack_command_for(
     session: &mut Session,
     current_dir: &Path,
 ) -> Fallible<ToolCommand> {
-    let mut command = run::npm::command(session)?;
+    let mut command = run::npm::command(CliPlatform::default(), session)?;
     command.arg("pack");
     command.arg("--no-update-notifier");
     command.arg(format!("{}@{}", name, version));

--- a/crates/volta-core/src/tool/package/resolve.rs
+++ b/crates/volta-core/src/tool/package/resolve.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use crate::error::ErrorDetails;
 use crate::hook::ToolHooks;
+use crate::platform::CliPlatform;
 use crate::run::{self, ToolCommand};
 use crate::session::Session;
 use crate::style::{progress_spinner, tool_version};
@@ -177,7 +178,7 @@ fn npm_view_query(name: &str, version: &str, session: &mut Session) -> Fallible<
 
 // build a command to run `npm view` with json output
 fn npm_view_command_for(name: &str, version: &str, session: &mut Session) -> Fallible<ToolCommand> {
-    let mut command = run::npm::command(session)?;
+    let mut command = run::npm::command(CliPlatform::default(), session)?;
     command.arg("view");
     command.arg("--json");
     command.arg(format!("{}@{}", name, version));

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -121,6 +121,12 @@ otherwise, they will be written to `stdout`.
     /// Enables Volta for the current user / shell
     #[structopt(name = "setup", author = "", version = "")]
     Setup(command::Setup),
+
+    /// Run a command with custom Node and/or Yarn versions
+    #[structopt(name = "run", author = "", version = "")]
+    #[structopt(raw(setting = "structopt::clap::AppSettings::AllowLeadingHyphen"))]
+    #[structopt(raw(setting = "structopt::clap::AppSettings::TrailingVarArg"))]
+    Run(command::Run),
 }
 
 impl Subcommand {
@@ -135,6 +141,7 @@ impl Subcommand {
             Subcommand::Which(which) => which.run(session),
             Subcommand::Use(r#use) => r#use.run(session),
             Subcommand::Setup(setup) => setup.run(session),
+            Subcommand::Run(run) => run.run(session),
         }
     }
 }

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod fetch;
 pub(crate) mod install;
 pub(crate) mod list;
 pub(crate) mod pin;
+pub(crate) mod run;
 pub(crate) mod setup;
 pub(crate) mod uninstall;
 pub(crate) mod r#use;
@@ -15,6 +16,7 @@ pub(crate) use install::Install;
 pub(crate) use list::List;
 pub(crate) use pin::Pin;
 pub(crate) use r#use::Use;
+pub(crate) use run::Run;
 pub(crate) use setup::Setup;
 pub(crate) use uninstall::Uninstall;
 

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -69,18 +69,18 @@ impl Command for Run {
 /// We ignore any setting that doesn't have a value associated with it
 /// We also ignore the PATH environment variable as that is set when running a command
 fn parse_envs(cli_values: Vec<String>) -> impl IntoIterator<Item = (String, String)> {
-    cli_values.into_iter().filter_map(|mut entry| {
-        entry.find('=').and_then(|index| {
-            // After `split_off`, entry will contain only the key
-            let value = entry.split_off(index);
+    cli_values.into_iter().filter_map(|entry| {
+        let mut key_value = entry.splitn(2, '=');
 
-            if entry.eq_ignore_ascii_case("PATH") {
+        match (key_value.next(), key_value.next()) {
+            (None, _) => None,
+            (Some(_), None) => None,
+            (Some(key), _) if key.eq_ignore_ascii_case("PATH") => {
                 debug!("Skipping PATH environment variable as it will be overwritten to execute the command");
                 None
-            } else {
-                Some((entry, value))
             }
-        })
+            (Some(key), Some(value)) => Some((key.into(), value.into())),
+        }
     })
 }
 

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 
 use crate::command::Command;
 use crate::common::{Error, IntoResult};
-use log::debug;
+use log::warn;
 use structopt::StructOpt;
 use volta_core::error::report_error;
 use volta_core::platform::{CliPlatform, InheritOption};
@@ -115,7 +115,7 @@ impl Run {
                 (None, _) => None,
                 (Some(_), None) => None,
                 (Some(key), _) if key.eq_ignore_ascii_case("PATH") => {
-                    debug!("Skipping PATH environment variable as it will be overwritten to execute the command");
+                    warn!("Ignoring {} environment variable as it will be overwritten when executing the command", key);
                     None
                 }
                 (Some(key), Some(value)) => Some((key, value)),

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -1,0 +1,111 @@
+use std::ffi::OsString;
+
+use crate::command::Command;
+use crate::common::{Error, IntoResult};
+use log::debug;
+use structopt::StructOpt;
+use volta_core::error::report_error;
+use volta_core::platform::{CliPlatform, InheritOption};
+use volta_core::run::execute_tool;
+use volta_core::session::{ActivityKind, Session};
+use volta_core::tool::{node, yarn};
+use volta_fail::{ExitCode, Fallible};
+
+#[derive(Debug, StructOpt)]
+pub(crate) struct Run {
+    /// Set the custom Node version
+    #[structopt(long = "node", value_name = "version")]
+    node: Option<String>,
+
+    /// Set the custom Yarn version
+    #[structopt(long = "yarn", value_name = "version", conflicts_with = "no_yarn")]
+    yarn: Option<String>,
+
+    /// Disables Yarn
+    #[structopt(long = "no-yarn", conflicts_with = "yarn")]
+    no_yarn: bool,
+
+    /// Set an environment variable (can be used multiple times)
+    #[structopt(long = "env", value_name = "NAME=value", raw(number_of_values = "1"))]
+    envs: Vec<String>,
+
+    #[structopt(parse(from_os_str))]
+    /// The command to run
+    command: OsString,
+
+    #[structopt(parse(from_os_str))]
+    /// Arguments to pass to the command
+    args: Vec<OsString>,
+}
+
+impl Command for Run {
+    fn run(self, session: &mut Session) -> Fallible<ExitCode> {
+        session.add_event_start(ActivityKind::Run);
+
+        let envs = parse_envs(self.envs);
+        let platform = parse_platform(self.node, self.yarn, self.no_yarn, session)?;
+
+        match execute_tool(&self.command, self.args, envs, platform, session).into_result() {
+            Ok(()) => {
+                session.add_event_end(ActivityKind::Run, ExitCode::Success);
+                Ok(ExitCode::Success)
+            }
+            Err(Error::Tool(code)) => {
+                session.add_event_tool_end(ActivityKind::Run, code);
+                Ok(ExitCode::ExecutionFailure)
+            }
+            Err(Error::Volta(err)) => {
+                report_error(env!("CARGO_PKG_VERSION"), &err);
+                session.add_event_error(ActivityKind::Run, &err);
+                session.add_event_end(ActivityKind::Run, err.exit_code());
+                Ok(err.exit_code())
+            }
+        }
+    }
+}
+
+/// Convert the environment variable settings passed to the command line into (Key, Value) pairs
+///
+/// We ignore any setting that doesn't have a value associated with it
+/// We also ignore the PATH environment variable as that is set when running a command
+fn parse_envs(cli_values: Vec<String>) -> impl IntoIterator<Item = (String, String)> {
+    cli_values.into_iter().filter_map(|mut entry| {
+        entry.find('=').and_then(|index| {
+            // After `split_off`, entry will contain only the key
+            let value = entry.split_off(index);
+
+            if entry.eq_ignore_ascii_case("PATH") {
+                debug!("Skipping PATH environment variable as it will be overwritten to execute the command");
+                None
+            } else {
+                Some((entry, value))
+            }
+        })
+    })
+}
+
+/// Builds a CliPlatform from the provided cli options
+///
+/// Will resolve a semver / tag version if necessary
+fn parse_platform(
+    node: Option<String>,
+    yarn: Option<String>,
+    no_yarn: bool,
+    session: &mut Session,
+) -> Fallible<CliPlatform> {
+    let node = node
+        .map(|version| node::resolve(version.parse()?, session))
+        .transpose()?;
+
+    let yarn = match (no_yarn, yarn) {
+        (true, _) => InheritOption::None,
+        (false, None) => InheritOption::Inherit,
+        (false, Some(version)) => InheritOption::Some(yarn::resolve(version.parse()?, session)?),
+    };
+
+    Ok(CliPlatform {
+        node,
+        npm: InheritOption::Inherit,
+        yarn,
+    })
+}

--- a/src/volta-shim.rs
+++ b/src/volta-shim.rs
@@ -3,7 +3,7 @@ mod common;
 use common::{ensure_layout, Error, IntoResult};
 use volta_core::error::report_error;
 use volta_core::log::{LogContext, LogVerbosity, Logger};
-use volta_core::run::execute_tool;
+use volta_core::run::execute_shim;
 use volta_core::session::{ActivityKind, Session};
 use volta_core::signal::setup_signal_handler;
 use volta_fail::ExitCode;
@@ -16,7 +16,7 @@ pub fn main() {
     let mut session = Session::init();
     session.add_event_start(ActivityKind::Tool);
 
-    let result = ensure_layout().and_then(|()| execute_tool(&mut session).into_result());
+    let result = ensure_layout().and_then(|()| execute_shim(&mut session).into_result());
     match result {
         Ok(()) => {
             session.add_event_end(ActivityKind::Tool, ExitCode::Success);

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -14,6 +14,7 @@ cfg_if! {
         mod volta_bypass;
         mod volta_install;
         mod volta_pin;
+        mod volta_run;
         mod volta_uninstall;
     }
 }

--- a/tests/acceptance/volta_run.rs
+++ b/tests/acceptance/volta_run.rs
@@ -223,21 +223,6 @@ fn inherited_node() {
 }
 
 #[test]
-fn no_node() {
-    let s = sandbox()
-        .node_available_versions(NODE_VERSION_INFO)
-        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
-        .build();
-
-    assert_that!(
-        s.volta("run node --version"),
-        execs()
-            .with_status(ExitCode::ConfigurationError as i32)
-            .with_stderr_contains("[..]Node is not available.")
-    );
-}
-
-#[test]
 fn command_line_npm() {
     let s = sandbox()
         .node_available_versions(NODE_VERSION_INFO)

--- a/tests/acceptance/volta_run.rs
+++ b/tests/acceptance/volta_run.rs
@@ -1,0 +1,350 @@
+use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, NpmFixture, YarnFixture};
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+use volta_fail::ExitCode;
+
+fn package_json_with_pinned_node(node: &str) -> String {
+    format!(
+        r#"{{
+  "name": "test-package",
+  "volta": {{
+    "node": "{}"
+  }}
+}}"#,
+        node
+    )
+}
+
+fn package_json_with_pinned_node_npm(node: &str, npm: &str) -> String {
+    format!(
+        r#"{{
+  "name": "test-package",
+  "volta": {{
+    "node": "{}",
+    "npm": "{}"
+  }}
+}}"#,
+        node, npm
+    )
+}
+
+fn package_json_with_pinned_node_yarn(node_version: &str, yarn_version: &str) -> String {
+    format!(
+        r#"{{
+  "name": "test-package",
+  "volta": {{
+    "node": "{}",
+    "yarn": "{}"
+  }}
+}}"#,
+        node_version, yarn_version
+    )
+}
+
+const NODE_VERSION_INFO: &str = r#"[
+{"version":"v10.99.1040","npm":"6.2.26","lts": "Dubnium","files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip", "linux-arm64"]},
+{"version":"v9.27.6","npm":"5.6.17","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip", "linux-arm64"]},
+{"version":"v8.9.10","npm":"5.6.7","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip", "linux-arm64"]},
+{"version":"v6.19.62","npm":"3.10.1066","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip", "linux-arm64"]}
+]
+"#;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "macos")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 4] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "9.27.6",
+                compressed_size: 272,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "8.9.10",
+                compressed_size: 272,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "6.19.62",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+        ];
+    } else if #[cfg(target_os = "linux")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 4] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "9.27.6",
+                compressed_size: 272,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "8.9.10",
+                compressed_size: 270,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "6.19.62",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+        ];
+    } else if #[cfg(target_os = "windows")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 4] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 1096,
+                uncompressed_size: None,
+            },
+            DistroMetadata {
+                version: "9.27.6",
+                compressed_size: 1068,
+                uncompressed_size: None,
+            },
+            DistroMetadata {
+                version: "8.9.10",
+                compressed_size: 1055,
+                uncompressed_size: None,
+            },
+            DistroMetadata {
+                version: "6.19.62",
+                compressed_size: 1056,
+                uncompressed_size: None,
+            },
+        ];
+    } else {
+        compile_error!("Unsupported target_os for tests (expected 'macos', 'linux', or 'windows').");
+    }
+}
+
+const YARN_VERSION_INFO: &str = r#"[
+{"tag_name":"v1.2.42","assets":[{"name":"yarn-v1.2.42.tar.gz"}]},
+{"tag_name":"v1.3.1","assets":[{"name":"yarn-v1.3.1.msi"}]},
+{"tag_name":"v1.4.159","assets":[{"name":"yarn-v1.4.159.tar.gz"}]},
+{"tag_name":"v1.7.71","assets":[{"name":"yarn-v1.7.71.tar.gz"}]},
+{"tag_name":"v1.12.99","assets":[{"name":"yarn-v1.12.99.tar.gz"}]}
+]"#;
+
+const YARN_VERSION_FIXTURES: [DistroMetadata; 4] = [
+    DistroMetadata {
+        version: "1.12.99",
+        compressed_size: 178,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.7.71",
+        compressed_size: 176,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.4.159",
+        compressed_size: 177,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.2.42",
+        compressed_size: 174,
+        uncompressed_size: Some(0x0028_0000),
+    },
+];
+
+const NPM_VERSION_FIXTURES: [DistroMetadata; 3] = [
+    DistroMetadata {
+        version: "1.2.3",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "4.5.6",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "8.1.5",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+];
+
+const NPM_VERSION_INFO: &str = r#"
+{
+    "name":"npm",
+    "dist-tags": { "latest":"8.1.5" },
+    "versions": {
+        "1.2.3": { "version":"1.2.3", "dist": { "shasum":"", "tarball":"" }},
+        "4.5.6": { "version":"4.5.6", "dist": { "shasum":"", "tarball":"" }},
+        "8.1.5": { "version":"8.1.5", "dist": { "shasum":"", "tarball":"" }}
+    }
+}
+"#;
+
+const VOLTA_LOGLEVEL: &str = "VOLTA_LOGLEVEL";
+
+#[test]
+fn command_line_node() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .env(VOLTA_LOGLEVEL, "debug")
+        .build();
+
+    assert_that!(
+        s.volta("run --node 10.99.1040 node --version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]Using node@10.99.1040 from command-line configuration")
+    );
+}
+
+#[test]
+fn inherited_node() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .package_json(&package_json_with_pinned_node("9.27.6"))
+        .env(VOLTA_LOGLEVEL, "debug")
+        .build();
+
+    assert_that!(
+        s.volta("run node --version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]Using node@9.27.6 from project configuration")
+    );
+}
+
+#[test]
+fn no_node() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.volta("run node --version"),
+        execs()
+            .with_status(ExitCode::ConfigurationError as i32)
+            .with_stderr_contains("[..]Node is not available.")
+    );
+}
+
+#[test]
+fn command_line_npm() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .npm_available_versions(NPM_VERSION_INFO)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .env(VOLTA_LOGLEVEL, "debug")
+        .build();
+
+    assert_that!(
+        s.volta("run --node 10.99.1040 --npm 8.1.5 npm --version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]Using npm@8.1.5 from command-line configuration")
+    );
+}
+
+#[test]
+fn inherited_npm() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .npm_available_versions(NPM_VERSION_INFO)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .package_json(&package_json_with_pinned_node_npm("9.27.6", "4.5.6"))
+        .env(VOLTA_LOGLEVEL, "debug")
+        .build();
+
+    assert_that!(
+        s.volta("run --node 10.99.1040 npm --version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]Using npm@4.5.6 from project configuration")
+    );
+}
+
+#[test]
+fn force_bundled_npm() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .npm_available_versions(NPM_VERSION_INFO)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .package_json(&package_json_with_pinned_node_npm("9.27.6", "4.5.6"))
+        .env(VOLTA_LOGLEVEL, "debug")
+        .build();
+
+    assert_that!(
+        s.volta("run --bundled-npm npm --version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]Using npm@5.6.17 from project configuration")
+    );
+}
+
+#[test]
+fn command_line_yarn() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .env(VOLTA_LOGLEVEL, "debug")
+        .build();
+
+    assert_that!(
+        s.volta("run --node 10.99.1040 --yarn 1.7.71 yarn --version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]Using yarn@1.7.71 from command-line configuration")
+    );
+}
+
+#[test]
+fn inherited_yarn() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .package_json(&package_json_with_pinned_node_yarn("10.99.1040", "1.2.42"))
+        .env(VOLTA_LOGLEVEL, "debug")
+        .build();
+
+    assert_that!(
+        s.volta("run --node 10.99.1040 yarn --version"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]Using yarn@1.2.42 from project configuration")
+    );
+}
+
+#[test]
+fn force_no_yarn() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .package_json(&package_json_with_pinned_node_yarn("10.99.1040", "1.2.42"))
+        .env(VOLTA_LOGLEVEL, "debug")
+        .build();
+
+    assert_that!(
+        s.volta("run --no-yarn yarn --version"),
+        execs()
+            .with_status(ExitCode::ConfigurationError as i32)
+            .with_stderr_contains("[..]No Yarn version found in this project.")
+    );
+}

--- a/tests/smoke/main.rs
+++ b/tests/smoke/main.rs
@@ -16,6 +16,7 @@ cfg_if::cfg_if! {
         mod support;
         mod volta_fetch;
         mod volta_install;
+        mod volta_run;
         mod autodownload;
     }
 }

--- a/tests/smoke/volta_run.rs
+++ b/tests/smoke/volta_run.rs
@@ -3,7 +3,6 @@ use crate::support::temp_project::temp_project;
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
-use volta_fail::ExitCode;
 
 // Note: Node 12.15.0 is bundled with npm 6.13.4
 const PACKAGE_JSON: &str = r#"{
@@ -31,7 +30,7 @@ fn run_npm() {
 
     assert_that!(
         p.volta("run --node 12.14.1 --npm 6.14.4 npm --version"),
-        execs().with_status(0).with_stdout_contains("6.14.4"),
+        execs().with_status(0).with_stdout_contains("6.14.4")
     )
 }
 

--- a/tests/smoke/volta_run.rs
+++ b/tests/smoke/volta_run.rs
@@ -1,0 +1,56 @@
+use crate::support::temp_project::temp_project;
+
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+use volta_fail::ExitCode;
+
+const PACKAGE_JSON: &str = r#"{
+    "name": "test-package",
+    "volta": {
+        "node": "12.15.0",
+        "yarn": "1.17.1"
+    }
+}"#;
+
+#[test]
+fn run_node() {
+    let p = temp_project().build();
+
+    assert_that!(
+        p.volta("run --node 12.16.0 node --version"),
+        execs().with_status(0).with_stdout_contains("v12.16.0")
+    );
+}
+
+#[test]
+fn run_yarn() {
+    let p = temp_project().build();
+
+    assert_that!(
+        p.volta("run --node 12.16.1 --yarn 1.22.0 yarn --version"),
+        execs().with_status(0).with_stdout_contains("1.22.0")
+    );
+}
+
+#[test]
+fn inherits_project_platform() {
+    let p = temp_project().package_json(PACKAGE_JSON).build();
+
+    assert_that!(
+        p.volta("run --yarn 1.21.0 yarn --version"),
+        execs().with_status(0).with_stdout_contains("1.21.0")
+    );
+}
+
+#[test]
+fn run_yarn_disabled() {
+    let p = temp_project().package_json(PACKAGE_JSON).build();
+
+    assert_that!(
+        p.volta("run --no-yarn yarn --version"),
+        execs()
+            .with_status(ExitCode::ConfigurationError as i32)
+            .with_stderr_contains("[..]No Yarn version found[..]")
+    );
+}

--- a/tests/smoke/volta_run.rs
+++ b/tests/smoke/volta_run.rs
@@ -5,10 +5,12 @@ use hamcrest2::prelude::*;
 use test_support::matchers::execs;
 use volta_fail::ExitCode;
 
+// Note: Node 12.15.0 is bundled with npm 6.13.4
 const PACKAGE_JSON: &str = r#"{
     "name": "test-package",
     "volta": {
         "node": "12.15.0",
+        "npm": "6.14.2",
         "yarn": "1.17.1"
     }
 }"#;
@@ -21,6 +23,16 @@ fn run_node() {
         p.volta("run --node 12.16.0 node --version"),
         execs().with_status(0).with_stdout_contains("v12.16.0")
     );
+}
+
+#[test]
+fn run_npm() {
+    let p = temp_project().build();
+
+    assert_that!(
+        p.volta("run --node 12.14.1 --npm 6.14.4 npm --version"),
+        execs().with_status(0).with_stdout_contains("6.14.4"),
+    )
 }
 
 #[test]
@@ -40,18 +52,6 @@ fn inherits_project_platform() {
     assert_that!(
         p.volta("run --yarn 1.21.0 yarn --version"),
         execs().with_status(0).with_stdout_contains("1.21.0")
-    );
-}
-
-#[test]
-fn run_yarn_disabled() {
-    let p = temp_project().package_json(PACKAGE_JSON).build();
-
-    assert_that!(
-        p.volta("run --no-yarn yarn --version"),
-        execs()
-            .with_status(ExitCode::ConfigurationError as i32)
-            .with_stderr_contains("[..]No Yarn version found[..]")
     );
 }
 

--- a/tests/smoke/volta_run.rs
+++ b/tests/smoke/volta_run.rs
@@ -54,3 +54,13 @@ fn run_yarn_disabled() {
             .with_stderr_contains("[..]No Yarn version found[..]")
     );
 }
+
+#[test]
+fn run_environment() {
+    let p = temp_project().build();
+
+    assert_that!(
+        p.volta("run --node 12.16.0 --env VOLTA_SMOKE_1234=hello node -e console.log(process.env.VOLTA_SMOKE_1234)"),
+        execs().with_status(0).with_stdout_contains("hello")
+    );
+}


### PR DESCRIPTION
Info
----
* As described in https://github.com/volta-cli/rfcs/pull/39, we want to have a `volta run` command that allows you to override the detect `node` and `yarn` versions when running a specific command.

Changes
-----
* Added `CommandLine` source for Platforms and an `InheritOption` type that represents one of 3 possibilities: A Value, No Value but allowed to inherit, and No Value but _not_ allowed to inherit.
* Added a `CliPlatform` type that represents the data we can potentially get from the CLI (including the ability to prevent inheriting from the contextual Platform).
* Created the `run` command that parses the options and passes them to the core logic to execute.

Tested
-----
* Manual testing of `volta run` in different scenarios.
* Added unit tests around new Platform behaviors (merging and `InheritOption`)
* Added acceptance tests to cover the behavior of each tool under different scenarios with `volta run`
* Added smoke tests to cover the core behaviors of `volta run`
* All tests (new and existing) pass.