### PR TITLE
Update the versions of tools used in the smoke tests

### DIFF
--- a/tests/smoke/autodownload.rs
+++ b/tests/smoke/autodownload.rs
@@ -14,7 +14,7 @@ static PACKAGE_JSON_WITH_PINNED_NODE: &str = r#"{
 static PACKAGE_JSON_WITH_PINNED_NODE_NPM: &str = r#"{
     "name": "test-package",
     "volta": {
-        "node": "12.13.0",
+        "node": "13.0.1",
         "npm": "6.13.4"
     }
 }"#;
@@ -22,7 +22,7 @@ static PACKAGE_JSON_WITH_PINNED_NODE_NPM: &str = r#"{
 static PACKAGE_JSON_WITH_PINNED_NODE_YARN: &str = r#"{
     "name": "test-package",
     "volta": {
-        "node": "12.13.0",
+        "node": "12.10.0",
         "yarn": "1.22.0"
     }
 }"#;

--- a/tests/smoke/volta_fetch.rs
+++ b/tests/smoke/volta_fetch.rs
@@ -8,27 +8,27 @@ use test_support::matchers::execs;
 fn fetch_node() {
     let p = temp_project().build();
 
-    assert_that!(p.volta("fetch node@10.4.1"), execs().with_status(0));
-    assert_eq!(p.node_version_is_fetched("10.4.1"), true);
-    assert_eq!(p.node_version_is_unpacked("10.4.1"), true);
+    assert_that!(p.volta("fetch node@12.16.0"), execs().with_status(0));
+    assert_eq!(p.node_version_is_fetched("12.16.0"), true);
+    assert_eq!(p.node_version_is_unpacked("12.16.0"), true);
 }
 
 #[test]
 fn fetch_yarn() {
     let p = temp_project().build();
 
-    assert_that!(p.volta("fetch yarn@1.10.1"), execs().with_status(0));
-    assert_eq!(p.yarn_version_is_fetched("1.10.1"), true);
-    assert_eq!(p.yarn_version_is_unpacked("1.10.1"), true);
+    assert_that!(p.volta("fetch yarn@1.22.2"), execs().with_status(0));
+    assert_eq!(p.yarn_version_is_fetched("1.22.2"), true);
+    assert_eq!(p.yarn_version_is_unpacked("1.22.2"), true);
 }
 
 #[test]
 fn fetch_npm() {
     let p = temp_project().build();
 
-    assert_that!(p.volta("fetch npm@6.7.0"), execs().with_status(0));
-    assert_eq!(p.npm_version_is_fetched("6.7.0"), true);
-    assert_eq!(p.npm_version_is_unpacked("6.7.0"), true);
+    assert_that!(p.volta("fetch npm@6.14.2"), execs().with_status(0));
+    assert_eq!(p.npm_version_is_fetched("6.14.2"), true);
+    assert_eq!(p.npm_version_is_unpacked("6.14.2"), true);
 }
 
 #[test]
