### PR TITLE
[Tiny] Remove Package Hooks under new install workflow

### DIFF
--- a/crates/volta-core/src/hook/mod.rs
+++ b/crates/volta-core/src/hook/mod.rs
@@ -9,7 +9,9 @@ use std::path::Path;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::layout::volta_home;
 use crate::project::Project;
-use crate::tool::{Node, Npm, Package, Tool, Yarn};
+#[cfg(not(feature = "package-global"))]
+use crate::tool::Package;
+use crate::tool::{Node, Npm, Tool, Yarn};
 use lazycell::LazyCell;
 use log::debug;
 
@@ -51,6 +53,7 @@ pub struct HookConfig {
     node: Option<ToolHooks<Node>>,
     npm: Option<ToolHooks<Npm>>,
     yarn: Option<ToolHooks<Yarn>>,
+    #[cfg(not(feature = "package-global"))]
     package: Option<ToolHooks<Package>>,
     events: Option<EventHooks>,
 }
@@ -102,6 +105,7 @@ impl HookConfig {
         self.yarn.as_ref()
     }
 
+    #[cfg(not(feature = "package-global"))]
     pub fn package(&self) -> Option<&ToolHooks<Package>> {
         self.package.as_ref()
     }
@@ -167,6 +171,7 @@ impl HookConfig {
                         node: None,
                         npm: None,
                         yarn: None,
+                        #[cfg(not(feature = "package-global"))]
                         package: None,
                         events: None,
                     }
@@ -200,6 +205,7 @@ impl HookConfig {
             node: merge_hooks!(self, other, node),
             npm: merge_hooks!(self, other, npm),
             yarn: merge_hooks!(self, other, yarn),
+            #[cfg(not(feature = "package-global"))]
             package: merge_hooks!(self, other, package),
             events: merge_hooks!(self, other, events),
         }

--- a/crates/volta-core/src/hook/serial.rs
+++ b/crates/volta-core/src/hook/serial.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 
 use super::tool;
 use crate::error::{ErrorKind, Fallible, VoltaError};
-use crate::tool::{Node, Npm, Package, Tool, Yarn};
+#[cfg(not(feature = "package-global"))]
+use crate::tool::Package;
+use crate::tool::{Node, Npm, Tool, Yarn};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -102,6 +104,7 @@ pub struct RawHookConfig {
     pub node: Option<RawToolHooks<Node>>,
     pub npm: Option<RawToolHooks<Npm>>,
     pub yarn: Option<RawToolHooks<Yarn>>,
+    #[cfg(not(feature = "package-global"))]
     pub packages: Option<RawToolHooks<Package>>,
     pub events: Option<RawEventHooks>,
 }
@@ -138,6 +141,7 @@ impl RawHookConfig {
         let node = self.node.map(|n| n.into_tool_hooks(base_dir)).transpose()?;
         let npm = self.npm.map(|n| n.into_tool_hooks(base_dir)).transpose()?;
         let yarn = self.yarn.map(|y| y.into_tool_hooks(base_dir)).transpose()?;
+        #[cfg(not(feature = "package-global"))]
         let package = self
             .packages
             .map(|p| p.into_tool_hooks(base_dir))
@@ -147,6 +151,7 @@ impl RawHookConfig {
             node,
             npm,
             yarn,
+            #[cfg(not(feature = "package-global"))]
             package,
             events,
         })


### PR DESCRIPTION
Info
-----
* Part 6 of package rework: Remove the unused `Package` hooks under the new workflow
* Since we are now delegating to `npm install --global` to handle package installs, we no longer want to have a hybrid Hooks & `.npmrc` method for redirecting the download.
    * Even before the change, Package hooks were soft-deprecated and didn't fully work as expected
    * With the new workflow, we can cleanly remove them and rely only on the `.npmrc` files used by the package manager.

Changes
-----
* Marked the `Package` hook kinds as only available without the feature flag enabled.

Tested
-----
* Confirmed that Volta compiles without warnings or errors both with and without the feature flag.