### PR TITLE
Remove use of #[feature] and build docs on stable

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: stable
           override: true
       - name: Build docs
         uses: actions-rs/cargo@v1

--- a/crates/volta-core/src/lib.rs
+++ b/crates/volta-core/src/lib.rs
@@ -1,9 +1,5 @@
 //! The main implementation crate for the core of Volta.
 
-// The `doc_cfg` feature has to be enabled for platform-specific API doc generation.
-// https://doc.rust-lang.org/nightly/unstable-book/language-features/doc-cfg.html
-#![cfg_attr(feature = "cross-platform-docs", feature(doc_cfg))]
-
 mod command;
 pub mod error;
 mod event;


### PR DESCRIPTION
Info
-----
* Building the docs currently fails on nightly due to some incomprehensible `serde` errors.
* The only reason we need to use nightly is that we have a feature declared in `volta_core`: `#[feature(doc_cfg)]`, which claims to help support cross-platform docs.
* However, we don't seem to be taking advantage of that feature within the API docs anywhere.

Changes
-----
* Removed the `#[feature]` attribute that we weren't using anyway.
* Updated the CI configuration to build the API docs on stable Rust.

Tested
-----
* Ran `cargo doc` on stable to ensure that it completes correctly.