### PR TITLE
[Small] Move node metadata into metadata submodule

### DIFF
--- a/crates/volta-core/src/tool/node/metadata.rs
+++ b/crates/volta-core/src/tool/node/metadata.rs
@@ -1,10 +1,28 @@
 use std::collections::HashSet;
 use std::iter::FromIterator;
 
-use super::resolve::{NodeDistroFiles, NodeEntry, NodeIndex};
 use crate::version::{option_version_serde, version_serde};
 use semver::Version;
 use serde::{Deserialize, Deserializer};
+
+/// The index of the public Node server.
+pub struct NodeIndex {
+    pub(super) entries: Vec<NodeEntry>,
+}
+
+#[derive(Debug)]
+pub struct NodeEntry {
+    pub version: Version,
+    pub npm: Version,
+    pub files: NodeDistroFiles,
+    pub lts: bool,
+}
+
+/// The set of available files on the public Node server for a given Node version.
+#[derive(Debug)]
+pub struct NodeDistroFiles {
+    pub files: HashSet<String>,
+}
 
 #[derive(Deserialize)]
 pub struct RawNodeIndex(Vec<RawNodeEntry>);

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -12,8 +12,8 @@ use log::info;
 use semver::Version;
 
 mod fetch;
+mod metadata;
 mod resolve;
-mod serial;
 
 pub use fetch::load_default_npm_version;
 pub use resolve::resolve;


### PR DESCRIPTION
Info
-----
* Having the metadata about node versions defined in the `resolve` submodule but then parsed in  the `serial` submodule made it a bit confusing to find where it was defined and how it was used.

Changes
-----
* Renamed `node::serial` to `node::metadata`
* Moved the definition of the metadata types into the `metadata` module.

Tested
-----
* This is purely a reorganization of code, no functional changes should happen.
* All tests pass.