@@ -36,7 +36,7 @@ fn fetch_package() {
     let p = temp_project().build();
 
     // have to install node first, because we need npm
-    assert_that!(p.volta("install node@10.4.1"), execs().with_status(0));
+    assert_that!(p.volta("install node@12.16.1"), execs().with_status(0));
 
     assert_that!(p.volta("fetch cowsay@1.4.0"), execs().with_status(0));
     assert_eq!(p.package_version_is_fetched("cowsay", "1.4.0"), true);

--- a/tests/smoke/volta_install.rs
+++ b/tests/smoke/volta_install.rs
@@ -8,16 +8,16 @@ use test_support::matchers::execs;
 fn install_node() {
     let p = temp_project().build();
 
-    assert_that!(p.volta("install node@10.2.1"), execs().with_status(0));
+    assert_that!(p.volta("install node@12.16.2"), execs().with_status(0));
 
     assert_that!(
         p.node("--version"),
-        execs().with_status(0).with_stdout_contains("v10.2.1")
+        execs().with_status(0).with_stdout_contains("v12.16.2")
     );
 
-    assert!(p.node_version_is_fetched("10.2.1"));
-    assert!(p.node_version_is_unpacked("10.2.1"));
-    p.assert_node_version_is_installed("10.2.1");
+    assert!(p.node_version_is_fetched("12.16.2"));
+    assert!(p.node_version_is_unpacked("12.16.2"));
+    p.assert_node_version_is_installed("12.16.2");
 }
 
 #[test]
@@ -33,39 +33,39 @@ fn install_node_lts() {
 fn install_yarn() {
     let p = temp_project().build();
 
-    assert_that!(p.volta("install node@10.2.1"), execs().with_status(0));
-    assert_that!(p.volta("install yarn@1.9.2"), execs().with_status(0));
+    assert_that!(p.volta("install node@12.16.3"), execs().with_status(0));
+    assert_that!(p.volta("install yarn@1.22.2"), execs().with_status(0));
 
     assert_that!(
         p.yarn("--version"),
-        execs().with_status(0).with_stdout_contains("1.9.2")
+        execs().with_status(0).with_stdout_contains("1.22.2")
     );
 
-    assert!(p.yarn_version_is_fetched("1.9.2"));
-    assert!(p.yarn_version_is_unpacked("1.9.2"));
-    p.assert_yarn_version_is_installed("1.9.2");
+    assert!(p.yarn_version_is_fetched("1.22.2"));
+    assert!(p.yarn_version_is_unpacked("1.22.2"));
+    p.assert_yarn_version_is_installed("1.22.2");
 }
 
 #[test]
 fn install_npm() {
     let p = temp_project().build();
 
-    // node 11.10.0 is bundled with npm 6.7.0
-    assert_that!(p.volta("install node@11.10.0"), execs().with_status(0));
+    // node 13.10.0 is bundled with npm 6.13.7
+    assert_that!(p.volta("install node@13.10.0"), execs().with_status(0));
     assert_that!(
         p.npm("--version"),
-        execs().with_status(0).with_stdout_contains("6.7.0")
+        execs().with_status(0).with_stdout_contains("6.13.7")
     );
 
     // install npm 6.8.0 and verify that is installed correctly
-    assert_that!(p.volta("install npm@6.8.0"), execs().with_status(0));
-    assert!(p.npm_version_is_fetched("6.8.0"));
-    assert!(p.npm_version_is_unpacked("6.8.0"));
-    p.assert_npm_version_is_installed("6.8.0");
+    assert_that!(p.volta("install npm@6.14.3"), execs().with_status(0));
+    assert!(p.npm_version_is_fetched("6.14.3"));
+    assert!(p.npm_version_is_unpacked("6.14.3"));
+    p.assert_npm_version_is_installed("6.14.3");
 
     assert_that!(
         p.npm("--version"),
-        execs().with_status(0).with_stdout_contains("6.8.0")
+        execs().with_status(0).with_stdout_contains("6.14.3")
     );
 }
 
@@ -83,7 +83,7 @@ fn install_package() {
     let p = temp_project().build();
 
     // have to install node first, because we need npm
-    assert_that!(p.volta("install node@10.4.1"), execs().with_status(0));
+    assert_that!(p.volta("install node@12.11.1"), execs().with_status(0));
 
     assert_that!(p.volta("install cowsay@1.4.0"), execs().with_status(0));
     assert!(p.shim_exists("cowsay"));
@@ -102,7 +102,7 @@ fn install_scoped_package() {
     let p = temp_project().build();
 
     // have to install node first, because we need npm
-    assert_that!(p.volta("install node@10.4.1"), execs().with_status(0));
+    assert_that!(p.volta("install node@12.14.1"), execs().with_status(0));
 
     assert_that!(p.volta("install @wdio/cli@5.12.4"), execs().with_status(0));
     assert!(p.shim_exists("wdio"));
@@ -121,7 +121,7 @@ fn install_package_tag_version() {
     let p = temp_project().build();
 
     // have to install node first, because we need npm
-    assert_that!(p.volta("install node@10.4.1"), execs().with_status(0));
+    assert_that!(p.volta("install node@12.12.0"), execs().with_status(0));
 
     assert_that!(p.volta("install elm@elm0.19.0"), execs().with_status(0));
     assert!(p.shim_exists("elm"));


### PR DESCRIPTION
We are seeing intermittent failures trying to download Node in the smoke tests. Updated the tests to use more recent versions of Node, as well as to use different versions for each test.