### PR TITLE
[Medium] Restructure Tool Metadata

### DIFF
--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -9,6 +9,7 @@ use log::{debug, info};
 pub mod node;
 pub mod npm;
 pub mod package;
+mod registry;
 mod serial;
 pub mod yarn;
 
@@ -16,7 +17,8 @@ pub use node::{
     load_default_npm_version, Node, NODE_DISTRO_ARCH, NODE_DISTRO_EXTENSION, NODE_DISTRO_OS,
 };
 pub use npm::{BundledNpm, Npm};
-pub use package::{bin_full_path, BinConfig, BinLoader, Package, PackageConfig, PackageDetails};
+pub use package::{bin_full_path, BinConfig, BinLoader, Package, PackageConfig};
+pub use registry::PackageDetails;
 pub use yarn::Yarn;
 
 #[inline]

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -12,8 +12,8 @@ use log::info;
 use semver::Version;
 
 mod fetch;
+mod metadata;
 mod resolve;
-mod serial;
 
 pub use fetch::load_default_npm_version;
 pub use resolve::resolve;

--- a/crates/volta-core/src/tool/npm/resolve.rs
+++ b/crates/volta-core/src/tool/npm/resolve.rs
@@ -46,7 +46,7 @@ pub fn resolve(matching: VersionSpec, session: &mut Session) -> Fallible<Option<
 
 fn fetch_npm_index(
     hooks: Option<&ToolHooks<Npm>>,
-) -> Fallible<(String, package::resolve::PackageIndex)> {
+) -> Fallible<(String, package::metadata::PackageIndex)> {
     let url = match hooks {
         Some(&ToolHooks {
             index: Some(ref hook),
@@ -59,7 +59,7 @@ fn fetch_npm_index(
     };
 
     let spinner = progress_spinner(&format!("Fetching public registry: {}", url));
-    let metadata: package::serial::RawPackageMetadata = attohttpc::get(&url)
+    let metadata: package::metadata::RawPackageMetadata = attohttpc::get(&url)
         .header(ACCEPT, NPM_ABBREVIATED_ACCEPT_HEADER)
         .send()
         .and_then(Response::error_for_status)

--- a/crates/volta-core/src/tool/package/metadata.rs
+++ b/crates/volta-core/src/tool/package/metadata.rs
@@ -3,16 +3,103 @@ use std::convert::{TryFrom, TryInto};
 use std::fs::{read_to_string, write};
 use std::path::{Path, PathBuf};
 
-use super::install::{BinConfig, BinLoader, PackageConfig};
-use super::resolve::PackageIndex;
 use super::PackageDetails;
 use crate::error::{Context, ErrorKind, Fallible, VoltaError};
 use crate::layout::volta_home;
+use crate::platform::PlatformSpec;
 use crate::toolchain;
 use crate::version::{hashmap_version_serde, version_serde};
 use fs_utils::ensure_containing_dir_exists;
 use semver::Version;
 use serde::{Deserialize, Serialize};
+
+/// Configuration information about an installed package.
+///
+/// This information will be stored in ~/.volta/tools/user/packages/<package>.json.
+///
+/// For an example, this looks like:
+///
+/// {
+///   "name": "cowsay",
+///   "version": "1.4.0",
+///   "platform": {
+///     "node": {
+///       "runtime": "11.10.1",
+///       "npm": "6.7.0"
+///     },
+///     "yarn": null
+///   },
+///   "bins": [
+///     "cowsay",
+///     "cowthink"
+///   ]
+/// }
+#[derive(PartialOrd, Ord, PartialEq, Eq)]
+pub struct PackageConfig {
+    /// The package name
+    pub name: String,
+    /// The package version
+    pub version: Version,
+    /// The platform used to install this package
+    pub platform: PlatformSpec,
+    /// The binaries installed by this package
+    pub bins: Vec<String>,
+}
+
+/// Configuration information about an installed binary from a package.
+///
+/// This information will be stored in ~/.volta/tools/user/bins/<bin-name>.json.
+///
+/// For an example, this looks like:
+///
+/// {
+///   "name": "cowsay",
+///   "package": "cowsay",
+///   "version": "1.4.0",
+///   "path": "./cli.js",
+///   "platform": {
+///     "node": {
+///       "runtime": "11.10.1",
+///       "npm": "6.7.0"
+///     },
+///     "yarn": null,
+///     "loader": {
+///       "exe": "node",
+///       "args": []
+///     }
+///   }
+/// }
+pub struct BinConfig {
+    /// The binary name
+    pub name: String,
+    /// The package that installed this binary
+    pub package: String,
+    /// The package version
+    pub version: Version,
+    /// The relative path of the binary in the installed package
+    pub path: String,
+    /// The platform used to install this binary
+    pub platform: PlatformSpec,
+    /// The loader information for the script, if any
+    pub loader: Option<BinLoader>,
+}
+
+/// Information about the Shebang script loader (e.g. `#!/usr/bin/env node`)
+///
+/// Only important for Windows at the moment, as Windows does not natively understand script
+/// loaders, so we need to provide that behavior when calling a script that uses one
+pub struct BinLoader {
+    /// The command used to run a script
+    pub command: String,
+    /// Any additional arguments specified for the loader
+    pub args: Vec<String>,
+}
+
+/// Index of versions of a specific package.
+pub struct PackageIndex {
+    pub tags: HashMap<String, Version>,
+    pub entries: Vec<PackageDetails>,
+}
 
 /// Package Metadata Response
 ///

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -16,10 +16,10 @@ use semver::Version;
 
 mod fetch;
 mod install;
+pub(crate) mod metadata;
 pub(crate) mod resolve;
-pub(crate) mod serial;
 
-pub use install::{BinConfig, BinLoader, PackageConfig};
+pub use metadata::{BinConfig, BinLoader, PackageConfig};
 pub use resolve::resolve;
 
 pub fn bin_full_path<P>(

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Display};
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use super::registry::PackageDetails;
 use super::{debug_already_fetched, info_fetched, Tool};
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::fs::{delete_dir_error, delete_file_error, dir_entry_match};
@@ -39,14 +40,6 @@ where
     canonicalize(raw_path).with_context(|| ErrorKind::ExecutablePathError {
         command: bin_name.to_string(),
     })
-}
-
-/// Details required for fetching a 3rd-party Package
-#[derive(Debug)]
-pub struct PackageDetails {
-    pub(crate) version: Version,
-    pub(crate) tarball_url: String,
-    pub(crate) shasum: String,
 }
 
 /// The Tool implementation for fetching and installing 3rd-party packages

--- a/crates/volta-core/src/tool/package/resolve.rs
+++ b/crates/volta-core/src/tool/package/resolve.rs
@@ -1,7 +1,6 @@
 //! Provides resolution of 3rd-party packages into specific versions, using the npm repository
 
-use std::collections::HashMap;
-
+use super::metadata::PackageIndex;
 use crate::error::{Context, ErrorKind, Fallible, VoltaError};
 use crate::hook::ToolHooks;
 use crate::platform::CliPlatform;
@@ -12,7 +11,7 @@ use crate::tool::PackageDetails;
 use crate::version::{VersionSpec, VersionTag};
 use attohttpc::{Response, StatusCode};
 use log::debug;
-use semver::{Version, VersionReq};
+use semver::VersionReq;
 
 pub fn resolve(
     name: &str,
@@ -102,12 +101,6 @@ fn resolve_semver(
     }
 }
 
-/// Index of versions of a specific package.
-pub struct PackageIndex {
-    pub tags: HashMap<String, Version>,
-    pub entries: Vec<PackageDetails>,
-}
-
 /// Use `npm view` to get the info for the package. This supports:
 ///
 /// * normal package installation from the public npm repo
@@ -140,12 +133,10 @@ fn npm_view_query(name: &str, version: &str, session: &mut Session) -> Fallible<
     // Sometimes the returned JSON is an array (semver case), otherwise it's a single object.
     // Check if the first char is '[' and parse as an array if so
     if response_json.starts_with('[') {
-        let metadatas: Vec<super::serial::NpmViewData> = serde_json::de::from_str(&response_json)
-            .with_context(|| {
-            ErrorKind::NpmViewMetadataParseError {
+        let metadatas: Vec<super::metadata::NpmViewData> = serde_json::de::from_str(&response_json)
+            .with_context(|| ErrorKind::NpmViewMetadataParseError {
                 package: name.to_string(),
-            }
-        })?;
+            })?;
         debug!("[parsed package metadata (array)]\n{:?}", metadatas);
 
         // get latest version, making sure the array is not empty
@@ -167,7 +158,7 @@ fn npm_view_query(name: &str, version: &str, session: &mut Session) -> Fallible<
 
         Ok(PackageIndex { tags, entries })
     } else {
-        let metadata: super::serial::NpmViewData = serde_json::de::from_str(&response_json)
+        let metadata: super::metadata::NpmViewData = serde_json::de::from_str(&response_json)
             .with_context(|| ErrorKind::NpmViewMetadataParseError {
                 package: name.to_string(),
             })?;
@@ -193,7 +184,7 @@ fn npm_view_command_for(name: &str, version: &str, session: &mut Session) -> Fal
 fn resolve_package_metadata(
     package_name: &str,
     package_info_url: &str,
-) -> Fallible<super::serial::RawPackageMetadata> {
+) -> Fallible<super::metadata::RawPackageMetadata> {
     let spinner = progress_spinner(&format!("Fetching package metadata: {}", package_info_url));
     let response_text = attohttpc::get(package_info_url)
         .send()
@@ -214,7 +205,7 @@ fn resolve_package_metadata(
             VoltaError::from_source(err, kind)
         })?;
 
-    let metadata: super::serial::RawPackageMetadata = serde_json::de::from_str(&response_text)
+    let metadata: super::metadata::RawPackageMetadata = serde_json::de::from_str(&response_text)
         .with_context(|| ErrorKind::ParsePackageMetadataError {
             from_url: package_info_url.to_string(),
         })?;

--- a/crates/volta-core/src/tool/registry.rs
+++ b/crates/volta-core/src/tool/registry.rs
@@ -1,0 +1,69 @@
+use std::collections::HashMap;
+
+use crate::version::{hashmap_version_serde, version_serde};
+use semver::Version;
+use serde::Deserialize;
+
+/// Details about a package in the npm Registry
+#[derive(Debug)]
+pub struct PackageDetails {
+    pub(crate) version: Version,
+    pub(crate) tarball_url: String,
+    pub(crate) shasum: String,
+}
+
+/// Index of versions of a specific package from the npm Registry
+pub struct PackageIndex {
+    pub tags: HashMap<String, Version>,
+    pub entries: Vec<PackageDetails>,
+}
+
+/// Package Metadata Response
+///
+/// See npm registry API doc:
+/// https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md
+#[derive(Deserialize, Debug)]
+pub struct RawPackageMetadata {
+    pub name: String,
+    pub versions: HashMap<String, RawPackageVersionInfo>,
+    #[serde(
+        rename = "dist-tags",
+        deserialize_with = "hashmap_version_serde::deserialize"
+    )]
+    pub dist_tags: HashMap<String, Version>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct RawPackageVersionInfo {
+    // there's a lot more in there, but right now just care about the version
+    #[serde(with = "version_serde")]
+    pub version: Version,
+    pub dist: RawDistInfo,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct RawDistInfo {
+    pub shasum: String,
+    pub tarball: String,
+}
+
+impl From<RawPackageMetadata> for PackageIndex {
+    fn from(serial: RawPackageMetadata) -> PackageIndex {
+        let mut entries: Vec<PackageDetails> = serial
+            .versions
+            .into_iter()
+            .map(|(_, version_info)| PackageDetails {
+                version: version_info.version,
+                tarball_url: version_info.dist.tarball,
+                shasum: version_info.dist.shasum,
+            })
+            .collect();
+
+        entries.sort_by(|a, b| b.version.cmp(&a.version));
+
+        PackageIndex {
+            tags: serial.dist_tags,
+            entries,
+        }
+    }
+}

--- a/crates/volta-core/src/tool/registry.rs
+++ b/crates/volta-core/src/tool/registry.rs
@@ -1,8 +1,26 @@
 use std::collections::HashMap;
 
 use crate::version::{hashmap_version_serde, version_serde};
+use cfg_if::cfg_if;
 use semver::Version;
 use serde::Deserialize;
+
+// Accept header needed to request the abbreviated metadata from the npm registry
+// See https://github.com/npm/registry/blob/master/docs/responses/package-metadata.md
+pub const NPM_ABBREVIATED_ACCEPT_HEADER: &str =
+    "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
+
+cfg_if! {
+    if #[cfg(feature = "mock-network")] {
+        pub fn public_registry_index(package: &str) -> String {
+            format!("{}/{}", mockito::SERVER_URL, package)
+        }
+    } else {
+        pub fn public_registry_index(package: &str) -> String {
+            format!("https://registry.npmjs.org/{}", package)
+        }
+    }
+}
 
 /// Details about a package in the npm Registry
 #[derive(Debug)]

--- a/crates/volta-core/src/tool/registry.rs
+++ b/crates/volta-core/src/tool/registry.rs
@@ -22,6 +22,15 @@ cfg_if! {
     }
 }
 
+pub fn public_registry_package(package: &str, version: &str) -> String {
+    format!(
+        "{}/-/{}-{}.tgz",
+        public_registry_index(package),
+        package,
+        version
+    )
+}
+
 /// Details about a package in the npm Registry
 #[derive(Debug)]
 pub struct PackageDetails {

--- a/crates/volta-core/src/tool/yarn/metadata.rs
+++ b/crates/volta-core/src/tool/yarn/metadata.rs
@@ -1,9 +1,13 @@
 use std::collections::BTreeSet;
 
-use super::resolve::YarnIndex;
 use crate::version::version_serde;
 use semver::Version;
 use serde::Deserialize;
+
+/// The public Yarn index.
+pub struct YarnIndex {
+    pub(super) entries: BTreeSet<Version>,
+}
 
 #[derive(Deserialize)]
 pub struct RawYarnIndex(Vec<RawYarnEntry>);

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -10,8 +10,8 @@ use crate::style::tool_version;
 use semver::Version;
 
 mod fetch;
+mod metadata;
 mod resolve;
-mod serial;
 
 pub use resolve::resolve;
 

--- a/crates/volta-core/src/tool/yarn/resolve.rs
+++ b/crates/volta-core/src/tool/yarn/resolve.rs
@@ -1,9 +1,7 @@
 //! Provides resolution of Yarn requirements into specific versions
 
-use std::collections::BTreeSet;
-
 use super::super::registry_fetch_error;
-use super::serial;
+use super::metadata::{RawYarnIndex, YarnIndex};
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::hook::ToolHooks;
 use crate::session::Session;
@@ -85,7 +83,7 @@ fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Yarn>>) -> Fall
     };
 
     let spinner = progress_spinner(&format!("Fetching public registry: {}", url));
-    let releases: serial::RawYarnIndex = attohttpc::get(&url)
+    let releases: RawYarnIndex = attohttpc::get(&url)
         .send()
         .and_then(Response::error_for_status)
         .and_then(Response::json)
@@ -108,9 +106,4 @@ fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Yarn>>) -> Fall
         }
         .into()),
     }
-}
-
-/// The public Yarn index.
-pub struct YarnIndex {
-    pub(super) entries: BTreeSet<Version>,
 }


### PR DESCRIPTION
Info
-----
* Metadata parsing for the various tool resolution / installation processes was spread in anunintuitive way.
* The main structs were defined in the `resolve` submodule for each tool, but then the deserialization of those structs was defined in `serial` that was a sibling of `resolve`.
* Also, the metadata defined in `package` around the npm Registry format was used in multiple places outside of Package, so it doesn't make sense to have it exclusively confined to `package` any more.

Changes
-----
* Renamed module `serial` to `metadata` for each tool.
* Moved the definition of the deserialized structs into the `metadata` method, so that it sits along side the deserializiation.
* Added a `tool::registry` module to hold all of the structs related to the npm Registry.
* Moved constants related to the npm Registry ('Accept' header value and urls) into the `registry` module.

Notes
-----
* This should be only a code organization change, no functionality should be any different.