### PR TITLE
[Small] Rework Shim code path to work with global packages

### DIFF
--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -117,7 +117,7 @@ impl Display for Package {
     }
 }
 
-fn new_package_image_dir(home: &volta_layout::v2::VoltaHome, package_name: &str) -> PathBuf {
+pub fn new_package_image_dir(home: &volta_layout::v2::VoltaHome, package_name: &str) -> PathBuf {
     // TODO: An updated layout (and associated migration) will be added in a follow-up PR
     // at which point this function can be removed
     home.package_image_root_dir().join(package_name)


### PR DESCRIPTION
Info
-----
* Part 3 of package install rework.
* With the changes to the directory structure and config format for global packages, the shim code path for actually running a global executable needs to be updated.

Changes
-----
* Updated `run::binary` to load binary information from the new configuration format when the feature flag is enabled.
* Changed calculation of the path to the binary to use the new directory structure for packages.

Tested
-----
* Manually tested on both Windows and Mac that executing a global package works correctly after installing it with `volta install`.