### PR TITLE
[Tiny] Update version requirement parsing to support hyphen ranges

### DIFF
--- a/crates/volta-core/src/version/serial.rs
+++ b/crates/volta-core/src/version/serial.rs
@@ -12,16 +12,9 @@ use semver::{Compat, ReqParseError, VersionReq};
 // then serializing them to pass to `npm view`, they need to be handled in
 // a Node-compatible way (or we get the wrong version info returned).
 pub fn parse_requirements(src: &str) -> Result<VersionReq, ReqParseError> {
-    let src = src.trim();
-    if !src.is_empty() && src.chars().next().unwrap().is_digit(10) {
-        let defaulted = format!("={}", src);
-        VersionReq::parse_compat(&defaulted, Compat::Node)
-    } else if !src.is_empty() && src.starts_with('v') {
-        let defaulted = src.replacen("v", "=", 1);
-        VersionReq::parse_compat(&defaulted, Compat::Node)
-    } else {
-        VersionReq::parse_compat(src, Compat::Node)
-    }
+    let src = src.trim().trim_start_matches('v');
+
+    VersionReq::parse_compat(src, Compat::Node)
 }
 
 #[cfg(test)]
@@ -51,6 +44,10 @@ pub mod tests {
         assert_eq!(
             parse_requirements(">=1.4").unwrap(),
             VersionReq::parse_compat(">=1.4", Compat::Node).unwrap()
+        );
+        assert_eq!(
+            parse_requirements("8.11 - 8.17 || 10.* || >= 12").unwrap(),
+            VersionReq::parse_compat("8.11 - 8.17 || 10.* || >= 12", Compat::Node).unwrap()
         );
     }
 }


### PR DESCRIPTION
Info
-----
Our current `parse_requirements` function is appending an `=` to any requirement that starts with a digit. This causes hyphen ranges (e.g. `8.11 - 8.17`) to be turned into invalid requirements (`=8.11 - 8.17`), which in turn causes the parse to fail. It appears that `VersionReq::parse_compat` already correctly parses `1` as `=1`, and so on, so adding the additional `=` character is redundant for those cases.

@mikrostew Do you have more context on why we were adding the `=` character? Is there a common case that is missed by excluding that character?

Changes
-----
* Updated `parse_requirements` to avoid prepending the `=` character, but still strip off a leading `v`

Tested
-----
* Added a unit test for hyphen ranges, which now passes.
* All the existing tests pass without changes.