### PR TITLE
[Small] Implement Uninstall for new package workflow

### DIFF
--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -126,7 +126,12 @@ impl Spec {
             }
             .into()),
             Spec::Package(name, _) => {
+                #[cfg(feature = "package-global")]
+                package_global::uninstall(&name)?;
+
+                #[cfg(not(feature = "package-global"))]
                 package::uninstall(&name)?;
+
                 Ok(())
             }
         }

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -17,8 +17,10 @@ use tempfile::TempDir;
 mod configure;
 mod install;
 mod metadata;
+mod uninstall;
 
 pub use metadata::{BinConfig, PackageConfig, PackageManifest};
+pub use uninstall::uninstall;
 
 /// The Tool implementation for installing 3rd-party global packages
 pub struct Package {


### PR DESCRIPTION
Info
-----
* Part 4 of package rework: Implementing uninstall

Changes
-----
* Created `uninstall` module within the feature-flagged `package_global` module.
* Added implementation of uninstall behavior.

Tested
-----
* Manual testing to confirm that uninstalling a package works in both the usual case and the "orphaned packages" case.

Notes
-----
* The implementation of uninstall is nearly identical to that in the existing `package` module (pre-rework).
    * The main difference is that the new package directory is removed, instead of the old `package_image_root_dir`
    * Additionally, the new config file format is used for loading the `PackageConfig`.