### PR TITLE
Fix 'conflicts_with' argument for run command

### DIFF
--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -17,7 +17,7 @@ pub(crate) struct Run {
     node: Option<String>,
 
     /// Set the custom npm version
-    #[structopt(long = "npm", value_name = "version", conflicts_with = "no_npm")]
+    #[structopt(long = "npm", value_name = "version", conflicts_with = "bundled_npm")]
     npm: Option<String>,
 
     /// Forces npm to be the version bundled with Node


### PR DESCRIPTION
Closes #745 

Info
-----
* The `--npm` option to `volta run` was incorrectly marked as conflicts with `--no-npm`, which doesn't exist
* This was causing `volta completions` to panic

Changes
-----
* Updated the `#[structopt]` attribute to correctly point to `bundled_npm` instead of `no_npm`

Tested
-----
* Confirmed that `volta completeions zsh` doesn't panic