### PR TITLE
Don't show error when loading bundled npm version for message

### DIFF
--- a/crates/volta-core/src/error/details.rs
+++ b/crates/volta-core/src/error/details.rs
@@ -188,11 +188,6 @@ pub enum ErrorDetails {
         binary: String,
     },
 
-    /// Thrown when pinning or installing npm@bundled and couldn't detect the bundled version
-    NoBundledNpm {
-        command: String,
-    },
-
     /// Thrown when there is no Node version matching a requested semver specifier.
     NodeVersionNotFound {
         matching: String,
@@ -811,13 +806,6 @@ To {action} the packages '{name}' and '{version}', please {action} them in separ
 Please uninstall and re-install the package that provides that executable.",
                 binary
             ),
-            ErrorDetails::NoBundledNpm { command } => write!(
-                f,
-                "Could not detect bundled npm version.
-
-Please ensure you have a Node version selected with `volta {} node` (see `volta help {0}` for more info).",
-                command
-            ),
             ErrorDetails::NodeVersionNotFound { matching } => write!(
                 f,
                 r#"Could not find Node version matching "{}" in the version registry.
@@ -1435,7 +1423,6 @@ impl VoltaFail for ErrorDetails {
             ErrorDetails::InvalidInvocation { .. } => ExitCode::InvalidArguments,
             ErrorDetails::InvalidToolName { .. } => ExitCode::InvalidArguments,
             ErrorDetails::NoBinPlatform { .. } => ExitCode::ExecutionFailure,
-            ErrorDetails::NoBundledNpm { .. } => ExitCode::ConfigurationError,
             ErrorDetails::NodeVersionNotFound { .. } => ExitCode::NoVersionMatch,
             ErrorDetails::NoGlobalInstalls { .. } => ExitCode::InvalidArguments,
             ErrorDetails::NoHomeEnvironmentVar => ExitCode::EnvironmentError,


### PR DESCRIPTION
After some additional thought, there is at least one legitimate use-case where the user wouldn't have downloaded `node` yet, but the `volta pin node@bundled` operation still succeeded and will work correctly: When they switch into a new project or fetch new changes in a project that results in `package.json` having a version of `node` that we haven't yet seen.

In that case, showing an error when the operation was successful seems unnecessarily harsh, and somewhat confusing.