### PR TITLE
[Small] Extend locks through entire install process

### DIFF
--- a/crates/volta-core/src/sync.rs
+++ b/crates/volta-core/src/sync.rs
@@ -37,6 +37,7 @@ impl VoltaLock {
 impl Drop for VoltaLock {
     #[allow(unused_must_use)]
     fn drop(&mut self) {
+        debug!("Unlocking Volta Directory");
         self.inner.unlock();
     }
 }


### PR DESCRIPTION
Info
-----
* With the implementation of #684, we are locking the Volta directory while fetching new versions of tools.
* However, we are _not_ locking the directory while performing additional actions (such as writing the default platform file or installing package dependencies).

Changes
-----
* Return the (optional) lock guard from each Tool's `ensure_fetched` function, allowing the subsequent behavior to keep the lock active until the entire process is completed.
* Added a debug statement to the `Drop` impl to show when the lock is dropped as well.
* Updated the `install` method on each Tool to keep the lock in scope throughout the process.

Tested
-----
* Confirmed through debug statements that the lock is maintained throughout the entire install process for each tool.