### PR TITLE
[Tiny] Complete removal of 'package' module under feature flag

### DIFF
--- a/crates/volta-core/src/run/binary.rs
+++ b/crates/volta-core/src/run/binary.rs
@@ -9,7 +9,7 @@ use crate::session::{ActivityKind, Session};
 #[cfg(not(feature = "package-global"))]
 use crate::tool::bin_full_path;
 #[cfg(feature = "package-global")]
-use crate::tool::package_global::{new_package_image_dir, BinConfig};
+use crate::tool::package::{new_package_image_dir, BinConfig};
 #[cfg(not(feature = "package-global"))]
 use crate::tool::{BinConfig, BinLoader};
 use log::debug;

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -5,7 +5,9 @@ use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::iter::empty;
 use std::path::Path;
-use std::process::{Command, ExitStatus, Output};
+#[cfg(not(feature = "package-global"))]
+use std::process::Output;
+use std::process::{Command, ExitStatus};
 
 use crate::command::create_command;
 use crate::error::{Context, ErrorKind, Fallible};
@@ -123,6 +125,7 @@ impl ToolCommand {
     /// Add a single argument to the Command.
     ///
     /// The new argument will be added to the end of the current argument list
+    #[cfg(not(feature = "package-global"))]
     pub(crate) fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut ToolCommand {
         self.command.arg(arg);
         self
@@ -152,6 +155,7 @@ impl ToolCommand {
     }
 
     /// Set the current working directory for the Command
+    #[cfg(not(feature = "package-global"))]
     pub(crate) fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut ToolCommand {
         self.command.current_dir(dir);
         self
@@ -167,6 +171,7 @@ impl ToolCommand {
     /// Execute the command, returning all of its output to the caller
     ///
     /// Any failures will be wrapped with the Error value in `on_failure`
+    #[cfg(not(feature = "package-global"))]
     pub(crate) fn output(mut self) -> Fallible<Output> {
         self.command.output().with_context(|| self.on_failure)
     }

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -9,9 +9,11 @@ use log::{debug, info};
 
 pub mod node;
 pub mod npm;
+#[cfg(not(feature = "package-global"))]
 pub mod package;
 #[cfg(feature = "package-global")]
-pub mod package_global;
+#[path = "package_global/mod.rs"]
+pub mod package;
 mod registry;
 mod serial;
 pub mod yarn;
@@ -21,10 +23,9 @@ pub use node::{
 };
 pub use npm::{BundledNpm, Npm};
 #[cfg(not(feature = "package-global"))]
-pub use package::Package;
-pub use package::{bin_full_path, BinConfig, BinLoader, PackageConfig};
+pub use package::{bin_full_path, BinConfig, BinLoader, Package, PackageConfig};
 #[cfg(feature = "package-global")]
-pub use package_global::Package;
+pub use package::{BinConfig, Package, PackageConfig, PackageManifest};
 pub use registry::PackageDetails;
 pub use yarn::Yarn;
 
@@ -125,15 +126,7 @@ impl Spec {
                 feature: "Uninstalling yarn".into(),
             }
             .into()),
-            Spec::Package(name, _) => {
-                #[cfg(feature = "package-global")]
-                package_global::uninstall(&name)?;
-
-                #[cfg(not(feature = "package-global"))]
-                package::uninstall(&name)?;
-
-                Ok(())
-            }
+            Spec::Package(name, _) => package::uninstall(&name),
         }
     }
 }

--- a/crates/volta-core/src/tool/package_global/metadata.rs
+++ b/crates/volta-core/src/tool/package_global/metadata.rs
@@ -11,7 +11,7 @@ use semver::Version;
 /// Configuration information about an installed package
 ///
 /// Will be stored in <VOLTA_HOME>/tools/user/packages/<package>.json
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde::Serialize, serde::Deserialize, PartialOrd, Ord, PartialEq, Eq)]
 pub struct PackageConfig {
     /// The package name
     pub name: String,


### PR DESCRIPTION
Info
-----
* Part 5 of package rework: Completely remove `tool::package` module when the feature flag is active
* Previously, to simplify implementation, both the `package` and `package_global` modules were available when the feature flag was enabled.
* Now that work has progressed far enough, we can completely replace the `package` module with the feature flag.

Changes
-----
* Updated the module definition to load `package_global/mod.rs` _as_ the module `package` when the feature flag is enabled.
* Added some more feature flags to prevent warnings with now-unused methods on `ToolCommand`
* Cleaned up some imports that were referencing `package_global` as a separate module.

Tested
-----
* Confirmed that Volta builds without errors / warnings both with and without the feature flag.