### PR TITLE
[Small] Treat files / dirs not existing as a successful remove

### DIFF
--- a/crates/volta-core/src/shim.rs
+++ b/crates/volta-core/src/shim.rs
@@ -120,6 +120,7 @@ pub fn delete(shim_name: &str) -> Fallible<ShimResult> {
 #[cfg(windows)]
 mod windows {
     use crate::error::{Context, ErrorKind, Fallible, VoltaError};
+    use crate::fs::remove_file_if_exists;
     use crate::layout::volta_home;
     use std::fs::{remove_file, write};
     use std::io;
@@ -135,17 +136,8 @@ mod windows {
 
     pub fn delete_git_bash_script(shim_name: &str) -> Fallible<()> {
         let script_path = volta_home()?.shim_git_bash_script_file(shim_name);
-        remove_file(script_path).or_else(|e| {
-            if e.kind() == io::ErrorKind::NotFound {
-                Ok(())
-            } else {
-                Err(VoltaError::from_source(
-                    e,
-                    ErrorKind::ShimRemoveError {
-                        name: shim_name.to_string(),
-                    },
-                ))
-            }
+        remove_file_if_exists(script_path).with_context(|| ErrorKind::ShimRemoveError {
+            name: shim_name.to_string(),
         })
     }
 }

--- a/crates/volta-core/src/tool/package/fetch.rs
+++ b/crates/volta-core/src/tool/package/fetch.rs
@@ -5,7 +5,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 
 use crate::error::{Context, ErrorKind, Fallible};
-use crate::fs::{create_staging_dir, ensure_dir_does_not_exist, read_dir_eager, read_file, rename};
+use crate::fs::{create_staging_dir, read_dir_eager, read_file, remove_dir_if_exists, rename};
 use crate::layout::volta_home;
 use crate::platform::CliPlatform;
 use crate::run::{self, ToolCommand};
@@ -201,7 +201,7 @@ fn unpack_archive(archive: Box<dyn Archive>, name: &str, version: &Version) -> F
         path: image_dir.clone(),
     })?;
     // and ensure that the target directory does not exist
-    ensure_dir_does_not_exist(&image_dir)?;
+    remove_dir_if_exists(&image_dir)?;
 
     let unpack_dir = find_unpack_dir(temp.path())?;
     rename(unpack_dir, &image_dir).with_context(|| ErrorKind::SetupToolImageError {

--- a/crates/volta-migrate/src/v2.rs
+++ b/crates/volta-migrate/src/v2.rs
@@ -8,7 +8,7 @@ use log::debug;
 use semver::Version;
 use tempfile::tempdir_in;
 use volta_core::error::{Context, ErrorKind, Fallible, VoltaError};
-use volta_core::fs::{ensure_dir_does_not_exist, read_dir_eager, rename};
+use volta_core::fs::{read_dir_eager, remove_dir_if_exists, rename};
 use volta_core::tool::load_default_npm_version;
 use volta_core::toolchain::serial::Platform;
 use volta_core::version::parse_version;
@@ -169,7 +169,7 @@ fn remove_npm_version_from_node_image_dir(
             version: node_string.clone(),
             dir: temp_image.clone(),
         })?;
-        ensure_dir_does_not_exist(&new_install)?;
+        remove_dir_if_exists(&new_install)?;
         rename(&temp_image, &new_install).with_context(|| ErrorKind::SetupToolImageError {
             tool: "Node".into(),
             version: node_string,


### PR DESCRIPTION
Closes #786 

Info
-----
* When running `volta uninstall`, we were deleting the config file with the assumption that it was there.
* If it wasn't, that would cause an error and abort the entire uninstall process.
* Since the goal of uninstall is to remove the file, if it isn't there, we should treat that as success.

Changes
-----
* Added `remove_file_if_exists` helper to `fs` module.
* Renamed `ensure_dir_does_not_exist` to `remove_dir_if_exists` for consistency.
* Updated calls to use the helper methods

Note
-----
Both methods attempt to delete the appropriate item and handle the `ErrorKind::NotFound` error type as a success. This avoids potential race conditions that could pop up when doing a separate check for if the item exists.