### PR TITLE
[package-global] Add feature flag for installing packages with global installs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ cross-platform-docs = ["volta-core/cross-platform-docs"]
 mock-network = ["mockito", "volta-core/mock-network"]
 volta-dev = []
 smoke-tests = []
+package-global = ["volta-core/package-global", "volta-migrate/package-global"]
 
 [[bin]]
 name = "volta-shim"

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -11,6 +11,7 @@ mock-network = ["mockito"]
 # See ci/publish-docs.yml for an example of how it's enabled.
 # See volta-core::path for an example of where it's used.
 cross-platform-docs = []
+package-global = ["volta-layout/package-global"]
 
 [dependencies]
 term_size = "0.3.0"

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -1,0 +1,41 @@
+use std::fmt::{self, Display};
+
+use super::Tool;
+use crate::error::{ErrorKind, Fallible};
+use crate::session::Session;
+use crate::style::tool_version;
+use crate::version::VersionSpec;
+
+pub struct Package {
+    pub(crate) name: String,
+    pub(crate) version: VersionSpec,
+}
+
+impl Package {
+    pub fn new(name: String, version: VersionSpec) -> Self {
+        Package { name, version }
+    }
+}
+
+impl Tool for Package {
+    fn fetch(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
+        todo!("Implement Fetch using global install");
+    }
+
+    fn install(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
+        todo!("Implement install using global install");
+    }
+
+    fn pin(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
+        Err(ErrorKind::CannotPinPackage { package: self.name }.into())
+    }
+}
+
+impl Display for Package {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.version {
+            VersionSpec::None => f.write_str(&self.name),
+            _ => f.write_str(&tool_version(&self.name, &self.version)),
+        }
+    }
+}

--- a/crates/volta-layout/Cargo.toml
+++ b/crates/volta-layout/Cargo.toml
@@ -4,5 +4,8 @@ version = "0.1.1"
 authors = ["Chuck Pierce <cpierce.grad@gmail.com>"]
 edition = "2018"
 
+[features]
+package-global = []
+
 [dependencies]
 volta-layout-macro = { path = "../volta-layout-macro" }

--- a/crates/volta-migrate/Cargo.toml
+++ b/crates/volta-migrate/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["Charles Pierce <cpierce.grad@gmail.com>"]
 edition = "2018"
 
+[features]
+package-global = ["volta-core/package-global", "volta-layout/package-global"]
+
 [dependencies]
 volta-core = { path = "../volta-core" }
 volta-layout = { path = "../volta-layout" }


### PR DESCRIPTION
Info
-----
* The implementation of the package install rework (see https://github.com/volta-cli/rfcs/pull/45) will be a significant revamp of the install code paths.
* To ensure that PRs don't become so large that they are difficult to review, we want to break the work up into smaller chunks.
* Adding a feature flag allows us to implement these changes without disrupting the working Volta on `main`

Changes
-----
* Added a feature flag `package-global` to all of the relevant crates.
* Updated the logic in the `tool` module to import the `Package` object from a new module when the feature flag is turned on (this module will be where most of the work goes).

Notes
-----
* For the initial work, the CI runs do not run tests using the feature flag.
* Once the core implementation is complete, then the CI will be updated to run those tests as well, ensuring that everything still works as expected both with and without the feature flag.