### PR TITLE
[Medium] Implement Package Migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,9 +2294,12 @@ version = "0.1.0"
 dependencies = [
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (git+https://github.com/mikrostew/semver?branch=new-parser)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "volta-core 0.1.0",
  "volta-layout 0.1.1",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/crates/volta-core/src/tool/package_global/install.rs
+++ b/crates/volta-core/src/tool/package_global/install.rs
@@ -11,7 +11,7 @@ impl Package {
     /// Sets the environment variable `npm_config_prefix` to redirect the install to the Volta
     /// data directory, taking advantage of the standard global install behavior with a custom
     /// location
-    pub(super) fn global_install(&self, platform_image: &Image) -> Fallible<()> {
+    pub fn global_install(&self, platform_image: &Image) -> Fallible<()> {
         let package = self.to_string();
         let mut command = create_command("npm");
         command.args(&[

--- a/crates/volta-layout/src/v3.rs
+++ b/crates/volta-layout/src/v3.rs
@@ -19,7 +19,6 @@ layout! {
             "inventory": inventory_dir {
                 "node": node_inventory_dir {}
                 "npm": npm_inventory_dir {}
-                "packages": package_inventory_dir {}
                 "yarn": yarn_inventory_dir {}
             }
             "image": image_dir {
@@ -41,20 +40,6 @@ layout! {
 }
 
 impl VoltaHome {
-    pub fn package_distro_file(&self, name: &str, version: &str) -> PathBuf {
-        path_buf!(
-            self.package_inventory_dir.clone(),
-            format!("{}-{}.tgz", name, version)
-        )
-    }
-
-    pub fn package_distro_shasum(&self, name: &str, version: &str) -> PathBuf {
-        path_buf!(
-            self.package_inventory_dir.clone(),
-            format!("{}-{}.shasum", name, version)
-        )
-    }
-
     pub fn node_image_dir(&self, node: &str) -> PathBuf {
         path_buf!(self.node_image_root_dir.clone(), node)
     }

--- a/crates/volta-migrate/Cargo.toml
+++ b/crates/volta-migrate/Cargo.toml
@@ -13,3 +13,6 @@ volta-layout = { path = "../volta-layout" }
 log = { version = "0.4", features = ["std"] }
 tempfile = "3.0.2"
 semver = { git = "https://github.com/mikrostew/semver", branch = "new-parser" }
+serde_json = { version = "1.0.37", features = ["preserve_order"] }
+serde = { version = "1.0.85", features = ["derive"] }
+walkdir = "2.2.9"

--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -157,9 +157,7 @@ pub fn run_migration() -> Fallible<()> {
 }
 
 fn detect_and_migrate() -> Fallible<()> {
-    info!(
-        "Your Volta directory is out of date and will be updated. This may take a few moments..."
-    );
+    info!("Updating your Volta directory. This may take a few moments...");
     let mut state = MigrationState::current()?;
 
     // To keep the complexity of writing a new migration from continuously increasing, each new

--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -15,10 +15,14 @@ mod empty;
 mod v0;
 mod v1;
 mod v2;
+#[cfg(feature = "package-global")]
+mod v3;
 
 use v0::V0;
 use v1::V1;
 use v2::V2;
+#[cfg(feature = "package-global")]
+use v3::V3;
 
 use log::debug;
 use volta_core::error::Fallible;
@@ -36,6 +40,8 @@ enum MigrationState {
     V0(Box<V0>),
     V1(Box<V1>),
     V2(Box<V2>),
+    #[cfg(feature = "package-global")]
+    V3(Box<V3>),
 }
 
 /// Macro to simplify the boilerplate associated with detecting a tagged state.
@@ -75,6 +81,10 @@ macro_rules! detect_tagged {
     }
 }
 
+#[cfg(feature = "package-global")]
+detect_tagged!((v3, V3, V3), (v2, V2, V2), (v1, V1, V1));
+
+#[cfg(not(feature = "package-global"))]
 detect_tagged!((v2, V2, V2), (v1, V1, V1));
 
 impl MigrationState {
@@ -154,10 +164,20 @@ fn detect_and_migrate() -> Fallible<()> {
     // latest version. We then apply the migrations sequentially here: V0 -> V1 -> ... -> VX
     loop {
         state = match state {
-            MigrationState::Empty(e) => MigrationState::V1(Box::new(e.try_into()?)),
+            #[cfg(feature = "package-global")]
+            MigrationState::Empty(e) => MigrationState::V3(Box::new(e.try_into()?)),
+            #[cfg(not(feature = "package-global"))]
+            MigrationState::Empty(e) => MigrationState::V2(Box::new(e.try_into()?)),
             MigrationState::V0(zero) => MigrationState::V1(Box::new((*zero).try_into()?)),
             MigrationState::V1(one) => MigrationState::V2(Box::new((*one).try_into()?)),
+            #[cfg(not(feature = "package-global"))]
             MigrationState::V2(_) => {
+                break;
+            }
+            #[cfg(feature = "package-global")]
+            MigrationState::V2(two) => MigrationState::V3(Box::new((*two).try_into()?)),
+            #[cfg(feature = "package-global")]
+            MigrationState::V3(_) => {
                 break;
             }
         };

--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -170,7 +170,7 @@ fn detect_and_migrate() -> Fallible<()> {
             #[cfg(feature = "package-global")]
             MigrationState::Empty(e) => MigrationState::V3(Box::new(e.try_into()?)),
             #[cfg(not(feature = "package-global"))]
-            MigrationState::Empty(e) => MigrationState::V2(Box::new(e.try_into()?)),
+            MigrationState::Empty(e) => MigrationState::V1(Box::new(e.try_into()?)),
             MigrationState::V0(zero) => MigrationState::V1(Box::new((*zero).try_into()?)),
             MigrationState::V1(one) => MigrationState::V2(Box::new((*one).try_into()?)),
             #[cfg(not(feature = "package-global"))]

--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -24,7 +24,7 @@ use v2::V2;
 #[cfg(feature = "package-global")]
 use v3::V3;
 
-use log::debug;
+use log::{debug, info};
 use volta_core::error::Fallible;
 use volta_core::layout::volta_home;
 #[cfg(unix)]
@@ -157,6 +157,9 @@ pub fn run_migration() -> Fallible<()> {
 }
 
 fn detect_and_migrate() -> Fallible<()> {
+    info!(
+        "Your Volta directory is out of date and will be updated. This may take a few moments..."
+    );
     let mut state = MigrationState::current()?;
 
     // To keep the complexity of writing a new migration from continuously increasing, each new

--- a/crates/volta-migrate/src/v2.rs
+++ b/crates/volta-migrate/src/v2.rs
@@ -16,7 +16,7 @@ use volta_layout::{v1, v2};
 
 /// Represents a V2 Volta Layout (used by Volta v0.7.3 and above)
 ///
-/// Holds a reference to the V1 layout struct to support potential future migrations
+/// Holds a reference to the V2 layout struct to support potential future migrations
 pub struct V2 {
     pub home: v2::VoltaHome,
 }
@@ -28,7 +28,7 @@ impl V2 {
         }
     }
 
-    /// Write the layout file to mark migration to V1 as complete
+    /// Write the layout file to mark migration to V2 as complete
     ///
     /// Should only be called once all other migration steps are finished, so that we don't
     /// accidentally mark an incomplete migration as completed

--- a/crates/volta-migrate/src/v3.rs
+++ b/crates/volta-migrate/src/v3.rs
@@ -1,0 +1,78 @@
+use std::convert::TryFrom;
+use std::fs::File;
+use std::path::PathBuf;
+
+use crate::empty::Empty;
+use crate::v2::V2;
+use log::debug;
+use volta_core::error::{Context, ErrorKind, Fallible, VoltaError};
+use volta_core::fs::remove_file_if_exists;
+use volta_layout::v3;
+
+/// Represents a V3 Volta layout (used by Volta v0.9.0 and above)
+///
+/// Holds a reference to the V3 layout struct to support future migrations
+pub struct V3 {
+    pub home: v3::VoltaHome,
+}
+
+impl V3 {
+    pub fn new(home: PathBuf) -> Self {
+        V3 {
+            home: v3::VoltaHome::new(home),
+        }
+    }
+
+    /// Write the layout file to mark migration to V2 as complete
+    ///
+    /// Should only be called once all other migration steps are finished, so that we don't
+    /// accidentally mark an incomplete migration as completed
+    fn complete_migration(home: v3::VoltaHome) -> Fallible<Self> {
+        debug!("Writing layout marker file");
+        File::create(home.layout_file()).with_context(|| ErrorKind::CreateLayoutFileError {
+            file: home.layout_file().to_owned(),
+        })?;
+
+        Ok(V3 { home })
+    }
+}
+
+impl TryFrom<Empty> for V3 {
+    type Error = VoltaError;
+
+    fn try_from(old: Empty) -> Fallible<Self> {
+        debug!("New Volta installation detected, creating fresh layout");
+
+        let home = v3::VoltaHome::new(old.home);
+        home.create().with_context(|| ErrorKind::CreateDirError {
+            dir: home.root().to_owned(),
+        })?;
+
+        V3::complete_migration(home)
+    }
+}
+
+impl TryFrom<V2> for V3 {
+    type Error = VoltaError;
+
+    fn try_from(old: V2) -> Fallible<Self> {
+        debug!("Migrating from V2 layout");
+
+        let new_home = v3::VoltaHome::new(old.home.root().to_owned());
+        new_home
+            .create()
+            .with_context(|| ErrorKind::CreateDirError {
+                dir: new_home.root().to_owned(),
+            })?;
+
+        // Perform the core of the migration
+
+        // Complete the migration, writing the V3 layout file
+        let layout = V3::complete_migration(new_home)?;
+
+        // Remove the V2 layout file, since we're now on V3 (do this after writing the V3 file so that we know the migration succeeded)
+        remove_file_if_exists(old.home.layout_file())?;
+
+        Ok(layout)
+    }
+}

--- a/crates/volta-migrate/src/v3.rs
+++ b/crates/volta-migrate/src/v3.rs
@@ -6,7 +6,7 @@ use crate::empty::Empty;
 use crate::v2::V2;
 use log::{debug, warn};
 use volta_core::error::{Context, ErrorKind, Fallible, VoltaError};
-use volta_core::fs::remove_file_if_exists;
+use volta_core::fs::{remove_dir_if_exists, remove_file_if_exists};
 use volta_core::platform::PlatformSpec;
 use volta_core::session::Session;
 use volta_core::tool::{Package, PackageConfig};
@@ -76,6 +76,9 @@ impl TryFrom<V2> for V3 {
 
         // Migrate installed packages to the new workflow
         migrate_packages(&old.home)?;
+
+        // Remove the package inventory directory, as we no longer cache package tarballs
+        remove_dir_if_exists(old.home.package_inventory_dir())?;
 
         // Complete the migration, writing the V3 layout file
         let layout = V3::complete_migration(new_home)?;

--- a/crates/volta-migrate/src/v3/config.rs
+++ b/crates/volta-migrate/src/v3/config.rs
@@ -1,0 +1,48 @@
+use std::fs::File;
+use std::path::Path;
+
+use semver::Version;
+use volta_core::platform::PlatformSpec;
+use volta_core::version::{option_version_serde, version_serde};
+
+#[derive(serde::Deserialize)]
+pub struct LegacyPackageConfig {
+    pub name: String,
+    #[serde(with = "version_serde")]
+    pub version: Version,
+    pub platform: LegacyPlatform,
+    pub bins: Vec<String>,
+}
+
+#[derive(serde::Deserialize)]
+pub struct LegacyPlatform {
+    pub node: NodeVersion,
+    #[serde(with = "option_version_serde")]
+    pub yarn: Option<Version>,
+}
+
+#[derive(serde::Deserialize)]
+pub struct NodeVersion {
+    #[serde(with = "version_serde")]
+    pub runtime: Version,
+    #[serde(with = "option_version_serde")]
+    pub npm: Option<Version>,
+}
+
+impl LegacyPackageConfig {
+    pub fn from_file(config_file: &Path) -> Option<Self> {
+        let file = File::open(config_file).ok()?;
+
+        serde_json::from_reader(file).ok()
+    }
+}
+
+impl From<LegacyPlatform> for PlatformSpec {
+    fn from(config_platform: LegacyPlatform) -> Self {
+        PlatformSpec {
+            node: config_platform.node.runtime,
+            npm: config_platform.node.npm,
+            yarn: config_platform.yarn,
+        }
+    }
+}

--- a/tests/acceptance/migrations.rs
+++ b/tests/acceptance/migrations.rs
@@ -31,6 +31,9 @@ fn empty_volta_home_is_created() {
     assert!(Sandbox::path_exists(".volta/tools/user"));
 
     // Layout file should now exist
+    #[cfg(feature = "package-global")]
+    assert!(Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(not(feature = "package-global"))]
     assert!(Sandbox::path_exists(".volta/layout.v2"));
 
     // shims should all be created
@@ -71,8 +74,14 @@ fn legacy_v0_volta_home_is_upgraded() {
     assert!(Sandbox::path_exists(".volta/tools/inventory/packages"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
 
-    // V2 layout file should now exist, V1 layout file should not exist
+    // Most recent layout file should exist, others should not
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
+    #[cfg(feature = "package-global")]
+    {
+        assert!(!Sandbox::path_exists(".volta/layout.v2"));
+        assert!(Sandbox::path_exists(".volta/layout.v3"));
+    }
+    #[cfg(not(feature = "package-global"))]
     assert!(Sandbox::path_exists(".volta/layout.v2"));
 
     // shims should all be created
@@ -139,8 +148,14 @@ fn tagged_v1_volta_home_is_upgraded() {
     assert!(Sandbox::path_exists(".volta/tools/inventory/packages"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
 
-    // V2 layout file should now exist, V1 layout file should not exist
+    // Most recent layout file should exist, others should not
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
+    #[cfg(feature = "package-global")]
+    {
+        assert!(!Sandbox::path_exists(".volta/layout.v2"));
+        assert!(Sandbox::path_exists(".volta/layout.v3"));
+    }
+    #[cfg(not(feature = "package-global"))]
     assert!(Sandbox::path_exists(".volta/layout.v2"));
 
     // shims should all be created
@@ -206,6 +221,34 @@ fn tagged_v1_to_v2_keeps_migrated_node_images() {
 }
 
 #[test]
+#[cfg(feature = "package-global")]
+fn current_v3_volta_home_is_unchanged() {
+    let s = sandbox().layout_file("v3").build();
+
+    // directories that are already created by the test framework
+    assert!(Sandbox::path_exists(".volta"));
+    assert!(Sandbox::path_exists(".volta/layout.v3"));
+    assert!(Sandbox::path_exists(".volta/cache/node"));
+    assert!(Sandbox::path_exists(".volta/tmp"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/packages"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
+
+    // running volta should not create anything else
+    assert_that!(s.volta("--version"), execs().with_status(0));
+
+    // everything should be the same as before running the command
+    assert!(Sandbox::path_exists(".volta"));
+    assert!(Sandbox::path_exists(".volta/layout.v3"));
+    assert!(Sandbox::path_exists(".volta/cache/node"));
+    assert!(Sandbox::path_exists(".volta/tmp"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/packages"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
+}
+
+#[test]
+#[cfg(not(feature = "package-global"))]
 fn current_v2_volta_home_is_unchanged() {
     let s = sandbox().layout_file("v2").build();
 

--- a/tests/acceptance/migrations.rs
+++ b/tests/acceptance/migrations.rs
@@ -26,6 +26,7 @@ fn empty_volta_home_is_created() {
     assert!(Sandbox::path_exists(".volta/tools/image/node"));
     assert!(Sandbox::path_exists(".volta/tools/image/yarn"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
+    #[cfg(not(feature = "package-global"))]
     assert!(Sandbox::path_exists(".volta/tools/inventory/packages"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
     assert!(Sandbox::path_exists(".volta/tools/user"));
@@ -66,12 +67,15 @@ fn legacy_v0_volta_home_is_upgraded() {
     // running volta should not create anything else
     assert_that!(s.volta("--version"), execs().with_status(0));
 
-    // everything should be the same as before running the command
+    // Layout should be updated to the most recent
     assert!(Sandbox::path_exists(".volta"));
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
+    #[cfg(not(feature = "package-global"))]
     assert!(Sandbox::path_exists(".volta/tools/inventory/packages"));
+    #[cfg(feature = "package-global")]
+    assert!(!Sandbox::path_exists(".volta/tools/inventory/packages"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
 
     // Most recent layout file should exist, others should not
@@ -145,6 +149,7 @@ fn tagged_v1_volta_home_is_upgraded() {
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
+    #[cfg(not(feature = "package-global"))]
     assert!(Sandbox::path_exists(".volta/tools/inventory/packages"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
 
@@ -231,7 +236,6 @@ fn current_v3_volta_home_is_unchanged() {
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
-    assert!(Sandbox::path_exists(".volta/tools/inventory/packages"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
 
     // running volta should not create anything else
@@ -243,7 +247,6 @@ fn current_v3_volta_home_is_unchanged() {
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
-    assert!(Sandbox::path_exists(".volta/tools/inventory/packages"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
 }
 

--- a/tests/smoke/main.rs
+++ b/tests/smoke/main.rs
@@ -18,5 +18,7 @@ cfg_if::cfg_if! {
         mod volta_install;
         mod volta_run;
         mod autodownload;
+        #[cfg(feature = "package-global")]
+        mod package_migration;
     }
 }

--- a/tests/smoke/package_migration.rs
+++ b/tests/smoke/package_migration.rs
@@ -1,0 +1,70 @@
+use crate::support::temp_project::temp_project;
+
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+const LEGACY_PACKAGE_CONFIG: &str = r#"{
+  "name": "cowsay",
+  "version": "1.1.7",
+  "platform": {
+    "node": {
+      "runtime": "12.18.3",
+      "npm": null
+    },
+    "yarn": null
+  },
+  "bins": [
+    "cowsay",
+    "cowthink"
+  ]
+}"#;
+
+const LEGACY_BIN_CONFIG: &str = r#"{
+  "name": "cowsay",
+  "package": "cowsay",
+  "version": "1.1.7",
+  "path": "./cli.js",
+  "platform": {
+    "node": {
+      "runtime": "12.18.3",
+      "npm": null
+    },
+    "yarn": null
+  },
+  "loader": {
+    "command": "node",
+    "args": []
+  }
+}"#;
+
+const COWSAY_HELLO: &str = r#" _______
+< hello >
+ -------
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||"#;
+
+#[test]
+fn legacy_package_upgrade() {
+    let p = temp_project()
+        .volta_home_file("tools/user/packages/cowsay.json", LEGACY_PACKAGE_CONFIG)
+        .volta_home_file("tools/user/bins/cowsay.json", LEGACY_BIN_CONFIG)
+        .volta_home_file(
+            "tools/image/packages/cowsay/1.3.1/README.md",
+            "Mock of installed package",
+        )
+        .volta_home_file("layout.v2", "")
+        .build();
+
+    assert_that!(p.volta("--version"), execs().with_status(0));
+
+    assert!(p.package_is_installed("cowsay"));
+
+    assert_that!(
+        p.exec_shim("cowsay", "hello"),
+        execs().with_status(0).with_stdout_contains(COWSAY_HELLO)
+    );
+}

--- a/tests/smoke/support/temp_project.rs
+++ b/tests/smoke/support/temp_project.rs
@@ -69,6 +69,14 @@ impl TempProjectBuilder {
         self
     }
 
+    /// Create a file in the `volta_home` directory (chainable)
+    #[cfg(feature = "package-global")]
+    pub fn volta_home_file(mut self, path: &str, contents: &str) -> Self {
+        let path = volta_home(self.root()).join(path);
+        self.files.push(FileBuilder::new(path, contents));
+        self
+    }
+
     /// Create the project
     pub fn build(mut self) -> TempProject {
         // First, clean the temporary project directory if it already exists


### PR DESCRIPTION
Info
-----
* Part 9 of package rework: Create migration for existing packages
* With the change to revamp to how packages are installed, we need to make sure to migrate anyone who has packages installed with the old logic.
* We achieve this by building a list of installed packages and re-installing them using the new logic
    * The package install process overwrites the configuration files and the package image directory, so the old package will be completely replaced.
* By reading the old package configuration file, we can make sure to keep the pinned platform associated with an already-installed package.

Changes
-----
* Created migration to `v3` layout.
    * Apart from changing the layout file, this migration updates the packages by loading the legacy package configs and re-installing each package.
* Added message to the start of any migration indicating the change is happening.
* Updated tests to reflect the new migration status.
* Added smoke test for the package migration.

Tested
-----
* All tests (including the new smoke test) pass.
* Manually tested that the migration correctly updates a package to the new installation method.