### PR TITLE
Include npm in the description of Volta run

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -122,7 +122,7 @@ otherwise, they will be written to `stdout`.
     #[structopt(name = "setup", author = "", version = "")]
     Setup(command::Setup),
 
-    /// Run a command with custom Node and/or Yarn versions
+    /// Run a command with custom Node, npm, and/or Yarn versions
     #[structopt(name = "run", author = "", version = "")]
     #[structopt(raw(setting = "structopt::clap::AppSettings::AllowLeadingHyphen"))]
     #[structopt(raw(setting = "structopt::clap::AppSettings::TrailingVarArg"))]


### PR DESCRIPTION
The description of `volta run` wasn't updated to include `npm`, so it only mentions Node and Yarn.