### PR TITLE
[Medium] Refactor hooks loading to avoid repeating project detection

### DIFF
--- a/crates/volta-core/src/event.rs
+++ b/crates/volta-core/src/event.rs
@@ -128,7 +128,7 @@ impl EventLog {
         self.events.push(event);
     }
 
-    pub fn publish(&mut self, plugin: Option<&Publish>) {
+    pub fn publish(&self, plugin: Option<&Publish>) {
         match plugin {
             // Note: This call to unimplemented is left in, as it's not a Fallible operation that can use ErrorKind::Unimplemented
             Some(&Publish::Url(_)) => unimplemented!(),

--- a/crates/volta-core/src/hook/mod.rs
+++ b/crates/volta-core/src/hook/mod.rs
@@ -1,7 +1,8 @@
 //! Provides types for working with Volta hooks.
 
-use std::env;
+use std::borrow::Cow;
 use std::fs::File;
+use std::iter::once;
 use std::marker::PhantomData;
 use std::path::Path;
 
@@ -38,9 +39,10 @@ impl LazyHookConfig {
         }
     }
 
-    /// Forces the loading of the hook configuration
-    pub fn get(&self) -> Fallible<&HookConfig> {
-        self.settings.try_borrow_with(HookConfig::current)
+    /// Forces the loading of the hook configuration from both project-local and user-default hooks
+    pub fn get(&self, project: Option<&Project>) -> Fallible<&HookConfig> {
+        self.settings
+            .try_borrow_with(|| HookConfig::current(project))
     }
 }
 
@@ -66,23 +68,22 @@ pub struct ToolHooks<T: Tool> {
 }
 
 impl<T: Tool> ToolHooks<T> {
-    /// Creates a merged struct, with "right" having precedence over "left".
-    fn merge(left: Self, right: Self) -> Self {
+    /// Extends this ToolHooks with another, giving precendence to the current instance
+    fn merge(self, other: Self) -> Self {
         Self {
-            distro: right.distro.or(left.distro),
-            latest: right.latest.or(left.latest),
-            index: right.index.or(left.index),
+            distro: self.distro.or(other.distro),
+            latest: self.latest.or(other.latest),
+            index: self.index.or(other.index),
             phantom: PhantomData,
         }
     }
 }
 
-macro_rules! merge_hook_config_field {
-    ($left:ident, $right:ident, $field:ident, $type:ident) => {
-        match ($left.$field, $right.$field) {
-            (Some(left), Some(right)) => Some($type::merge(left, right)),
-            (Some(left), None) => Some(left),
-            (None, Some(right)) => Some(right),
+macro_rules! merge_hooks {
+    ($self:ident, $other:ident, $field:ident) => {
+        match ($self.$field, $other.$field) {
+            (Some(current), Some(other)) => Some(current.merge(other)),
+            (Some(single), None) | (None, Some(single)) => Some(single),
             (None, None) => None,
         }
     };
@@ -111,52 +112,51 @@ impl HookConfig {
 
     /// Returns the current hooks, which are a merge between the user hooks and
     /// the project hooks (if any).
-    fn current() -> Fallible<Self> {
-        let maybe_project_config = Self::for_current_dir()?;
-        let maybe_default_config = Self::for_default()?;
-
-        Ok(match (maybe_project_config, maybe_default_config) {
-            (Some(project_config), Some(default_config)) => {
-                debug!("Merging default and project hooks");
-                Self::merge(default_config, project_config)
-            }
-            (Some(project_config), None) => project_config,
-            (None, Some(default_config)) => default_config,
-            (None, None) => {
-                debug!("No custom hooks found");
-                Self {
-                    node: None,
-                    npm: None,
-                    yarn: None,
-                    package: None,
-                    events: None,
+    fn current(project: Option<&Project>) -> Fallible<Self> {
+        Self::paths(project)?
+            .try_fold(None, |acc: Option<Self>, hooks_file| {
+                // Try to load the hooks and merge with any existing hooks
+                // Due to the iteration order, the existing hooks always have precedence
+                match Self::from_file(&hooks_file)? {
+                    Some(hooks) => {
+                        debug!("Loaded custom hooks file: {}", hooks_file.display());
+                        Ok(Some(match acc {
+                            Some(existing) => existing.merge(hooks),
+                            None => hooks,
+                        }))
+                    }
+                    None => Ok(acc),
                 }
-            }
-        })
+            })
+            // If there were no hooks loaded, provide a default empty HookConfig
+            .map(|maybe_config| {
+                maybe_config.unwrap_or_else(|| {
+                    debug!("No custom hooks found");
+                    Self {
+                        node: None,
+                        npm: None,
+                        yarn: None,
+                        package: None,
+                        events: None,
+                    }
+                })
+            })
     }
 
-    /// Returns the per-project hooks for the current directory.
-    fn for_current_dir() -> Fallible<Option<Self>> {
-        Self::for_dir(&env::current_dir().with_context(|| ErrorKind::CurrentDirError)?)
-    }
+    /// Returns an iterator of all the possible locations for a hooks file, in precedence order
+    ///
+    /// Item type is Cow<Path> to support both owned and borrowed values
+    fn paths<'a>(project: Option<&'a Project>) -> Fallible<impl Iterator<Item = Cow<'a, Path>>> {
+        let default_hooks_file = volta_home()?.default_hooks_file();
 
-    /// Returns the per-project hooks for the specified directory.  If the
-    /// specified directory is not itself a project, its ancestors will be
-    /// searched.
-    fn for_dir(base_dir: &Path) -> Fallible<Option<Self>> {
-        match Project::find_dir(&base_dir) {
-            Some(project_dir) => {
-                let path = project_dir.join(".volta").join("hooks.json");
-                let hooks_config = Self::from_file(&path)?;
-
-                if hooks_config.is_some() {
-                    debug!("Found project hooks in '{}'", path.display());
-                }
-
-                Ok(hooks_config)
-            }
-            None => Ok(None),
-        }
+        Ok(project
+            .map(|p| {
+                let mut path = p.project_root().join(".volta");
+                path.push("hooks.json");
+                Cow::Owned(path)
+            })
+            .into_iter()
+            .chain(once(Cow::Borrowed(default_hooks_file))))
     }
 
     fn from_file(file_path: &Path) -> Fallible<Option<Self>> {
@@ -173,31 +173,20 @@ impl HookConfig {
                 file: file_path.to_path_buf(),
             })?;
 
-        let hooks_path = file_path.parent().unwrap_or_else(|| Path::new("/"));
+        // Invariant: Since we successfully loaded the file, file_path _must_ have a parent
+        let hooks_path = file_path.parent().unwrap();
 
         raw.into_hook_config(hooks_path).map(Some)
     }
 
-    /// Returns the per-user hooks, loaded from the filesystem.
-    fn for_default() -> Fallible<Option<Self>> {
-        let path = volta_home()?.default_hooks_file();
-        let hooks_config = Self::from_file(&path)?;
-
-        if hooks_config.is_some() {
-            debug!("Found user hooks in '{}'", path.display());
-        }
-
-        Ok(hooks_config)
-    }
-
-    /// Creates a merged struct, with "right" having precedence over "left".
-    fn merge(left: Self, right: Self) -> Self {
+    /// Merges this HookConfig with another, giving precedence to the current instance
+    fn merge(self, other: Self) -> Self {
         Self {
-            node: merge_hook_config_field!(left, right, node, ToolHooks),
-            npm: merge_hook_config_field!(left, right, npm, ToolHooks),
-            yarn: merge_hook_config_field!(left, right, yarn, ToolHooks),
-            package: merge_hook_config_field!(left, right, package, ToolHooks),
-            events: merge_hook_config_field!(left, right, events, EventHooks),
+            node: merge_hooks!(self, other, node),
+            npm: merge_hooks!(self, other, npm),
+            yarn: merge_hooks!(self, other, yarn),
+            package: merge_hooks!(self, other, package),
+            events: merge_hooks!(self, other, events),
         }
     }
 }
@@ -209,10 +198,10 @@ pub struct EventHooks {
 }
 
 impl EventHooks {
-    /// Creates a merged struct, with "right" having precedence over "left".
-    fn merge(left: Self, right: Self) -> Self {
+    /// Merges this EventHooks with another, giving precedence to the current instance
+    fn merge(self, other: Self) -> Self {
         Self {
-            publish: right.publish.or(left.publish),
+            publish: self.publish.or(other.publish),
         }
     }
 }
@@ -390,53 +379,17 @@ pub mod tests {
     }
 
     #[test]
-    fn test_for_dir() {
-        let project_dir = fixture_path("hooks/project");
-        let hooks_dir = project_dir.join(".volta");
-        let hooks = HookConfig::for_dir(&project_dir)
-            .expect("Could not read project hooks.json")
-            .expect("Could not find project hooks.json");
-        let node = hooks.node.unwrap();
-
-        assert_eq!(
-            node.distro,
-            Some(tool::DistroHook::Bin {
-                bin: "/some/bin/for/node/distro".to_string(),
-                base_path: hooks_dir.clone(),
-            })
-        );
-        assert_eq!(
-            node.latest,
-            Some(tool::MetadataHook::Bin {
-                bin: "/some/bin/for/node/latest".to_string(),
-                base_path: hooks_dir.clone(),
-            })
-        );
-        assert_eq!(
-            node.index,
-            Some(tool::MetadataHook::Bin {
-                bin: "/some/bin/for/node/index".to_string(),
-                base_path: hooks_dir,
-            })
-        );
-        assert_eq!(
-            hooks.events.unwrap().publish,
-            Some(Publish::Bin("/events/bin".to_string()))
-        );
-    }
-
-    #[test]
     fn test_merge() {
         let fixture_dir = fixture_path("hooks");
         let default_hooks = HookConfig::from_file(&fixture_dir.join("templates.json"))
             .unwrap()
             .unwrap();
-        let project_dir = fixture_path("hooks/project");
-        let project_hooks_dir = project_dir.join(".volta");
-        let project_hooks = HookConfig::for_dir(&project_dir)
+        let project_hooks_dir = fixture_path("hooks/project/.volta");
+        let project_hooks_file = project_hooks_dir.join("hooks.json");
+        let project_hooks = HookConfig::from_file(&project_hooks_file)
             .expect("Could not read project hooks.json")
             .expect("Could not find project hooks.json");
-        let merged_hooks = HookConfig::merge(default_hooks, project_hooks);
+        let merged_hooks = project_hooks.merge(default_hooks);
         let node = merged_hooks.node.expect("No node config found");
         let yarn = merged_hooks.yarn.expect("No yarn config found");
 

--- a/crates/volta-core/src/project.rs
+++ b/crates/volta-core/src/project.rs
@@ -119,6 +119,11 @@ impl Project {
         self.project_root.join("package.json")
     }
 
+    /// Returns the path to the project root
+    pub fn project_root(&self) -> &Path {
+        &self.project_root
+    }
+
     /// Returns the path to the local binary directory for this project.
     pub fn local_bin_dir(&self) -> PathBuf {
         let sub_dir: PathBuf = ["node_modules", ".bin"].iter().collect();

--- a/tests/acceptance/hooks.rs
+++ b/tests/acceptance/hooks.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+
+use crate::support::sandbox::sandbox;
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+use volta_core::error::ExitCode;
+
+fn default_hooks_json() -> String {
+    format!(
+        r#"
+{{
+    "node": {{
+        "distro": {{
+            "template": "{}/hook/default/node/{{{{version}}}}"
+        }}
+    }},
+    "yarn": {{
+        "distro": {{
+            "template": "{0}/hook/default/yarn/{{{{version}}}}"
+        }}
+    }}
+}}"#,
+        mockito::SERVER_URL
+    )
+}
+
+fn project_hooks_json() -> String {
+    format!(
+        r#"
+{{
+    "yarn": {{
+        "distro": {{
+            "template": "{0}/hook/project/yarn/{{{{version}}}}"
+        }}
+    }}
+}}"#,
+        mockito::SERVER_URL
+    )
+}
+
+#[test]
+fn redirects_download() {
+    let s = sandbox().default_hooks(&default_hooks_json()).build();
+
+    assert_that!(
+        s.volta("install node@1.2.3"),
+        execs()
+            .with_status(ExitCode::NetworkError as i32)
+            .with_stderr_contains("[..]Could not download node@1.2.3")
+            .with_stderr_contains("[..]/hook/default/node/1.2.3")
+    );
+}
+
+#[test]
+fn merges_project_and_default_hooks() {
+    let local_hooks: PathBuf = [".volta", "hooks.json"].iter().collect();
+    let s = sandbox()
+        .package_json("{}")
+        .default_hooks(&default_hooks_json())
+        .project_file(&local_hooks.to_string_lossy(), &project_hooks_json())
+        .build();
+
+    // Project defines yarn hooks, so those should be used
+    assert_that!(
+        s.volta("install yarn@3.2.1"),
+        execs()
+            .with_status(ExitCode::NetworkError as i32)
+            .with_stderr_contains("[..]Could not download yarn@3.2.1")
+            .with_stderr_contains("[..]/hook/project/yarn/3.2.1")
+    );
+
+    // Project doesn't define node hooks, so should inherit from the default
+    assert_that!(
+        s.volta("install node@10.12.1"),
+        execs()
+            .with_status(ExitCode::NetworkError as i32)
+            .with_stderr_contains("[..]Could not download node@10.12.1")
+            .with_stderr_contains("[..]/hook/default/node/10.12.1")
+    );
+}

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -6,6 +6,7 @@ cfg_if! {
 
         // test files
         mod corrupted_download;
+        mod hooks;
         mod intercept_global_installs;
         mod merged_platform;
         mod migrations;

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -255,6 +255,13 @@ impl SandboxBuilder {
         self
     }
 
+    /// Set the hooks.json for the sandbox
+    pub fn default_hooks(mut self, contents: &str) -> Self {
+        self.files
+            .push(FileBuilder::new(default_hooks_file(), contents));
+        self
+    }
+
     /// Set a layout version file for the sandbox (chainable)
     pub fn layout_file(mut self, version: &str) -> Self {
         self.files.push(FileBuilder::new(layout_file(version), ""));
@@ -365,6 +372,13 @@ impl SandboxBuilder {
     /// Add an arbitrary file to the sandbox (chainable)
     pub fn file(mut self, path: &str, contents: &str) -> Self {
         let file_name = sandbox_path(path);
+        self.files.push(FileBuilder::new(file_name, contents));
+        self
+    }
+
+    /// Add an arbitrary file to the test project within the sandbox (chainable)
+    pub fn project_file(mut self, path: &str, contents: &str) -> Self {
+        let file_name = self.root().join(path);
         self.files.push(FileBuilder::new(file_name, contents));
         self
     }
@@ -536,6 +550,9 @@ fn package_image_dir(name: &str, version: &str) -> PathBuf {
 }
 fn default_platform_file() -> PathBuf {
     user_dir().join("platform.json")
+}
+fn default_hooks_file() -> PathBuf {
+    volta_home().join("hooks.json")
 }
 fn layout_file(version: &str) -> PathBuf {
     volta_home().join(format!("layout.{}", version))


### PR DESCRIPTION
Info
-----
* Since project-local hooks were implemented, the work to detect a project root (walking up the file system looking for `package.json` was duplicated between `Project` and `HookConfig`.
* With the prospect of support for workspaces coming soon, that work has the potential to grow significantly, since it will now involve parsing `package.json` to find the `extends` key.
* To prevent that duplication, we should use the values already detected by the `project` to locate project-local hooks.

Changes
-----
* Updated `HookConfig` to accept an optional `Project` item, and use the already detected `project_root` to find project-local hooks.
* Refactored the `merge` functions to be more idiomatic Rust methods, making the precedence more explicit with `self` and `other` instead of `left` and `right`.
* Refactored the top-level merging to work as an iterator of possible hook file locations.

Notes
-----
* The iterator-style merging in `HookConfig::paths` and `HookConfig::current` is slightly overkill for the current use-case where there are only 2 possible locations. However, it will be quite useful when the workspaces support adds the ability to have multiple project roots.