### PR TITLE
Return to using single-threaded smoke tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --test smoke --features smoke-tests
+          args: --test smoke --features smoke-tests -- --test-threads 1
 
   shell-tests:
     name: Shell Script Tests


### PR DESCRIPTION
Attempting to improve the stability of the smoke tests by returning to single-threaded