### PR TITLE
Update npm@bundled tests to ensure the default version file is available

### DIFF
--- a/tests/acceptance/volta_install.rs
+++ b/tests/acceptance/volta_install.rs
@@ -153,6 +153,7 @@ fn install_node_with_npm_hides_bundled_version() {
 fn install_npm_bundled_clears_npm() {
     let s = sandbox()
         .platform(&platform_with_node_npm("8.9.10", "6.2.26"))
+        .node_npm_version_file("8.9.10", "5.6.7")
         .build();
 
     assert_that!(
@@ -170,6 +171,7 @@ fn install_npm_bundled_clears_npm() {
 fn install_npm_bundled_reports_info() {
     let s = sandbox()
         .platform(&platform_with_node_npm("8.9.10", "6.2.26"))
+        .node_npm_version_file("8.9.10", "5.6.7")
         .env("VOLTA_LOGLEVEL", "info")
         .build();
 
@@ -177,6 +179,6 @@ fn install_npm_bundled_reports_info() {
         s.volta("install npm@bundled"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains("[..]set bundled npm[..]")
+            .with_stdout_contains("[..]set bundled npm (currently 5.6.7)[..]")
     );
 }

--- a/tests/acceptance/volta_pin.rs
+++ b/tests/acceptance/volta_pin.rs
@@ -575,6 +575,7 @@ fn pin_npm_missing_release() {
 fn pin_npm_bundled_removes_npm() {
     let s = sandbox()
         .package_json(&package_json_with_pinned_node_npm("1.2.3", "4.5.6"))
+        .node_npm_version_file("1.2.3", "3.2.1")
         .build();
 
     assert_that!(
@@ -592,6 +593,7 @@ fn pin_npm_bundled_removes_npm() {
 fn pin_npm_bundled_reports_info() {
     let s = sandbox()
         .package_json(&package_json_with_pinned_node_npm("1.2.3", "4.5.6"))
+        .node_npm_version_file("1.2.3", "3.2.1")
         .env("VOLTA_LOGLEVEL", "info")
         .build();
 
@@ -599,7 +601,7 @@ fn pin_npm_bundled_reports_info() {
         s.volta("pin npm@bundled"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stdout_contains("[..]set package.json to use bundled npm[..]")
+            .with_stdout_contains("[..]set package.json to use bundled npm (currently 3.2.1)[..]")
     );
 }
 


### PR DESCRIPTION
The change in #691 to show an error when unable to determine the bundled version of `npm` after running `volta install npm@bundled` or `volta pin npm@bundled` broke the tests of that behavior, but somehow they passed the PR CI (though not the merge CI).

Updated the tests to make sure that the npm version file is available for all of those tests.