### PR TITLE
Automate creation of releases with GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ on:
   push:
     tags:
       - v*
+  pull_request:
+    branches:
+      - master
 
 name: Build and Release
 
@@ -115,6 +118,7 @@ jobs:
       - linux
       - macos
       - windows
+    if: github.event_name == 'push' && startsWith(github.ref, 'v')
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,216 @@
+on:
+  push:
+    tags:
+      - v*
+
+name: Build and Release
+
+jobs:
+  centos:
+    name: Build - CentOS / RHEL
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up docker image
+        run: docker build -t volta .
+        working-directory: ./ci/docker
+      - name: Compile and package Volta
+        run: docker run --volume ${PWD}:/root/workspace --workdir /root/workspace --rm --init --tty volta /root/workspace/ci/build-and-package.sh volta-centos
+      - name: Confirm correct OpenSSL Version
+        run: |
+          objdump -p target/release/volta
+          readelf -d target/release/volta
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: linux-centos
+          path: target/release/volta-centos.tar.gz
+
+  linux:
+    strategy:
+      matrix:
+        openssl:
+          - 1_1_0
+          - 1_0_1
+    name: Build - OpenSSL ${{ matrix.openssl }}
+    runs-on: ubuntu-16.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Check out OpenSSL
+        uses: actions/checkout@v2
+        with:
+          repository: openssl/openssl
+          ref: OpenSSL_${{ matrix.openssl }}-stable
+          path: openssl
+      - name: Set up docker image
+        run: docker build -t volta .
+        working-directory: ./ci/docker
+      - name: Compile and package OpenSSL & Volta
+        run: docker run --volume ${PWD}:/root/workspace --workdir /root/workspace --rm --init --tty volta /root/workspace/ci/build-with-openssl.sh volta-openssl-${{ matrix.openssl }}
+      - name: Confirm OpenSSL Version
+        run: |
+          objdump -p target/release/volta
+          readelf -d target/release/volta
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: linux-openssl-${{ matrix.openssl }}
+          path: target/release/volta-openssl-${{ matrix.openssl }}.tar.gz
+
+  macos:
+    name: Build - MacOS
+    runs-on: macos-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Compile and package Volta
+        run: ./ci/build-and-package.sh volta-macos
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: macos
+          path: target/release/volta-macos.tar.gz
+
+  windows:
+    name: Build - Windows
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Add cargo-wix subcommand
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-wix
+      - name: Compile and package Volta
+        uses: actions-rs/cargo@v1
+        with:
+          command: wix
+          args: --nocapture --output target\wix\volta-windows.msi
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: windows
+          path: target/wix/volta-windows.msi
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    needs:
+      - centos
+      - linux
+      - macos
+      - windows
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Determine release version
+        id: release_info
+        env:
+          TAG: ${{ github.ref }}
+        run: echo "::set-output name=version::${TAG:1}"
+      - name: Fetch CentOS artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: linux-centos
+          path: release
+      - name: Fetch OpenSSL 1.0.* artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: linux-openssl-1_0_1
+          path: release
+      - name: Fetch OpenSSL 1.1.* artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: linux-openssl-1_1_0
+          path: release
+      - name: Fetch MacOS artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: macos
+          path: release
+      - name: Fetch Windows artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: windows
+          path: release
+      - name: Show release artifacts
+        run: ls -la release
+      - name: Create draft release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: true
+          prerelease: true
+      - name: Upload CentOS artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/volta-centos.tar.gz
+          asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-rhel.tar.gz
+          asset_content_type: applictaion/gzip
+      - name: Upload OpenSSL 1.0.* artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/volta-openssl-1_0_1.tar.gz
+          asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-1.0.tar.gz
+          asset_content_type: applictaion/gzip
+      - name: Upload OpenSSL 1.1.* artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/volta-openssl-1_1_0.tar.gz
+          asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-1.1.tar.gz
+          asset_content_type: applictaion/gzip
+      - name: Upload MacOS artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/volta-macos.tar.gz
+          asset_name: volta-${{ steps.release_info.outputs.version }}-macos.tar.gz
+          asset_content_type: applictaion/gzip
+      - name: Upload Windows artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/volta-windows.msi
+          asset_name: volta-${{ steps.release_info.outputs.version }}-windows-x86_64.msi
+          asset_content_type: applictaion/x-msi
+      - name: Upload manifest file
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ci/volta.manifest
+          asset_name: volta.manifest
+          asset_content_type: text/plain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - master
 
-name: Build and Release
+name: Production
 
 jobs:
   centos:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,16 +99,24 @@ jobs:
         with:
           command: install
           args: cargo-wix
-      - name: Compile and package Volta
+      - name: Compile and package installer
         uses: actions-rs/cargo@v1
         with:
           command: wix
           args: --nocapture --output target\wix\volta-windows.msi
