### PR TITLE
Fix writing of npm launch scripts on Windows

### DIFF
--- a/crates/volta-core/src/tool/npm/fetch.rs
+++ b/crates/volta-core/src/tool/npm/fetch.rs
@@ -175,7 +175,7 @@ node "$basedir/{}-cli.js" "$@"
 #[cfg(windows)]
 fn overwrite_cmd_launcher(base_path: &Path, tool: &str) -> Fallible<()> {
     write(
-        base_path.join(tool),
+        base_path.join(format!("{}.cmd", tool)),
         // Note: Adapted from the existing npm/npx cmd launcher, without unnecessary detection of Node location
         format!(
             r#"@ECHO OFF


### PR DESCRIPTION
Closes #776 

Info
-----
* The windows-specific overwriting of the npm `cmd` launcher is writing the wrong file. It's writing `npm` and `npx` instead of `npm.cmd` and `npx.cmd`
* This causes `npm.cmd` to not be correctly updated and to look in the wrong location for the actual JS script

Changes
-----
* Updated `overwrite_cmd_launcher` to make sure it is writing the `*.cmd` files.

Tested
-----
* Confirmed that custom npm versions run correctly on Windows.