### PR TITLE
[Medium] Reimplement 'volta install' using global package install

### DIFF
--- a/crates/volta-core/src/error/kind.rs
+++ b/crates/volta-core/src/error/kind.rs
@@ -40,6 +40,12 @@ pub enum ErrorKind {
         command: String,
     },
 
+    /// Thrown when a user tries to `volta fetch` something other than node/yarn/npm.
+    #[cfg(feature = "package-global")]
+    CannotFetchPackage {
+        package: String,
+    },
+
     /// Thrown when a user tries to `volta pin` something other than node/yarn/npm.
     CannotPinPackage {
         package: String,
@@ -582,6 +588,14 @@ Please ensure your PATH is valid."
 
 VOLTA_BYPASS is enabled, please ensure that the command exists on your system or unset VOLTA_BYPASS",
                 command,
+            ),
+            #[cfg(feature = "package-global")]
+            ErrorKind::CannotFetchPackage { package } => write!(
+                f,
+                "Fetching packages without installing them is not supported.
+
+Use `volta install {}` to update the default version.",
+                package
             ),
             ErrorKind::CannotPinPackage { package } => write!(
                 f,
@@ -1470,6 +1484,8 @@ impl ErrorKind {
             ErrorKind::BinaryNotFound { .. } => ExitCode::ExecutableNotFound,
             ErrorKind::BuildPathError => ExitCode::EnvironmentError,
             ErrorKind::BypassError { .. } => ExitCode::ExecutionFailure,
+            #[cfg(feature = "package-global")]
+            ErrorKind::CannotFetchPackage { .. } => ExitCode::InvalidArguments,
             ErrorKind::CannotPinPackage { .. } => ExitCode::InvalidArguments,
             ErrorKind::CompletionsOutFileError { .. } => ExitCode::InvalidArguments,
             ErrorKind::ContainingDirError { .. } => ExitCode::FileSystemError,

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -100,7 +100,10 @@ impl Spec {
             }
             // When using global package install, we allow the package manager to perform the version resolution
             #[cfg(feature = "package-global")]
-            Spec::Package(name, version) => Ok(Box::new(Package::new(name, version))),
+            Spec::Package(name, version) => {
+                let package = Package::new(name, version)?;
+                Ok(Box::new(package))
+            }
         }
     }
 

--- a/crates/volta-core/src/tool/package/install.rs
+++ b/crates/volta-core/src/tool/package/install.rs
@@ -130,7 +130,7 @@ fn install_dependencies(package_dir: &Path, image: Image, display: &str) -> Fall
     let spinner = progress_spinner(&format!("Installing dependencies for {}", display));
     let output = command
         .output()
-        .with_context(|| ErrorKind::PackageInstallFailed)?;
+        .with_context(|| ErrorKind::PackageDependenciesInstallFailed)?;
     spinner.finish_and_clear();
 
     debug!(
@@ -145,7 +145,7 @@ fn install_dependencies(package_dir: &Path, image: Image, display: &str) -> Fall
     if output.status.success() {
         Ok(())
     } else {
-        Err(ErrorKind::PackageInstallFailed.into())
+        Err(ErrorKind::PackageDependenciesInstallFailed.into())
     }
 }
 

--- a/crates/volta-core/src/tool/package_global/install.rs
+++ b/crates/volta-core/src/tool/package_global/install.rs
@@ -34,12 +34,13 @@ impl Package {
 
         debug!("Installing {} with command: {:?}", package, command);
         let spinner = progress_spinner(&format!("Installing {}", package));
-        let output = command
+        let output_result = command
             .output()
             .with_context(|| ErrorKind::PackageInstallFailed {
                 package: package.clone(),
-            })?;
+            });
         spinner.finish_and_clear();
+        let output = output_result?;
 
         let stderr = String::from_utf8_lossy(&output.stderr);
         debug!("[install stderr]\n{}", stderr);