-      - name: Upload release artifact
+      - name: Create zip of binaries
+        run: powershell Compress-Archive volta*.exe volta-windows.zip
+        working-directory: ./target/release
+      - name: Upload installer
         uses: actions/upload-artifact@v2-preview
         with:
-          name: windows
+          name: windows-installer
           path: target/wix/volta-windows.msi
+      - name: Upload zip
+        uses: actions/upload-artifact@v2-preview
+        with:
+          name: windows-zip
+          path: target/release/volta-windows.zip
 
   release:
     name: Publish release
@@ -147,10 +155,15 @@ jobs:
         with:
           name: macos
           path: release
-      - name: Fetch Windows artifact
+      - name: Fetch Windows installer
         uses: actions/download-artifact@v1
         with:
-          name: windows
+          name: windows-installer
+          path: release
+      - name: Fetch Windows zip
+        uses: actions/download-artifact@v1
+        with:
+          name: windows-zip
           path: release
       - name: Show release artifacts
         run: ls -la release
@@ -200,7 +213,7 @@ jobs:
           asset_path: ./release/volta-macos.tar.gz
           asset_name: volta-${{ steps.release_info.outputs.version }}-macos.tar.gz
           asset_content_type: applictaion/gzip
-      - name: Upload Windows artifact
+      - name: Upload Windows installer
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -209,6 +222,15 @@ jobs:
           asset_path: ./release/volta-windows.msi
           asset_name: volta-${{ steps.release_info.outputs.version }}-windows-x86_64.msi
           asset_content_type: applictaion/x-msi
+      - name: Upload Windows zip
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/volta-windows.zip
+          asset_name: volta-${{ steps.release_info.outputs.version }}-windows.zip
+          asset_content_type: application/zip
       - name: Upload manifest file
         uses: actions/upload-release-asset@v1
         env:

--- a/ci/build-and-package.sh
+++ b/ci/build-and-package.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Building Volta"
+
+cargo build --release
+
+echo "Packaging Binaries"
+
+cd target/release
+tar -zcvf "$1.tar.gz" volta volta-shim volta-migrate

--- a/ci/build-with-openssl.sh
+++ b/ci/build-with-openssl.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Building OpenSSL"
+cd openssl
+./config shared --prefix=/root/workspace/openssl-dist
+make
+make install_sw
+cd -
+
+OPENSSL_DIR=/root/workspace/openssl-dist ./ci/build-and-package.sh "$1"

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -1,0 +1,9 @@
+FROM centos:6
+
+# Set up additional build tools
+RUN yum -y update && yum clean all
+RUN yum -y install gcc curl openssl openssl-devel ca-certificates tar perl perl-Module-Load-Conditional && yum clean all
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"

--- a/ci/volta.manifest
+++ b/ci/volta.manifest
@@ -1,0 +1,3 @@
+volta
+volta-shim
+volta-migrate


### PR DESCRIPTION
Closes #676 

Info
-----
* To streamline and normalize the release process, we should build all the artifacts in CI, instead of on an individual maintainer's machines.
* We can use GitHub Actions to trigger these builds whenever a tag is pushed to the repository, allowing us to still have control over when releases are created.
* GitHub Actions can also create a new release and upload the artifacts so that it is ready for publishing.

Changes
-----
* Added `release.yml` with jobs to build all the necessary binaries and create a new Release in the repository.
* Added Dockerfile and supporting scripts to `ci` directory for Linux builds.

Notes
-----
* The release process will be triggered whenever we push a tag with the name `v<version>` to the repo.
* MacOS and Windows build are straightforward, using only `cargo` commands.
* Linux is where things get complicated, as we have a couple of constraints:
    * To ensure we don't have overly-restrictive `glibc` requirements, we need to build on an older distro.
    * We also need to support 3 different OpenSSL versions: 1.0.*, 1.1.*, and the custom-bundled version used by CentOS / RHEL
* To solve all these constraints, we take the following approach:
    * All Linux builds are performed on a Docker image of CentOS 6 (Previously, builds were manually created on a Linux machine that had RHEL 7, so this is slightly older and thus less restrictive).
    * For CentOS OpenSSL, we use the version that is included in the image
    * For OpenSSL 1.0.* and 1.1.*, we download the `1_0_1-stable` and `1_1_0-stable` branches of OpenSSL and build from source, then compile against those versions.
* The release is created as a draft, with no description. This allows us to insert the release notes / changelog (without having to do complicated text parsing) as well as spot-check to make sure everything is ready to be published.
* For Windows, in addition to the MSI installer, also create a zip file of the binaries.

Tested
-----
* For testing, I had this workflow set to trigger on PRs as well, which is why I force-pushed so many times.
* I was able to create a draft release from the PR branch, using a mocked version number.
* After merging, we will likely need to do a sanity check by pushing a tag to the repo and confirming we see a release created.