### PR TITLE
Update release automation to correctly parse the version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
         id: release_info
         env:
           TAG: ${{ github.ref }}
-        run: echo "::set-output name=version::${TAG:1}"
+        run: echo "::set-output name=version::${TAG:11}"
       - name: Fetch CentOS artifact
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
It turns out that in a `push` workflow, `github.ref` actually has the value: `refs.tags.{tagname}`, not just `{tagname}`, so we need to update our logic for parsing the version out of the ref.

Skipping the first 11 characters means stripping off the `refs.tags.v` from `refs.tags.v{version}`, leaving just the version number, which we can then use for naming the release artifacts.