### PR TITLE
[Medium] Extend Locks through entire install process

### DIFF
--- a/crates/volta-core/src/error/kind.rs
+++ b/crates/volta-core/src/error/kind.rs
@@ -171,6 +171,9 @@ pub enum ErrorKind {
         errors: Vec<String>,
     },
 
+    /// Thrown when unable to acquire a lock on the Volta directory
+    LockAcquireError,
+
     /// Thrown when BinConfig (read from file) does not contain Platform info.
     NoBinPlatform {
         binary: String,
@@ -826,7 +829,11 @@ To {action} the packages '{name}' and '{version}', please {action} them in separ
                     name, call_to_action, formatted_errs
                 )
             }
-
+            // Note: No CTA as this error is purely informational and shouldn't be exposed to the user
+            ErrorKind::LockAcquireError => write!(
+                f,
+                "Unable to acquire lock on Volta directory"
+            ),
             ErrorKind::NoBinPlatform { binary } => write!(
                 f,
                 "Platform info for executable `{}` is missing
@@ -1477,6 +1484,7 @@ impl ErrorKind {
             ErrorKind::InvalidHookOutput { .. } => ExitCode::ExecutionFailure,
             ErrorKind::InvalidInvocation { .. } => ExitCode::InvalidArguments,
             ErrorKind::InvalidToolName { .. } => ExitCode::InvalidArguments,
+            ErrorKind::LockAcquireError => ExitCode::FileSystemError,
             ErrorKind::NoBinPlatform { .. } => ExitCode::ExecutionFailure,
             ErrorKind::NoBundledNpm { .. } => ExitCode::ConfigurationError,
             ErrorKind::NoCommandLineYarn => ExitCode::ConfigurationError,

--- a/crates/volta-core/src/shim.rs
+++ b/crates/volta-core/src/shim.rs
@@ -8,9 +8,12 @@ use std::path::Path;
 use crate::error::{Context, ErrorKind, Fallible, VoltaError};
 use crate::fs::{read_dir_eager, symlink_file};
 use crate::layout::{volta_home, volta_install};
+use crate::sync::VoltaLock;
 use log::debug;
 
 pub fn regenerate_shims_for_dir(dir: &Path) -> Fallible<()> {
+    // Acquire a lock on the Volta directory, if possible, to prevent concurrent changes
+    let _lock = VoltaLock::acquire();
     debug!("Rebuilding shims for directory: {}", dir.display());
     for shim_name in get_shim_list_deduped(dir)?.iter() {
         delete(shim_name)?;

--- a/crates/volta-core/src/sync.rs
+++ b/crates/volta-core/src/sync.rs
@@ -1,42 +1,94 @@
 use std::fs::{File, OpenOptions};
+use std::marker::PhantomData;
 use std::ops::Drop;
-use std::path::Path;
+use std::sync::Mutex;
 
+use crate::error::{Context, ErrorKind, Fallible};
+use crate::layout::volta_home;
 use crate::style::progress_spinner;
 use fs2::FileExt;
+use lazy_static::lazy_static;
 use log::debug;
+
+lazy_static! {
+    static ref LOCK_STATE: Mutex<Option<LockState>> = Mutex::new(None);
+}
+
+struct LockState {
+    file: File,
+    count: usize,
+}
 
 const LOCK_FILE: &str = "volta.lock";
 
-/// An RAII implementation of an exclusive lock on the Volta directory. When this falls out of scope,
-/// the lock will be unlocked.
+/// An RAII implementation of a process lock on the Volta directory. A given Volta process can have
+/// multiple active locks, but only one process can have any locks at a time.
+///
+/// Once all of the `VoltaLock` objects go out of scope, the lock will be released to other
+/// processes.
 pub struct VoltaLock {
-    inner: File,
+    // Private field ensures that this cannot be created except for with the `acquire()` method
+    _private: PhantomData<()>,
 }
 
 impl VoltaLock {
-    pub fn acquire(volta_home: &Path) -> std::io::Result<Self> {
-        let path = volta_home.join(LOCK_FILE);
-        debug!("Acquiring lock on Volta directory: {}", path.display());
+    pub fn acquire() -> Fallible<Self> {
+        let mut state = LOCK_STATE
+            .lock()
+            .with_context(|| ErrorKind::LockAcquireError)?;
 
-        let file = OpenOptions::new().write(true).create(true).open(path)?;
-        // First we try to lock the file without blocking. If that fails, then we show a spinner
-        // and block until the lock completes.
-        if file.try_lock_exclusive().is_err() {
-            let spinner = progress_spinner("Waiting for file lock on Volta directory");
-            // Note: Blocks until the file can be locked
-            let lock_result = file.lock_exclusive();
-            spinner.finish_and_clear();
-            lock_result?;
+        match &mut *state {
+            Some(inner) => {
+                inner.count += 1;
+            }
+            None => {
+                let path = volta_home()?.root().join(LOCK_FILE);
+                debug!("Acquiring lock on Volta directory: {}", path.display());
+
+                let file = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(path)
+                    .with_context(|| ErrorKind::LockAcquireError)?;
+                // First we try to lock the file without blocking. If that fails, then we show a spinner
+                // and block until the lock completes.
+                if file.try_lock_exclusive().is_err() {
+                    let spinner = progress_spinner("Waiting for file lock on Volta directory");
+                    // Note: Blocks until the file can be locked
+                    let lock_result = file
+                        .lock_exclusive()
+                        .with_context(|| ErrorKind::LockAcquireError);
+                    spinner.finish_and_clear();
+                    lock_result?;
+                }
+
+                *state = Some(LockState { file, count: 1 });
+            }
         }
 
-        Ok(Self { inner: file })
+        Ok(Self {
+            _private: PhantomData,
+        })
     }
 }
 
 impl Drop for VoltaLock {
-    #[allow(unused_must_use)]
     fn drop(&mut self) {
-        self.inner.unlock();
+        if let Ok(mut state) = LOCK_STATE.lock() {
+            match &mut *state {
+                Some(inner) => {
+                    if inner.count == 1 {
+                        debug!("Unlocking Volta Directory");
+                        let _ = inner.file.unlock();
+                        *state = None;
+                    } else {
+                        inner.count -= 1;
+                    }
+                }
+                None => {
+                    debug!("Unexpected unlock of Volta directory when it wasn't locked");
+                }
+            }
+        }
     }
 }

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -1,7 +1,6 @@
 use std::fmt::{self, Display};
 
 use crate::error::{ErrorKind, Fallible};
-use crate::layout::volta_home;
 use crate::session::Session;
 use crate::style::{note_prefix, success_prefix, tool_version};
 use crate::sync::VoltaLock;
@@ -153,8 +152,7 @@ where
     F: Fn() -> Fallible<bool>,
 {
     if !already_fetched()? {
-        let home = volta_home()?.root();
-        let lock = match VoltaLock::acquire(home) {
+        let lock = match VoltaLock::acquire() {
             Ok(l) => Some(l),
             Err(_) => {
                 debug!("Unable to acquire lock on Volta directory!");

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -143,8 +143,9 @@ enum FetchStatus {
 /// Uses the supplied `already_fetched` predicate to determine if a tool is available or not.
 ///
 /// This uses double-checking logic, to correctly handle concurrent fetch requests:
-///     If `already_fetched` indicates that a fetch is needed, we acquire an exclusive lock on the Volta directory
-///     Then, we check _again_, to confirm that no other process completed the fetch while we waited for the lock
+///
+/// - If `already_fetched` indicates that a fetch is needed, we acquire an exclusive lock on the Volta directory
+/// - Then, we check _again_, to confirm that no other process completed the fetch while we waited for the lock
 ///
 /// Note: If acquiring the lock fails, we proceed anyway, since the fetch is still necessary.
 fn check_fetched<F>(already_fetched: F) -> Fallible<FetchStatus>

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -8,6 +8,7 @@ use crate::error::{ErrorKind, Fallible};
 use crate::inventory::node_available;
 use crate::session::Session;
 use crate::style::{note_prefix, tool_version};
+use crate::sync::VoltaLock;
 use cfg_if::cfg_if;
 use log::info;
 use semver::Version;
@@ -130,6 +131,8 @@ impl Tool for Node {
         Ok(())
     }
     fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
+        // Acquire a lock on the Volta directory, if possible, to prevent concurrent changes
+        let _lock = VoltaLock::acquire();
         let node_version = self.ensure_fetched(session)?;
 
         let default_toolchain = session.toolchain_mut()?;

--- a/crates/volta-core/src/tool/npm/mod.rs
+++ b/crates/volta-core/src/tool/npm/mod.rs
@@ -9,6 +9,7 @@ use crate::error::{Context, ErrorKind, Fallible};
 use crate::inventory::npm_available;
 use crate::session::Session;
 use crate::style::{success_prefix, tool_version};
+use crate::sync::VoltaLock;
 use log::info;
 use semver::Version;
 
@@ -54,6 +55,8 @@ impl Tool for Npm {
         Ok(())
     }
     fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
+        // Acquire a lock on the Volta directory, if possible, to prevent concurrent changes
+        let _lock = VoltaLock::acquire();
         self.ensure_fetched(session)?;
 
         session

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -126,7 +126,7 @@ impl Display for Package {
 pub fn uninstall(name: &str) -> Fallible<()> {
     let home = volta_home()?;
     // Acquire a lock on the Volta directory, if possible, to prevent concurrent changes
-    let _lock = VoltaLock::acquire(home.root()).ok();
+    let _lock = VoltaLock::acquire().ok();
 
     // if the package config file exists, use that to remove any installed bins and shims
     let package_config_file = home.default_package_config_file(name);

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -84,6 +84,8 @@ impl Tool for Package {
         Ok(())
     }
     fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
+        // Acquire a lock on the Volta directory, if possible, to prevent concurrent changes
+        let _lock = VoltaLock::acquire();
         if self.is_installed() {
             info!("Package {} is already installed", self);
             Ok(())
@@ -126,7 +128,7 @@ impl Display for Package {
 pub fn uninstall(name: &str) -> Fallible<()> {
     let home = volta_home()?;
     // Acquire a lock on the Volta directory, if possible, to prevent concurrent changes
-    let _lock = VoltaLock::acquire().ok();
+    let _lock = VoltaLock::acquire();
 
     // if the package config file exists, use that to remove any installed bins and shims
     let package_config_file = home.default_package_config_file(name);

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -8,6 +8,7 @@ use crate::error::{ErrorKind, Fallible};
 use crate::inventory::yarn_available;
 use crate::session::Session;
 use crate::style::tool_version;
+use crate::sync::VoltaLock;
 use semver::Version;
 
 mod fetch;
@@ -53,6 +54,8 @@ impl Tool for Yarn {
         Ok(())
     }
     fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
+        // Acquire a lock on the Volta directory, if possible, to prevent concurrent changes
+        let _lock = VoltaLock::acquire();
         self.ensure_fetched(session)?;
 
         session

--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -134,8 +134,7 @@ impl MigrationState {
 pub fn run_migration() -> Fallible<()> {
     // Acquire an exclusive lock on the Volta directory, to ensure that no other migrations are running.
     // If this fails, however, we still need to run the migration
-    let home = volta_home()?.root();
-    match VoltaLock::acquire(home) {
+    match VoltaLock::acquire() {
         Ok(_lock) => {
             // The lock was acquired, so we can be confident that no other migrations are running
             detect_and_migrate()


### PR DESCRIPTION
Info
-----
* With the implementation of #684, we are locking the Volta directory while fetching new versions of tools.
* However, we are _not_ maintaining the lock while performing additional actions (such as writing the default platform file or installing package dependencies).
* We want to make sure that the lock is maintained throughout the `volta install` process, while also ensuring that we don't get deadlocks from the `ensure_fetched` lock (which is needed because it can be called separately by the shims).
* Ultimately, the goal of `VoltaLock` is to be a _per-process_ lock, where we prevent other Volta processes from modifying the Volta directory, but allow the current one to make changes.

Changes
-----
* Refactored the `VoltaLock` type to keep a count of active locks and only release the file lock when all of them have been released—essentially a refcount style of locking.
* Ensured that each `install` function acquires and keeps a lock through the entire `volta install` process.
* Also added a lock to the `regenerate_shims_for_dir` function, to prevent overlapping shim modifications.
* Added a debug statement to the `Drop` impl to show when the lock is dropped.

Tested
-----
* Confirmed through debug statements that the lock is maintained throughout the entire install process for each tool.
* Confirmed that package installs that require a Node download don't deadlock.