### PR TITLE
[Medium] Generate config files and shims during package install

### DIFF
--- a/crates/volta-core/src/error/kind.rs
+++ b/crates/volta-core/src/error/kind.rs
@@ -283,6 +283,18 @@ pub enum ErrorKind {
         package: String,
     },
 
+    /// Thrown when parsing the package manifest fails
+    #[cfg(feature = "package-global")]
+    PackageManifestParseError {
+        package: String,
+    },
+
+    /// Thrown when reading the package manifest fails
+    #[cfg(feature = "package-global")]
+    PackageManifestReadError {
+        package: String,
+    },
+
     /// Thrown when there is an error fetching package metadata
     PackageMetadataFetchError {
         from_url: String,
@@ -1027,6 +1039,22 @@ This project is configured to use version {} of npm.",
 Please confirm the package is valid and run with `--verbose` for more diagnostics.",
                 package
             ),
+            #[cfg(feature = "package-global")]
+            ErrorKind::PackageManifestParseError { package } => write!(
+                f,
+                "Could not parse package.json manifest for {}
+
+Please ensure the package includes a valid manifest file.",
+                package
+            ),
+            #[cfg(feature = "package-global")]
+            ErrorKind::PackageManifestReadError { package } => write!(
+                f,
+                "Could not read package.json manifest for {}
+
+Please ensure the package includes a valid manifest file.",
+                package
+            ),
             ErrorKind::PackageMetadataFetchError { from_url } => write!(
                 f,
                 "Could not download package metadata
@@ -1542,6 +1570,10 @@ impl ErrorKind {
             ErrorKind::PackageDependenciesInstallFailed => ExitCode::FileSystemError,
             #[cfg(feature = "package-global")]
             ErrorKind::PackageInstallFailed { .. } => ExitCode::UnknownError,
+            #[cfg(feature = "package-global")]
+            ErrorKind::PackageManifestParseError { .. } => ExitCode::ConfigurationError,
+            #[cfg(feature = "package-global")]
+            ErrorKind::PackageManifestReadError { .. } => ExitCode::FileSystemError,
             ErrorKind::PackageMetadataFetchError { .. } => ExitCode::NetworkError,
             ErrorKind::PackageNotFound { .. } => ExitCode::InvalidArguments,
             ErrorKind::PackageParseError { .. } => ExitCode::ConfigurationError,

--- a/crates/volta-core/src/tool/package_global/configure.rs
+++ b/crates/volta-core/src/tool/package_global/configure.rs
@@ -1,22 +1,14 @@
-use super::metadata::PackageManifest;
+use super::metadata::{BinConfig, PackageConfig, PackageManifest};
 use super::Package;
-use crate::error::Fallible;
-use crate::platform::Image;
+use crate::error::{ErrorKind, Fallible};
+use crate::layout::volta_home;
+use crate::platform::{Image, PlatformSpec};
+use crate::shim;
 
 impl Package {
-    pub(super) fn write_config_and_shims(
-        &self,
-        _manifest: &PackageManifest,
-        _image: &Image,
-    ) -> Fallible<()> {
-        // TODO: Generate Package config and write it
-        // TODO: Generate bin configs and write them
-        // TODO: Create shims for bins
-        Ok(())
-    }
-
+    /// Read the manifest for the package being installed
     pub(super) fn parse_manifest(&self) -> Fallible<PackageManifest> {
-        let mut package_dir = self.staging.path().join(&self.name);
+        let mut package_dir = self.staging.path().to_owned();
         // Looking forward to allowing direct package manager global installs,
         // this method should be updated to support the different directory layouts
         // of different package managers.
@@ -28,14 +20,69 @@ impl Package {
         package_dir.push("node_modules");
         package_dir.push(&self.name);
 
-        let mut manifest = PackageManifest::for_dir(&self.name, &package_dir)?;
+        PackageManifest::for_dir(&self.name, &package_dir)
+    }
 
-        // Internally, an empty string key represents a bin entry that is only the PATH
-        // This needs to be updated to use the package name as the key
-        if let Some(path) = manifest.bin.remove("") {
-            manifest.bin.insert(self.name.clone(), path);
+    /// Generate configuration files and shims for the package and each of its bins
+    pub(super) fn write_config_and_shims(
+        &self,
+        manifest: &PackageManifest,
+        image: &Image,
+    ) -> Fallible<()> {
+        self.validate_bins(manifest)?;
+
+        let platform = PlatformSpec {
+            node: image.node.value.clone(),
+            npm: image.npm.clone().map(|s| s.value),
+            yarn: image.yarn.clone().map(|s| s.value),
+        };
+
+        // Generate the shims and bin configs for each bin provided by the package
+        for bin_name in &manifest.bin {
+            shim::create(&bin_name)?;
+
+            BinConfig {
+                name: bin_name.clone(),
+                package: self.name.clone(),
+                version: manifest.version.clone(),
+                platform: platform.clone(),
+            }
+            .write()?;
         }
 
-        Ok(manifest)
+        // Write the config for the package
+        PackageConfig {
+            name: self.name.clone(),
+            version: manifest.version.clone(),
+            platform,
+            bins: manifest.bin.clone(),
+        }
+        .write()?;
+
+        Ok(())
+    }
+
+    /// Validate that we aren't attempting to install a bin that is already installed by
+    /// another package.
+    fn validate_bins(&self, manifest: &PackageManifest) -> Fallible<()> {
+        let home = volta_home()?;
+        for bin_name in &manifest.bin {
+            // Check for name conflicts with already-installed bins
+            // Some packages may install bins with the same name
+            if let Ok(config) = BinConfig::from_file(home.default_tool_bin_config(&bin_name)) {
+                // The file exists, so there is a bin with this name
+                // That is okay iff it came from the package that is currently being installed
+                if self.name != config.package {
+                    return Err(ErrorKind::BinaryAlreadyInstalled {
+                        bin_name: bin_name.into(),
+                        existing_package: config.package,
+                        new_package: self.name.clone(),
+                    }
+                    .into());
+                }
+            }
+        }
+
+        Ok(())
     }
 }

--- a/crates/volta-core/src/tool/package_global/configure.rs
+++ b/crates/volta-core/src/tool/package_global/configure.rs
@@ -1,0 +1,41 @@
+use super::metadata::PackageManifest;
+use super::Package;
+use crate::error::Fallible;
+use crate::platform::Image;
+
+impl Package {
+    pub(super) fn write_config_and_shims(
+        &self,
+        _manifest: &PackageManifest,
+        _image: &Image,
+    ) -> Fallible<()> {
+        // TODO: Generate Package config and write it
+        // TODO: Generate bin configs and write them
+        // TODO: Create shims for bins
+        Ok(())
+    }
+
+    pub(super) fn parse_manifest(&self) -> Fallible<PackageManifest> {
+        let mut package_dir = self.staging.path().join(&self.name);
+        // Looking forward to allowing direct package manager global installs,
+        // this method should be updated to support the different directory layouts
+        // of different package managers.
+
+        // `lib` is not in the directory structure on Windows
+        #[cfg(not(windows))]
+        package_dir.push("lib");
+
+        package_dir.push("node_modules");
+        package_dir.push(&self.name);
+
+        let mut manifest = PackageManifest::for_dir(&self.name, &package_dir)?;
+
+        // Internally, an empty string key represents a bin entry that is only the PATH
+        // This needs to be updated to use the package name as the key
+        if let Some(path) = manifest.bin.remove("") {
+            manifest.bin.insert(self.name.clone(), path);
+        }
+
+        Ok(manifest)
+    }
+}

--- a/crates/volta-core/src/tool/package_global/install.rs
+++ b/crates/volta-core/src/tool/package_global/install.rs
@@ -1,8 +1,7 @@
 use super::Package;
 use crate::command::create_command;
 use crate::error::{Context, ErrorKind, Fallible};
-use crate::platform::PlatformSpec;
-use crate::session::Session;
+use crate::platform::Image;
 use crate::style::progress_spinner;
 use log::debug;
 
@@ -12,14 +11,8 @@ impl Package {
     /// Sets the environment variable `npm_config_prefix` to redirect the install to the Volta
     /// data directory, taking advantage of the standard global install behavior with a custom
     /// location
-    pub(super) fn global_install(&self, session: &mut Session) -> Fallible<()> {
+    pub(super) fn global_install(&self, platform_image: &Image) -> Fallible<()> {
         let package = self.to_string();
-        let default_image = session
-            .default_platform()?
-            .map(PlatformSpec::as_default)
-            .ok_or(ErrorKind::NoPlatform)?
-            .checkout(session)?;
-
         let mut command = create_command("npm");
         command.args(&[
             "install",
@@ -29,7 +22,7 @@ impl Package {
             "--no-audit",
         ]);
         command.arg(&package);
-        command.env("PATH", default_image.path()?);
+        command.env("PATH", platform_image.path()?);
         command.env("npm_config_prefix", self.staging.path());
 
         debug!("Installing {} with command: {:?}", package, command);

--- a/crates/volta-core/src/tool/package_global/metadata.rs
+++ b/crates/volta-core/src/tool/package_global/metadata.rs
@@ -1,0 +1,81 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::path::Path;
+
+use crate::error::{Context, ErrorKind, Fallible};
+use crate::version::version_serde;
+use semver::Version;
+
+#[derive(serde::Deserialize)]
+pub struct PackageManifest {
+    /// The name of the package
+    pub name: String,
+    /// The version of the package
+    #[serde(deserialize_with = "version_serde::deserialize")]
+    pub version: Version,
+    /// The `bin` section, containing a map of binary names to locations
+    #[serde(default, deserialize_with = "serde_bins::deserialize")]
+    pub bin: HashMap<String, String>,
+}
+
+impl PackageManifest {
+    pub fn for_dir(package: &str, package_root: &Path) -> Fallible<Self> {
+        let package_file = package_root.join("package.json");
+        let file =
+            File::open(&package_file).with_context(|| ErrorKind::PackageManifestReadError {
+                package: package.into(),
+            })?;
+
+        serde_json::de::from_reader(file).with_context(|| ErrorKind::PackageManifestParseError {
+            package: package.into(),
+        })
+    }
+}
+
+mod serde_bins {
+    use std::collections::HashMap;
+    use std::fmt;
+
+    use serde::de::{Deserializer, Error, MapAccess, Visitor};
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(BinMapVisitor)
+    }
+
+    struct BinMapVisitor;
+
+    impl<'de> Visitor<'de> for BinMapVisitor {
+        type Value = HashMap<String, String>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("string or map")
+        }
+
+        // Handle String values with only the path
+        fn visit_str<E>(self, bin_path: &str) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            let mut bin_map = HashMap::new();
+            // Add the value to the map with the empty string as the key since we don't know
+            // what the binary name will be at this level (npm uses the package name in this case)
+            bin_map.insert("".into(), bin_path.into());
+            Ok(bin_map)
+        }
+
+        // Handle maps of Name -> Path
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut bin_map = HashMap::new();
+            while let Some((name, path)) = access.next_entry()? {
+                bin_map.insert(name, path);
+            }
+            Ok(bin_map)
+        }
+    }
+}

--- a/crates/volta-core/src/tool/package_global/metadata.rs
+++ b/crates/volta-core/src/tool/package_global/metadata.rs
@@ -1,11 +1,125 @@
-use std::collections::HashMap;
 use std::fs::File;
 use std::path::Path;
 
 use crate::error::{Context, ErrorKind, Fallible};
-use crate::version::version_serde;
+use crate::layout::volta_home;
+use crate::platform::PlatformSpec;
+use crate::version::{option_version_serde, version_serde};
+use fs_utils::ensure_containing_dir_exists;
 use semver::Version;
 
+/// Configuration information about an installed package
+///
+/// Will be stored in <VOLTA_HOME>/tools/user/packages/<package>.json
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct PackageConfig {
+    /// The package name
+    pub name: String,
+    /// The package version
+    #[serde(with = "version_serde")]
+    pub version: Version,
+    /// The platform used to install this package
+    #[serde(with = "RawPlatformSpec")]
+    pub platform: PlatformSpec,
+    /// The binaries installed by this package
+    pub bins: Vec<String>,
+}
+
+impl PackageConfig {
+    /// Parse a `PackageConfig` instance from a config file
+    pub fn from_file<P>(file: P) -> Fallible<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let config = File::open(&file).with_context(|| ErrorKind::ReadPackageConfigError {
+            file: file.as_ref().to_owned(),
+        })?;
+        serde_json::from_reader(config).with_context(|| ErrorKind::ParsePackageConfigError)
+    }
+
+    /// Write this `PackageConfig` into the appropriate config file
+    pub fn write(self) -> Fallible<()> {
+        let config_file_path = volta_home()?.default_package_config_file(&self.name);
+
+        ensure_containing_dir_exists(&config_file_path).with_context(|| {
+            ErrorKind::ContainingDirError {
+                path: config_file_path.clone(),
+            }
+        })?;
+
+        let file = File::create(&config_file_path).with_context(|| {
+            ErrorKind::WritePackageConfigError {
+                file: config_file_path,
+            }
+        })?;
+        serde_json::to_writer_pretty(file, &self)
+            .with_context(|| ErrorKind::StringifyPackageConfigError)
+    }
+}
+
+/// Configuration information about a single installed binary from a package
+///
+/// Will be stored in <VOLTA_HOME>/tools/user/bins/<bin-name>.json
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct BinConfig {
+    /// The binary name
+    pub name: String,
+    /// The package that installed the binary
+    pub package: String,
+    /// The package version
+    #[serde(with = "version_serde")]
+    pub version: Version,
+    /// The platform used to install this binary
+    #[serde(with = "RawPlatformSpec")]
+    pub platform: PlatformSpec,
+}
+
+impl BinConfig {
+    /// Parse a `BinConfig` instance from the given config file
+    pub fn from_file<P>(file: P) -> Fallible<Self>
+    where
+        P: AsRef<Path>,
+    {
+        let config = File::open(&file).with_context(|| ErrorKind::ReadBinConfigError {
+            file: file.as_ref().to_owned(),
+        })?;
+        serde_json::from_reader(config).with_context(|| ErrorKind::ParseBinConfigError)
+    }
+
+    /// Write this `BinConfig` to the appropriate config file
+    pub fn write(self) -> Fallible<()> {
+        let config_file_path = volta_home()?.default_tool_bin_config(&self.name);
+
+        ensure_containing_dir_exists(&config_file_path).with_context(|| {
+            ErrorKind::ContainingDirError {
+                path: config_file_path.clone(),
+            }
+        })?;
+
+        let file =
+            File::create(&config_file_path).with_context(|| ErrorKind::WriteBinConfigError {
+                file: config_file_path,
+            })?;
+        serde_json::to_writer_pretty(file, &self)
+            .with_context(|| ErrorKind::StringifyBinConfigError)
+    }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[serde(remote = "PlatformSpec")]
+struct RawPlatformSpec {
+    #[serde(with = "version_serde")]
+    node: Version,
+    #[serde(with = "option_version_serde")]
+    npm: Option<Version>,
+    #[serde(with = "option_version_serde")]
+    yarn: Option<Version>,
+}
+
+/// The relevant information we need out of a package's `package.json` file
+///
+/// This includes the exact Version (since we can install using a range)
+/// and the list of bins provided by the package.
 #[derive(serde::Deserialize)]
 pub struct PackageManifest {
     /// The name of the package
@@ -15,10 +129,11 @@ pub struct PackageManifest {
     pub version: Version,
     /// The `bin` section, containing a map of binary names to locations
     #[serde(default, deserialize_with = "serde_bins::deserialize")]
-    pub bin: HashMap<String, String>,
+    pub bin: Vec<String>,
 }
 
 impl PackageManifest {
+    /// Parse the `package.json` for a given package directory
     pub fn for_dir(package: &str, package_root: &Path) -> Fallible<Self> {
         let package_file = package_root.join("package.json");
         let file =
@@ -26,19 +141,30 @@ impl PackageManifest {
                 package: package.into(),
             })?;
 
-        serde_json::de::from_reader(file).with_context(|| ErrorKind::PackageManifestParseError {
-            package: package.into(),
-        })
+        let mut manifest: Self = serde_json::de::from_reader(file).with_context(|| {
+            ErrorKind::PackageManifestParseError {
+                package: package.into(),
+            }
+        })?;
+
+        // If the bin list contains only an empty string, that means `bin` was a string value,
+        // rather than a map. In that case, to match `npm`s behavior, we use the name of the package
+        // as the bin name.
+        if manifest.bin == [""] {
+            manifest.bin.pop();
+            manifest.bin.push(manifest.name.clone());
+        }
+
+        Ok(manifest)
     }
 }
 
 mod serde_bins {
-    use std::collections::HashMap;
     use std::fmt;
 
     use serde::de::{Deserializer, Error, MapAccess, Visitor};
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<HashMap<String, String>, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
     where
         D: Deserializer<'de>,
     {
@@ -48,22 +174,20 @@ mod serde_bins {
     struct BinMapVisitor;
 
     impl<'de> Visitor<'de> for BinMapVisitor {
-        type Value = HashMap<String, String>;
+        type Value = Vec<String>;
 
         fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.write_str("string or map")
         }
 
         // Handle String values with only the path
-        fn visit_str<E>(self, bin_path: &str) -> Result<Self::Value, E>
+        fn visit_str<E>(self, _path: &str) -> Result<Self::Value, E>
         where
             E: Error,
         {
-            let mut bin_map = HashMap::new();
-            // Add the value to the map with the empty string as the key since we don't know
-            // what the binary name will be at this level (npm uses the package name in this case)
-            bin_map.insert("".into(), bin_path.into());
-            Ok(bin_map)
+            // Use an empty string as a placeholder for the binary name, since at this level we
+            // don't know the binary name for sure (npm uses the package name in this case)
+            Ok(vec![String::new()])
         }
 
         // Handle maps of Name -> Path
@@ -71,11 +195,11 @@ mod serde_bins {
         where
             M: MapAccess<'de>,
         {
-            let mut bin_map = HashMap::new();
-            while let Some((name, path)) = access.next_entry()? {
-                bin_map.insert(name, path);
+            let mut bins = Vec::new();
+            while let Some((name, _)) = access.next_entry::<String, String>()? {
+                bins.push(name);
             }
-            Ok(bin_map)
+            Ok(bins)
         }
     }
 }

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -40,13 +40,13 @@ impl Package {
     pub fn complete_install(self, image: &Image) -> Fallible<PackageManifest> {
         let manifest = self.parse_manifest()?;
 
-        self.write_config_and_shims(&manifest, &image)?;
         self.persist_install()?;
+        self.write_config_and_shims(&manifest, &image)?;
 
         Ok(manifest)
     }
 
-    fn persist_install(self) -> Fallible<()> {
+    fn persist_install(&self) -> Fallible<()> {
         let home = volta_home()?;
         let package_dir = new_package_image_dir(home, &self.name);
 
@@ -61,7 +61,7 @@ impl Package {
 
         rename(self.staging.path(), &package_dir).with_context(|| {
             ErrorKind::SetupToolImageError {
-                tool: self.name,
+                tool: self.name.clone(),
                 version: self.version.to_string(),
                 dir: package_dir,
             }

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -18,7 +18,7 @@ mod configure;
 mod install;
 mod metadata;
 
-use metadata::PackageManifest;
+pub use metadata::{BinConfig, PackageConfig, PackageManifest};
 
 /// The Tool implementation for installing 3rd-party global packages
 pub struct Package {
@@ -91,12 +91,7 @@ impl Tool for Package {
         self.global_install(&default_image)?;
         let manifest = self.complete_install(&default_image)?;
 
-        let bins = manifest
-            .bin
-            .keys()
-            .map(AsRef::as_ref)
-            .collect::<Vec<&str>>()
-            .join(", ");
+        let bins = manifest.bin.join(", ");
 
         info!(
             "{} installed {} with executables: {}",


### PR DESCRIPTION
Info
-----
* Part 2 of package install rework: Complete the `volta install <package>` flow.
* Parse `package.json` to determine the exact version and any bins that are installed by the package
* Write the package config, bin configs, and shims

Changes
-----
* Added `metadata` module with the various metadata files that are used. Each is similar to an existing `metadata` with the old flow, but implemented differently to fit the new workflow.
* Added `configure` module with methods for parsing the manifest and writing the configs and shims
* Restructured the data flow in the `Package::install` method to ensure all of the appropriate data is available and can be used. This was also done somewhat looking forward to enabling `npm i -g` to reuse much of the code.

Notes
-----
* This only represents the end of the `volta install` flow. The changes needed to the `run` flow so that bins can actually be executed will be added in the next PR
* The requirement that a package contain at least one bin was dropped. While not technically supported yet, the goal of these changes is to eventually support that (along with many other things), so it seemed reasonable to drop that requirement now instead of adding it and then removing it.