### PR TITLE
Remove erroneous information from 'volta list' output

### DIFF
--- a/crates/volta-core/src/project.rs
+++ b/crates/volta-core/src/project.rs
@@ -1,11 +1,9 @@
 //! Provides the `Project` type, which represents a Node project tree in
 //! the filesystem.
 
-use std::collections::HashMap;
 use std::env;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
 use lazycell::LazyCell;
 use semver::Version;
@@ -137,42 +135,9 @@ impl Project {
         Ok(false)
     }
 
-    /// Returns a matching config if the bin exists at the specified version in
-    /// the project.
-    pub fn matching_bin(&self, bin_name: &OsStr, version: &Version) -> Fallible<Option<BinConfig>> {
-        let home = volta_home()?;
-        let config_path = bin_name
-            .to_str()
-            .map(|name| home.default_tool_bin_config(name));
-
-        let bin_config = config_path.map(BinConfig::from_file).transpose()?;
-
-        let matching_config = bin_config.and_then(|config| {
-            if self.has_direct_dependency(&config.package) && &config.version == version {
-                Some(config)
-            } else {
-                None
-            }
-        });
-
-        Ok(matching_config)
-    }
-
-    fn has_direct_dependency(&self, dependency: &str) -> bool {
+    pub fn has_direct_dependency(&self, dependency: &str) -> bool {
         self.manifest.dependencies.contains_key(dependency)
             || self.manifest.dev_dependencies.contains_key(dependency)
-    }
-
-    pub fn has_dependency(&self, dependency: &str, version: &Version) -> bool {
-        let has_dep = |deps: &HashMap<String, String>| {
-            deps.get(dependency)
-                .and_then(|v| Version::from_str(v).ok())
-                .map(|v| &v == version)
-        };
-
-        has_dep(&self.manifest.dependencies)
-            .or_else(|| has_dep(&self.manifest.dev_dependencies))
-            .unwrap_or(false)
     }
 
     /// Writes the specified version of Node to the `volta.node` key in package.json.

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -334,12 +334,6 @@ fn format_package(package: &Package) -> String {
             node,
             tools,
             ..
-        }
-        | Package::Project {
-            details,
-            node,
-            tools,
-            ..
         } => {
             let tools = match tools.len() {
                 0 => String::from(""),
@@ -357,6 +351,15 @@ fn format_package(package: &Package) -> String {
             ));
             let platform = WRAPPER.fill(&format!("platform:\n{}", platform_detail));
             format!("{}@{}\n{}\n{}", details.name, version, binaries, platform)
+        }
+        Package::Project { name, tools, .. } => {
+            let tools = match tools.len() {
+                0 => String::from(""),
+                _ => tools.join(", "),
+            };
+
+            let binaries = WRAPPER.fill(&format!("binary tools: {}", tools));
+            format!("{}{}\n{}", name, list_package_source(package), binaries)
         }
         Package::Fetched(details) => {
             let package_info = format!("{}@{}", details.name, details.version);
@@ -812,12 +815,8 @@ See options for more detailed reports by running `volta list --help`.";
             ];
             let packages = vec![
                 Package::Project {
-                    details: PackageDetails {
-                        name: "create-react-app".to_string(),
-                        version: Version::from((3, 0, 1)),
-                    },
+                    name: "create-react-app".to_string(),
                     path: PROJECT_PATH.clone(),
-                    node: NODE_12.clone(),
                     tools: vec!["create-react-app".to_string()],
                 },
                 Package::Default {
@@ -1125,7 +1124,7 @@ See `volta help install` for details and more options.";
     mod packages {
         use super::*;
         use crate::command::list::{Package, PackageDetails};
-        use semver::{Identifier, Version};
+        use semver::Version;
 
         #[test]
         fn none() {
@@ -1163,19 +1162,12 @@ See `volta help install` for details and more options.";
         fn single_project() {
             let expected = "⚡️ Package versions in your toolchain:
 
-    ember-cli@3.10.1 (current @ ~/path/to/project.json)
-        binary tools: ember
-        platform:
-            runtime: node@12.2.0
-            package manager: npm@built-in";
+    ember-cli (current @ ~/path/to/project.json)
+        binary tools: ember";
 
             let packages = [Package::Project {
-                details: PackageDetails {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 10, 1)),
-                },
+                name: "ember-cli".to_string(),
                 path: PROJECT_PATH.clone(),
-                node: NODE_12.clone(),
                 tools: vec!["ember".to_string()],
             }];
 
@@ -1232,11 +1224,8 @@ See `volta help install` for details and more options.";
         platform:
             runtime: node@12.2.0
             package manager: npm@built-in
-    ember-cli@3.11.0--beta.3 (current @ ~/path/to/project.json)
-        binary tools: ember
-        platform:
-            runtime: node@12.2.0
-            package manager: npm@built-in";
+    ember-cli (current @ ~/path/to/project.json)
+        binary tools: ember";
 
             let packages = [
                 Package::Default {
@@ -1248,17 +1237,7 @@ See `volta help install` for details and more options.";
                     tools: vec!["ember".to_string()],
                 },
                 Package::Project {
-                    details: PackageDetails {
-                        name: "ember-cli".to_string(),
-                        version: Version {
-                            major: 3,
-                            minor: 11,
-                            patch: 0,
-                            pre: vec![Identifier::AlphaNumeric("-beta.3".to_string())],
-                            build: vec![],
-                        },
-                    },
-                    node: NODE_12.clone(),
+                    name: "ember-cli".to_string(),
                     path: PROJECT_PATH.clone(),
                     tools: vec!["ember".to_string()],
                 },
@@ -1271,7 +1250,7 @@ See `volta help install` for details and more options.";
     mod tools {
         use super::*;
         use crate::command::list::{Package, PackageDetails};
-        use semver::{Identifier, Version};
+        use semver::Version;
 
         #[test]
         fn none() {
@@ -1309,19 +1288,12 @@ See `volta help install` for details and more options.";
         fn single_project() {
             let expected = "⚡️ Tool `ember` available from:
 
-    ember-cli@3.10.1 (current @ ~/path/to/project.json)
-        binary tools: ember
-        platform:
-            runtime: node@12.2.0
-            package manager: npm@built-in";
+    ember-cli (current @ ~/path/to/project.json)
+        binary tools: ember";
 
             let packages = [Package::Project {
-                details: PackageDetails {
-                    name: "ember-cli".to_string(),
-                    version: Version::from((3, 10, 1)),
-                },
+                name: "ember-cli".to_string(),
                 path: PROJECT_PATH.clone(),
-                node: NODE_12.clone(),
                 tools: vec!["ember".to_string()],
             }];
 
@@ -1378,11 +1350,8 @@ See `volta help install` for details and more options.";
         platform:
             runtime: node@12.2.0
             package manager: npm@built-in
-    ember-cli@3.11.0--beta.3 (current @ ~/path/to/project.json)
-        binary tools: ember
-        platform:
-            runtime: node@12.2.0
-            package manager: npm@built-in";
+    ember-cli (current @ ~/path/to/project.json)
+        binary tools: ember";
 
             let packages = [
                 Package::Default {
@@ -1394,17 +1363,7 @@ See `volta help install` for details and more options.";
                     tools: vec!["ember".to_string()],
                 },
                 Package::Project {
-                    details: PackageDetails {
-                        name: "ember-cli".to_string(),
-                        version: Version {
-                            major: 3,
-                            minor: 11,
-                            patch: 0,
-                            pre: vec![Identifier::AlphaNumeric("-beta.3".to_string())],
-                            build: vec![],
-                        },
-                    },
-                    node: NODE_12.clone(),
+                    name: "ember-cli".to_string(),
                     path: PROJECT_PATH.clone(),
                     tools: vec!["ember".to_string()],
                 },
@@ -1571,16 +1530,10 @@ See `volta help install` for details and more options.";
             platform:
                 runtime: node@12.2.0
                 package manager: npm@built-in
-        typescript@3.5.1 (current @ ~/path/to/project.json)
+        typescript (current @ ~/path/to/project.json)
             binary tools: tsc, tsserver
-            platform:
-                runtime: node@12.2.0
-                package manager: npm@built-in
-        ember-cli@3.10.1 (current @ ~/path/to/project.json)
+        ember-cli (current @ ~/path/to/project.json)
             binary tools: ember
-            platform:
-                runtime: node@12.2.0
-                package manager: npm@built-in
         ember-cli@3.8.2 (default)
             binary tools: ember
             platform:
@@ -1645,21 +1598,13 @@ See `volta help install` for details and more options.";
                     tools: vec!["tsc".to_string(), "tsserver".to_string()],
                 },
                 Package::Project {
-                    details: PackageDetails {
-                        name: "typescript".to_string(),
-                        version: Version::from((3, 5, 1)),
-                    },
+                    name: "typescript".to_string(),
                     path: PROJECT_PATH.clone(),
-                    node: NODE_12.clone(),
                     tools: vec!["tsc".to_string(), "tsserver".to_string()],
                 },
                 Package::Project {
-                    details: PackageDetails {
-                        name: "ember-cli".to_string(),
-                        version: Version::from((3, 10, 1)),
-                    },
+                    name: "ember-cli".to_string(),
                     path: PROJECT_PATH.clone(),
-                    node: NODE_12.clone(),
                     tools: vec!["ember".to_string()],
                 },
                 Package::Default {

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -96,9 +96,7 @@ enum Package {
         tools: Vec<String>,
     },
     Project {
-        details: PackageDetails,
-        /// The version of Node the package is installed against.
-        node: Version,
+        name: String,
         /// The names of the tools associated with the package.
         tools: Vec<String>,
         path: PathBuf,
@@ -120,8 +118,7 @@ impl Package {
                 tools: config.bins.clone(),
             },
             Source::Project(path) => Package::Project {
-                details,
-                node: config.platform.node.clone(),
+                name: details.name,
                 tools: config.bins.clone(),
                 path: path.clone(),
             },
@@ -134,16 +131,16 @@ impl Package {
             configs
                 .iter()
                 .map(|config| {
-                    let source = Self::source(&config.name, &config.version, project);
+                    let source = Self::source(&config.name, project);
                     Package::new(&config, &source)
                 })
                 .collect()
         })
     }
 
-    fn source(name: &str, version: &Version, project: Option<&Project>) -> Source {
+    fn source(name: &str, project: Option<&Project>) -> Source {
         match project {
-            Some(project) if project.has_dependency(name, version) => {
+            Some(project) if project.has_direct_dependency(name) => {
                 Source::Project(project.package_file())
             }
             _ => Source::Default,

--- a/src/command/list/plain.rs
+++ b/src/command/list/plain.rs
@@ -157,7 +157,14 @@ fn display_package(package: &Package) -> String {
                 _ => format!(" {} ", tools.join(", ")),
             };
 
-            format!("package {} /{}/{}", name, tools, package_source(&package))
+            format!(
+                "package {} /{}/ {} {}{}",
+                tool_version(&name, "project"),
+                tools,
+                "node@project",
+                "npm@project",
+                package_source(&package)
+            )
         }
         Package::Fetched(details) => format!(
             "package {} (fetched)",
@@ -179,9 +186,11 @@ fn display_tool(name: &str, host: &Package) -> Option<String> {
         Package::Project {
             name: host_name, ..
         } => Some(format!(
-            "tool {} / {} /{}",
+            "tool {} / {} / {} {}{}",
             name,
-            host_name,
+            tool_version(&host_name, "project"),
+            "node@project",
+            "npm@project",
             package_source(&host)
         )),
         Package::Fetched(..) => None,
@@ -360,7 +369,7 @@ mod tests {
                 }])
                 .expect("Should always return a `String` if given a non-empty set")
                 .as_str(),
-                "package typescript / tsc, tsserver / (current @ /a/b/c)"
+                "package typescript@project / tsc, tsserver / node@project npm@project (current @ /a/b/c)"
             );
         }
 
@@ -388,7 +397,7 @@ mod tests {
                 ])
                 .expect("Should always return a `String` if given a non-empty set")
                 .as_str(),
-                "package typescript / tsc, tsserver / (current @ /a/b/c)\n\
+                "package typescript@project / tsc, tsserver / node@project npm@project (current @ /a/b/c)\n\
                  package ember-cli@3.10.0 / ember / node@12.4.0 npm@built-in (default)\n\
                  package create-react-app@1.0.0 (fetched)"
             );
@@ -445,7 +454,7 @@ mod tests {
                 )
                 .expect("should always return `Some` for `Project`")
                 .as_str(),
-                "tool tsc / typescript / (current @ /a/b/c)"
+                "tool tsc / typescript@project / node@project npm@project (current @ /a/b/c)"
             );
         }
 
@@ -538,7 +547,7 @@ mod tests {
                  package-manager yarn@1.16.0 (current @ /a/b/c)\n\
                  package-manager yarn@1.17.0 (default)\n\
                  package ember-cli@3.10.2 / ember / node@12.4.0 npm@built-in (default)\n\
-                 package ember-cli / ember / (current @ /a/b/c)\n\
+                 package ember-cli@project / ember / node@project npm@project (current @ /a/b/c)\n\
                  package typescript@3.4.1 / tsc, tsserver / node@12.4.0 npm@built-in (default)"
             )
         }


### PR DESCRIPTION
Info
-----
* As discussed in #711, the output of `volta list` (both formatters) around project-local binaries is inaccurate.
* Though we don't yet have a clear path forward for determining the version / platform for project-locals, we can remove the incorrect information so as not to confuse the user.

Changes
-----
* Updated the `list::Package` data model to not include version or platform for local packages.
* Updated the logic for detecting a local package to not try to match on version (which didn't work anyway, because package.json is almost always filled with semver requirements).
* Changed both `human` and `plain` formatters to elide the incorrect information.

Tested
-----
* Updated the tests to represent the new output.

Notes / Questions
-----
* The `expected` output from the tests shows the way it looks for both formatters.
* Does this constitute a breaking change, since we are altering the output of the `plain` formatter, which is intended to be scripted against? I lean towards Yes, but I could see an argument either way.
* If so, is fixing it again (when resolving #711) _another_ breaking change, since we'd be moving back to the old style?
* Is there a better format we can use to show the user project-local bins without giving incorrect information?