--- a/crates/volta-core/src/tool/package_global/install.rs
+++ b/crates/volta-core/src/tool/package_global/install.rs
@@ -1,0 +1,63 @@
+use super::{new_package_image_dir, Package};
+use crate::command::create_command;
+use crate::error::{Context, ErrorKind, Fallible};
+use crate::layout::volta_home;
+use crate::platform::PlatformSpec;
+use crate::session::Session;
+use crate::style::progress_spinner;
+use log::debug;
+
+impl Package {
+    /// Use `npm install --global` to install the package
+    ///
+    /// Sets the environment variable `npm_config_prefix` to redirect the install to the Volta
+    /// data directory, taking advantage of the standard global install behavior with a custom
+    /// location
+    pub(super) fn global_install(&self, session: &mut Session) -> Fallible<()> {
+        let package = self.to_string();
+        let default_image = session
+            .default_platform()?
+            .map(PlatformSpec::as_default)
+            .ok_or(ErrorKind::NoPlatform)?
+            .checkout(session)?;
+        let home = volta_home()?;
+
+        let mut command = create_command("npm");
+        command.args(&[
+            "install",
+            "--global",
+            "--loglevel=warn",
+            "--no-update-notifier",
+            "--no-audit",
+        ]);
+        command.arg(&package);
+        command.env("PATH", default_image.path()?);
+        command.env("npm_config_prefix", new_package_image_dir(home, &self.name));
+
+        debug!("Installing {} with command: {:?}", package, command);
+        let spinner = progress_spinner(&format!("Installing {}", package));
+        let output = command
+            .output()
+            .with_context(|| ErrorKind::PackageInstallFailed {
+                package: package.clone(),
+            })?;
+        spinner.finish_and_clear();
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        debug!("[install stderr]\n{}", stderr);
+        debug!(
+            "[install stdout]\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+
+        if output.status.success() {
+            Ok(())
+        } else if stderr.contains("code E404") {
+            // npm outputs "code E404" as part of the error output when a package couldn't be found
+            // Detect that and show a nicer error message (since we likely know the problem in that case)
+            Err(ErrorKind::PackageNotFound { package }.into())
+        } else {
+            Err(ErrorKind::PackageInstallFailed { package }.into())
+        }
+    }
+}

--- a/crates/volta-core/src/tool/package_global/install.rs
+++ b/crates/volta-core/src/tool/package_global/install.rs
@@ -1,7 +1,6 @@
-use super::{new_package_image_dir, Package};
+use super::Package;
 use crate::command::create_command;
 use crate::error::{Context, ErrorKind, Fallible};
-use crate::layout::volta_home;
 use crate::platform::PlatformSpec;
 use crate::session::Session;
 use crate::style::progress_spinner;
@@ -20,7 +19,6 @@ impl Package {
             .map(PlatformSpec::as_default)
             .ok_or(ErrorKind::NoPlatform)?
             .checkout(session)?;
-        let home = volta_home()?;
 
         let mut command = create_command("npm");
         command.args(&[
@@ -32,7 +30,7 @@ impl Package {
         ]);
         command.arg(&package);
         command.env("PATH", default_image.path()?);
-        command.env("npm_config_prefix", new_package_image_dir(home, &self.name));
+        command.env("npm_config_prefix", self.staging.path());
 
         debug!("Installing {} with command: {:?}", package, command);
         let spinner = progress_spinner(&format!("Installing {}", package));

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -23,7 +23,10 @@ impl Package {
 
 impl Tool for Package {
     fn fetch(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
-        todo!("Implement Fetch using global install");
+        Err(ErrorKind::CannotFetchPackage {
+            package: self.to_string(),
+        }
+        .into())
     }
 
     fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt::{self, Display};
+use std::path::PathBuf;
 
 use super::Tool;
 use crate::error::{ErrorKind, Fallible};
@@ -6,6 +7,9 @@ use crate::session::Session;
 use crate::style::tool_version;
 use crate::version::VersionSpec;
 
+mod install;
+
+/// The Tool implementation for installing 3rd-party global packages
 pub struct Package {
     pub(crate) name: String,
     pub(crate) version: VersionSpec,
@@ -22,8 +26,10 @@ impl Tool for Package {
         todo!("Implement Fetch using global install");
     }
 
-    fn install(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
-        todo!("Implement install using global install");
+    fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
+        self.global_install(session)?;
+
+        todo!("Parse package.json for version / bins and write configs");
     }
 
     fn pin(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
@@ -38,4 +44,10 @@ impl Display for Package {
             _ => f.write_str(&tool_version(&self.name, &self.version)),
         }
     }
+}
+
+fn new_package_image_dir(home: &volta_layout::v2::VoltaHome, package_name: &str) -> PathBuf {
+    // TODO: An updated layout (and associated migration) will be added in a follow-up PR
+    // at which point this function can be removed
+    home.package_image_root_dir().join(package_name)
 }

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -2,22 +2,57 @@ use std::fmt::{self, Display};
 use std::path::PathBuf;
 
 use super::Tool;
-use crate::error::{ErrorKind, Fallible};
+use crate::error::{Context, ErrorKind, Fallible};
+use crate::fs::{create_staging_dir, remove_dir_if_exists, rename};
+use crate::layout::volta_home;
 use crate::session::Session;
 use crate::style::tool_version;
+use crate::sync::VoltaLock;
 use crate::version::VersionSpec;
+use fs_utils::ensure_containing_dir_exists;
+use tempfile::TempDir;
 
 mod install;
 
 /// The Tool implementation for installing 3rd-party global packages
 pub struct Package {
-    pub(crate) name: String,
-    pub(crate) version: VersionSpec,
+    name: String,
+    version: VersionSpec,
+    staging: TempDir,
 }
 
 impl Package {
-    pub fn new(name: String, version: VersionSpec) -> Self {
-        Package { name, version }
+    pub fn new(name: String, version: VersionSpec) -> Fallible<Self> {
+        let staging = create_staging_dir()?;
+        Ok(Package {
+            name,
+            version,
+            staging,
+        })
+    }
+
+    pub fn persist_install(self) -> Fallible<()> {
+        let home = volta_home()?;
+        let package_dir = new_package_image_dir(home, &self.name);
+
+        remove_dir_if_exists(&package_dir)?;
+
+        // Handle scoped packages (@vue/cli), which have an extra directory for the scope
+        ensure_containing_dir_exists(&package_dir).with_context(|| {
+            ErrorKind::ContainingDirError {
+                path: package_dir.to_owned(),
+            }
+        })?;
+
+        rename(self.staging.path(), &package_dir).with_context(|| {
+            ErrorKind::SetupToolImageError {
+                tool: self.name,
+                version: self.version.to_string(),
+                dir: package_dir,
+            }
+        })?;
+
+        Ok(())
     }
 }
 
@@ -30,9 +65,13 @@ impl Tool for Package {
     }
 
     fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
+        let _lock = VoltaLock::acquire()?;
         self.global_install(session)?;
 
-        todo!("Parse package.json for version / bins and write configs");
+        // TODO: Parse package.json for version / bins
+        // TODO: Write package config, bin configs, and shims
+
+        self.persist_install()
     }
 
     fn pin(self: Box<Self>, _session: &mut Session) -> Fallible<()> {


### PR DESCRIPTION
Info
-----
* First step of the package rework: Install packages using `npm install --global` with a redirect into a Volta-managed directory.
* Install into a temporary directory first, to avoid creating unnecessary directories in the event of an error.
* This PR explicitly doesn't include parsing the `package.json` or writing configs & shims, those will be added in a future PR.

Changes
-----
* Added new error messages for new error paths.
* Created `global_install` method to actually run the install command.
* Created skeleton implementation of `Tool::install` for `Package`
* Included `TODO` comments for areas that will be added in future PRs.

Tested
-----
All tested locally as automated tests will be added in a future PR, when the entire workflow is complete
* Confirmed packages are installed and executable in the expected location.
* Verified that the issue described in #762 is resolved (since the directory structure includes `node_modules`)
* Ensured directories aren't created when there is an error with installation (e.g. when the package doesn't exist)

Notes
-----
* `volta fetch <package>` was made into an error because with the switch to using `npm install --global` directly it doesn't work the way it would be expected to.
    * Since the install process is entirely managed by `npm`, we can't reasonably have a "pre-fetched" version around to shortcut.
    * If we allowed it, the `volta install <package>` process would ultimately overwrite it anyway, because we would need to ensure that we were using the potentially new Node version.