### PR TITLE
[Tiny] Update command doc comments to avoid completions bug

### DIFF
--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -204,7 +204,7 @@ pub(crate) struct List {
     // `Option<Subcommand>` with `impl FromStr for Subcommand` for `StructOpt`
     // because StructOpt does not currently support custom parsing for enum
     // variants (as detailed in commit 5f9214ae).
-    /// The tool to lookup: `all`, `node`, `yarn`, or the name of a package or binary.
+    /// The tool to lookup - `all`, `node`, `yarn`, or the name of a package or binary.
     #[structopt(name = "tool")]
     subcommand: Option<String>,
 


### PR DESCRIPTION
Closes #770 
Closes #496 

Info
-----
* StructOpt / Clap seem to generate invalid completions files for zsh when there is a `:` in the description for a command or flag.
* This results in very weird behavior when pressing Tab while using the auto-generated completions.

Changes
-----
* Removed the `:` from the `volta list` description, replacing it with a `-`

Tested
-----
* Confirmed locally that completions no longer error.