### PR TITLE
[Small] Error when installing a package manager before Node

### DIFF
--- a/crates/volta-core/src/error/kind.rs
+++ b/crates/volta-core/src/error/kind.rs
@@ -184,6 +184,11 @@ pub enum ErrorKind {
     /// Thrown when Yarn is not set at the command-line
     NoCommandLineYarn,
 
+    /// Thrown when a user tries to install a Yarn or npm version before installing a Node version.
+    NoDefaultNodeVersion {
+        tool: String,
+    },
+
     /// Thrown when there is no Node version matching a requested semver specifier.
     NodeVersionNotFound {
         matching: String,
@@ -842,6 +847,13 @@ Please ensure you have a Node version selected with `volta {} node` (see `volta 
 
 Use `volta run --yarn` to select a version (see `volta help run` for more info)."
             ),
+            ErrorKind::NoDefaultNodeVersion { tool } => write!(
+                f,
+                "Cannot install {} because the default Node version is not set.
+
+Use `volta install node` to select a default Node first, then install a {0} version.",
+                                tool
+            ),
             ErrorKind::NodeVersionNotFound { matching } => write!(
                 f,
                 r#"Could not find Node version matching "{}" in the version registry.
@@ -1468,6 +1480,7 @@ impl ErrorKind {
             ErrorKind::NoBinPlatform { .. } => ExitCode::ExecutionFailure,
             ErrorKind::NoBundledNpm { .. } => ExitCode::ConfigurationError,
             ErrorKind::NoCommandLineYarn => ExitCode::ConfigurationError,
+            ErrorKind::NoDefaultNodeVersion { .. } => ExitCode::ConfigurationError,
             ErrorKind::NodeVersionNotFound { .. } => ExitCode::NoVersionMatch,
             ErrorKind::NoGlobalInstalls { .. } => ExitCode::InvalidArguments,
             ErrorKind::NoHomeEnvironmentVar => ExitCode::EnvironmentError,

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -94,6 +94,11 @@ impl Toolchain {
                 platform.yarn = yarn;
                 self.save()?;
             }
+        } else if yarn.is_some() {
+            return Err(ErrorKind::NoDefaultNodeVersion {
+                tool: "Yarn".into(),
+            }
+            .into());
         }
 
         Ok(())
@@ -106,6 +111,8 @@ impl Toolchain {
                 platform.npm = npm;
                 self.save()?;
             }
+        } else if npm.is_some() {
+            return Err(ErrorKind::NoDefaultNodeVersion { tool: "npm".into() }.into());
         }
 
         Ok(())

--- a/tests/acceptance/corrupted_download.rs
+++ b/tests/acceptance/corrupted_download.rs
@@ -92,6 +92,7 @@ fn install_corrupted_yarn_leaves_inventory_unchanged() {
 #[test]
 fn install_valid_yarn_saves_to_inventory() {
     let s = sandbox()
+        .platform(r#"{ "node": { "runtime": "1.2.3", "npm": null }, "yarn": null }"#)
         .node_available_versions(NODE_VERSION_INFO)
         .yarn_available_versions(YARN_VERSION_INFO)
         .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)

--- a/tests/acceptance/volta_install.rs
+++ b/tests/acceptance/volta_install.rs
@@ -1,4 +1,6 @@
-use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, Sandbox};
+use crate::support::sandbox::{
+    sandbox, DistroMetadata, NodeFixture, NpmFixture, Sandbox, YarnFixture,
+};
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
@@ -114,6 +116,67 @@ cfg_if::cfg_if! {
     }
 }
 
+const YARN_VERSION_INFO: &str = r#"[
+{"tag_name":"v1.2.42","assets":[{"name":"yarn-v1.2.42.tar.gz"}]},
+{"tag_name":"v1.3.1","assets":[{"name":"yarn-v1.3.1.msi"}]},
+{"tag_name":"v1.4.159","assets":[{"name":"yarn-v1.4.159.tar.gz"}]},
+{"tag_name":"v1.7.71","assets":[{"name":"yarn-v1.7.71.tar.gz"}]},
+{"tag_name":"v1.12.99","assets":[{"name":"yarn-v1.12.99.tar.gz"}]}
+]"#;
+
+const YARN_VERSION_FIXTURES: [DistroMetadata; 4] = [
+    DistroMetadata {
+        version: "1.12.99",
+        compressed_size: 178,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.7.71",
+        compressed_size: 176,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.4.159",
+        compressed_size: 177,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.2.42",
+        compressed_size: 174,
+        uncompressed_size: Some(0x0028_0000),
+    },
+];
+
+const NPM_VERSION_INFO: &str = r#"
+{
+    "name":"npm",
+    "dist-tags": { "latest":"8.1.5" },
+    "versions": {
+        "1.2.3": { "version":"1.2.3", "dist": { "shasum":"", "tarball":"" }},
+        "4.5.6": { "version":"4.5.6", "dist": { "shasum":"", "tarball":"" }},
+        "8.1.5": { "version":"8.1.5", "dist": { "shasum":"", "tarball":"" }}
+    }
+}
+"#;
+
+const NPM_VERSION_FIXTURES: [DistroMetadata; 3] = [
+    DistroMetadata {
+        version: "1.2.3",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "4.5.6",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "8.1.5",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+];
+
 #[test]
 fn install_node_informs_newer_npm() {
     let s = sandbox()
@@ -180,5 +243,39 @@ fn install_npm_bundled_reports_info() {
         execs()
             .with_status(ExitCode::Success as i32)
             .with_stdout_contains("[..]set bundled npm (currently 5.6.7)[..]")
+    );
+}
+
+#[test]
+fn install_npm_without_node_errors() {
+    let s = sandbox()
+        .npm_available_versions(NPM_VERSION_INFO)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.volta("install npm@4.5.6"),
+        execs()
+            .with_status(ExitCode::ConfigurationError as i32)
+            .with_stderr_contains(
+                "[..]Cannot install npm because the default Node version is not set."
+            )
+    );
+}
+
+#[test]
+fn install_yarn_without_node_errors() {
+    let s = sandbox()
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .build();
+
+    assert_that!(
+        s.volta("install yarn@1.2.42"),
+        execs()
+            .with_status(ExitCode::ConfigurationError as i32)
+            .with_stderr_contains(
+                "[..]Cannot install Yarn because the default Node version is not set."
+            )
     );
 }


### PR DESCRIPTION
Closes #575 

Info
-----
Currently, calling `volta pin yarn` or `volta pin npm` when Node isn't yet pinned will (correctly) show an error. However, the same is not true for `volta install npm` or `volta install yarn`. Instead, `volta install npm` without a Node version set will report success, however then trying to call `npm` immediately after will fail.

Even worse, if you follow the instructions and subsequently install Node, the fact that you had installed a version of `npm` or `yarn` is lost and we tell you to install them again.

Changes
-----
Updated `Toolchain::set_active_npm` and `Toolchain::set_active_yarn` to show an error if the platform isn't set (i.e. there is no Node version selected), exactly as `Project::pin_npm` and `Project::pin_yarn` do in the same situation.

Tested
-----
Updated tests to support the new behavior and added tests to confirm that the errors are correctly thrown.

Note
-----
While making this change, I noticed a small UX issue: Currently on either `volta pin` _or_ `volta install`, we go through the entire "resolve -> fetch" process first, and only show the error once we go to persist the changes. We should be able to detect that the install / pin will fail earlier and show an error immediately, without waiting to resolve or fetch the version.

Opened #764  to address that separately.