### PR TITLE
[Tiny] Move yarn metadata into metadata submodule

### DIFF
--- a/crates/volta-core/src/tool/yarn/metadata.rs
+++ b/crates/volta-core/src/tool/yarn/metadata.rs
@@ -1,9 +1,13 @@
 use std::collections::BTreeSet;
 
-use super::resolve::YarnIndex;
 use crate::version::version_serde;
 use semver::Version;
 use serde::Deserialize;
+
+/// The public Yarn index.
+pub struct YarnIndex {
+    pub(super) entries: BTreeSet<Version>,
+}
 
 #[derive(Deserialize)]
 pub struct RawYarnIndex(Vec<RawYarnEntry>);

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -10,8 +10,8 @@ use crate::style::tool_version;
 use semver::Version;
 
 mod fetch;
+mod metadata;
 mod resolve;
-mod serial;
 
 pub use resolve::resolve;
 

--- a/crates/volta-core/src/tool/yarn/resolve.rs
+++ b/crates/volta-core/src/tool/yarn/resolve.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeSet;
 
 use super::super::registry_fetch_error;
-use super::serial;
+use super::metadata::{RawYarnIndex, YarnIndex};
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::hook::ToolHooks;
 use crate::session::Session;
@@ -85,7 +85,7 @@ fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Yarn>>) -> Fall
     };
 
     let spinner = progress_spinner(&format!("Fetching public registry: {}", url));
-    let releases: serial::RawYarnIndex = attohttpc::get(&url)
+    let releases: RawYarnIndex = attohttpc::get(&url)
         .send()
         .and_then(Response::error_for_status)
         .and_then(Response::json)
@@ -108,9 +108,4 @@ fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Yarn>>) -> Fall
         }
         .into()),
     }
-}
-
-/// The public Yarn index.
-pub struct YarnIndex {
-    pub(super) entries: BTreeSet<Version>,
 }


### PR DESCRIPTION
Info
-----
* Having the metadata about Yarn versions defined in the `resolve` submodule but then parsed in  the `serial` submodule made it a bit confusing to find where it was defined and how it was used.

Changes
-----
* Renamed `yarn::serial` to `yarn::metadata`
* Moved the definition of the metadata type into the `metadata` module.

Tested
-----
* This is purely a reorganization of code, no functional changes should happen.
* All tests pass.