### PR TITLE
[Medium] Add new layout version for new package installation workflow

### DIFF
--- a/crates/volta-core/src/inventory.rs
+++ b/crates/volta-core/src/inventory.rs
@@ -48,6 +48,7 @@ pub fn yarn_versions() -> Fallible<BTreeSet<Version>> {
 }
 
 /// Checks if a given package version image is available on the local machine
+#[cfg(not(feature = "package-global"))]
 pub fn package_available(name: &str, version: &Version) -> Fallible<bool> {
     volta_home().map(|home| home.package_image_dir(name, &version.to_string()).exists())
 }

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -6,7 +6,10 @@ use cfg_if::cfg_if;
 use double_checked_cell::DoubleCheckedCell;
 use dunce::canonicalize;
 use lazy_static::lazy_static;
+#[cfg(not(feature = "package-global"))]
 use volta_layout::v2::{VoltaHome, VoltaInstall};
+#[cfg(feature = "package-global")]
+use volta_layout::v3::{VoltaHome, VoltaInstall};
 
 cfg_if! {
     if #[cfg(unix)] {

--- a/crates/volta-core/src/run/binary.rs
+++ b/crates/volta-core/src/run/binary.rs
@@ -9,7 +9,7 @@ use crate::session::{ActivityKind, Session};
 #[cfg(not(feature = "package-global"))]
 use crate::tool::bin_full_path;
 #[cfg(feature = "package-global")]
-use crate::tool::package::{new_package_image_dir, BinConfig};
+use crate::tool::package::BinConfig;
 #[cfg(not(feature = "package-global"))]
 use crate::tool::{BinConfig, BinLoader};
 use log::debug;
@@ -112,7 +112,7 @@ impl DefaultBinary {
     pub fn from_config(bin_config: BinConfig, session: &mut Session) -> Fallible<Self> {
         // Looking forward to supporting installs from all package managers, we will want this
         // logic to support the various possible directory structures for each package manager
-        let mut bin_path = new_package_image_dir(volta_home()?, &bin_config.package);
+        let mut bin_path = volta_home()?.package_image_dir(&bin_config.package);
         // On Windows, the binaries are in the root of the `prefix` directory
         // On other OSes, they are in a `bin` subdirectory
         #[cfg(not(windows))]

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -1,5 +1,4 @@
 use std::fmt::{self, Display};
-use std::path::PathBuf;
 
 use super::Tool;
 use crate::error::{Context, ErrorKind, Fallible};
@@ -49,8 +48,7 @@ impl Package {
     }
 
     fn persist_install(&self) -> Fallible<()> {
-        let home = volta_home()?;
-        let package_dir = new_package_image_dir(home, &self.name);
+        let package_dir = volta_home()?.package_image_dir(&self.name);
 
         remove_dir_if_exists(&package_dir)?;
 
@@ -117,10 +115,4 @@ impl Display for Package {
             _ => f.write_str(&tool_version(&self.name, &self.version)),
         }
     }
-}
-
-pub fn new_package_image_dir(home: &volta_layout::v2::VoltaHome, package_name: &str) -> PathBuf {
-    // TODO: An updated layout (and associated migration) will be added in a follow-up PR
-    // at which point this function can be removed
-    home.package_image_root_dir().join(package_name)
 }

--- a/crates/volta-core/src/tool/package_global/uninstall.rs
+++ b/crates/volta-core/src/tool/package_global/uninstall.rs
@@ -1,5 +1,4 @@
 use super::metadata::{BinConfig, PackageConfig};
-use super::new_package_image_dir;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::fs::{dir_entry_match, remove_dir_if_exists, remove_file_if_exists};
 use crate::layout::volta_home;
@@ -45,7 +44,7 @@ pub fn uninstall(name: &str) -> Fallible<()> {
     };
 
     // Remove the package directory itself
-    let package_image_dir = new_package_image_dir(home, name);
+    let package_image_dir = home.package_image_dir(name);
     remove_dir_if_exists(package_image_dir)?;
 
     if package_found {

--- a/crates/volta-layout/src/lib.rs
+++ b/crates/volta-layout/src/lib.rs
@@ -4,6 +4,8 @@ mod macros;
 pub mod v0;
 pub mod v1;
 pub mod v2;
+#[cfg(feature = "package-global")]
+pub mod v3;
 
 fn executable(name: &str) -> String {
     format!("{}{}", name, std::env::consts::EXE_SUFFIX)

--- a/crates/volta-layout/src/v3.rs
+++ b/crates/volta-layout/src/v3.rs
@@ -1,0 +1,121 @@
+use std::path::PathBuf;
+
+use super::executable;
+use volta_layout_macro::layout;
+
+pub use crate::v1::VoltaInstall;
+
+layout! {
+    pub struct VoltaHome {
+        "cache": cache_dir {
+            "node": node_cache_dir {
+                "index.json": node_index_file;
+                "index.json.expires": node_index_expiry_file;
+            }
+        }
+        "bin": shim_dir {}
+        "log": log_dir {}
+        "tools": tools_dir {
+            "inventory": inventory_dir {
+                "node": node_inventory_dir {}
+                "npm": npm_inventory_dir {}
+                "packages": package_inventory_dir {}
+                "yarn": yarn_inventory_dir {}
+            }
+            "image": image_dir {
+                "node": node_image_root_dir {}
+                "npm": npm_image_root_dir {}
+                "yarn": yarn_image_root_dir {}
+                "packages": package_image_root_dir {}
+            }
+            "user": default_toolchain_dir {
+                "bins": default_bin_dir {}
+                "packages": default_package_dir {}
+                "platform.json": default_platform_file;
+            }
+        }
+        "tmp": tmp_dir {}
+        "hooks.json": default_hooks_file;
+        "layout.v3": layout_file;
+    }
+}
+
+impl VoltaHome {
+    pub fn package_distro_file(&self, name: &str, version: &str) -> PathBuf {
+        path_buf!(
+            self.package_inventory_dir.clone(),
+            format!("{}-{}.tgz", name, version)
+        )
+    }
+
+    pub fn package_distro_shasum(&self, name: &str, version: &str) -> PathBuf {
+        path_buf!(
+            self.package_inventory_dir.clone(),
+            format!("{}-{}.shasum", name, version)
+        )
+    }
+
+    pub fn node_image_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_root_dir.clone(), node)
+    }
+
+    pub fn npm_image_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_root_dir.clone(), npm)
+    }
+
+    pub fn npm_image_bin_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_dir(npm), "bin")
+    }
+
+    pub fn yarn_image_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_root_dir.clone(), version)
+    }
+
+    pub fn yarn_image_bin_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_dir(version), "bin")
+    }
+
+    pub fn package_image_dir(&self, name: &str) -> PathBuf {
+        path_buf!(self.package_image_root_dir.clone(), name)
+    }
+
+    pub fn default_package_config_file(&self, package_name: &str) -> PathBuf {
+        path_buf!(
+            self.default_package_dir.clone(),
+            format!("{}.json", package_name)
+        )
+    }
+
+    pub fn default_tool_bin_config(&self, bin_name: &str) -> PathBuf {
+        path_buf!(self.default_bin_dir.clone(), format!("{}.json", bin_name))
+    }
+
+    pub fn node_npm_version_file(&self, version: &str) -> PathBuf {
+        path_buf!(
+            self.node_inventory_dir.clone(),
+            format!("node-v{}-npm", version)
+        )
+    }
+
+    pub fn shim_file(&self, toolname: &str) -> PathBuf {
+        path_buf!(self.shim_dir.clone(), executable(toolname))
+    }
+}
+
+#[cfg(windows)]
+impl VoltaHome {
+    pub fn shim_git_bash_script_file(&self, toolname: &str) -> PathBuf {
+        path_buf!(self.shim_dir.clone(), toolname)
+    }
+
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        self.node_image_dir(node)
+    }
+}
+
+#[cfg(unix)]
+impl VoltaHome {
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_dir(node), "bin")
+    }
+}

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -435,6 +435,7 @@ impl SandboxBuilder {
         self.root.root().mkdir_p();
 
         // make sure these directories exist
+        ok_or_panic! { fs::create_dir_all(volta_bin_dir()) };
         ok_or_panic! { fs::create_dir_all(node_cache_dir()) };
         ok_or_panic! { fs::create_dir_all(node_inventory_dir()) };
         ok_or_panic! { fs::create_dir_all(package_inventory_dir()) };


### PR DESCRIPTION
Info
-----
* Part 8 of package rework: Create a new layout version to represent the new package installation process.
* This new layout is a small change from the previous (`package_image_dir` no longer uses `version`), however it also will serve as a marker for migrating existing package installations.

Changes
-----
* Added `v3` layout in `volta_layout`
* Updated `layout` module in `volta_core` to use `v3` layout when the feature flag is active.
* Removed `new_package_image_dir` function and switched to calling `package_image_dir` on the `VoltaHome` instance.
* Removed `inventory::package_available` method when the feature flag is on, since it isn't used any more.

Notes
-----
* This change only includes the updated `layout`, but does _not_ include a migration for that layout yet. The actual migration will be added in the next PR.