### PR TITLE
[Medium] Refactor install logic to use bare functions

### DIFF
--- a/crates/volta-core/src/tool/package_global/configure.rs
+++ b/crates/volta-core/src/tool/package_global/configure.rs
@@ -1,88 +1,90 @@
+use std::path::PathBuf;
+
 use super::metadata::{BinConfig, PackageConfig, PackageManifest};
-use super::Package;
 use crate::error::{ErrorKind, Fallible};
 use crate::layout::volta_home;
 use crate::platform::{Image, PlatformSpec};
 use crate::shim;
 
-impl Package {
-    /// Read the manifest for the package being installed
-    pub(super) fn parse_manifest(&self) -> Fallible<PackageManifest> {
-        let mut package_dir = self.staging.path().to_owned();
-        // Looking forward to allowing direct package manager global installs,
-        // this method should be updated to support the different directory layouts
-        // of different package managers.
+/// Read the manifest for the package being installed
+pub(super) fn parse_manifest(
+    package_name: &str,
+    staging_dir: PathBuf,
+) -> Fallible<PackageManifest> {
+    let mut package_dir = staging_dir;
+    // Looking forward to allowing direct package manager global installs,
+    // this method should be updated to support the different directory layouts
+    // of different package managers.
 
-        // `lib` is not in the directory structure on Windows
-        #[cfg(not(windows))]
-        package_dir.push("lib");
+    // `lib` is not in the directory structure on Windows
+    #[cfg(not(windows))]
+    package_dir.push("lib");
 
-        package_dir.push("node_modules");
-        package_dir.push(&self.name);
+    package_dir.push("node_modules");
+    package_dir.push(package_name);
 
-        PackageManifest::for_dir(&self.name, &package_dir)
-    }
+    PackageManifest::for_dir(package_name, &package_dir)
+}
 
-    /// Generate configuration files and shims for the package and each of its bins
-    pub(super) fn write_config_and_shims(
-        &self,
-        manifest: &PackageManifest,
-        image: &Image,
-    ) -> Fallible<()> {
-        self.validate_bins(manifest)?;
+/// Generate configuration files and shims for the package and each of its bins
+pub(super) fn write_config_and_shims(
+    name: &str,
+    manifest: &PackageManifest,
+    image: &Image,
+) -> Fallible<()> {
+    validate_bins(name, manifest)?;
 
-        let platform = PlatformSpec {
-            node: image.node.value.clone(),
-            npm: image.npm.clone().map(|s| s.value),
-            yarn: image.yarn.clone().map(|s| s.value),
-        };
+    let platform = PlatformSpec {
+        node: image.node.value.clone(),
+        npm: image.npm.clone().map(|s| s.value),
+        yarn: image.yarn.clone().map(|s| s.value),
+    };
 
-        // Generate the shims and bin configs for each bin provided by the package
-        for bin_name in &manifest.bin {
-            shim::create(&bin_name)?;
+    // Generate the shims and bin configs for each bin provided by the package
+    for bin_name in &manifest.bin {
+        shim::create(&bin_name)?;
 
-            BinConfig {
-                name: bin_name.clone(),
-                package: self.name.clone(),
-                version: manifest.version.clone(),
-                platform: platform.clone(),
-            }
-            .write()?;
-        }
-
-        // Write the config for the package
-        PackageConfig {
-            name: self.name.clone(),
+        BinConfig {
+            name: bin_name.clone(),
+            package: name.into(),
             version: manifest.version.clone(),
-            platform,
-            bins: manifest.bin.clone(),
+            platform: platform.clone(),
         }
         .write()?;
-
-        Ok(())
     }
 
-    /// Validate that we aren't attempting to install a bin that is already installed by
-    /// another package.
-    fn validate_bins(&self, manifest: &PackageManifest) -> Fallible<()> {
-        let home = volta_home()?;
-        for bin_name in &manifest.bin {
-            // Check for name conflicts with already-installed bins
-            // Some packages may install bins with the same name
-            if let Ok(config) = BinConfig::from_file(home.default_tool_bin_config(&bin_name)) {
-                // The file exists, so there is a bin with this name
-                // That is okay iff it came from the package that is currently being installed
-                if self.name != config.package {
-                    return Err(ErrorKind::BinaryAlreadyInstalled {
-                        bin_name: bin_name.into(),
-                        existing_package: config.package,
-                        new_package: self.name.clone(),
-                    }
-                    .into());
+    // Write the config for the package
+    PackageConfig {
+        name: name.into(),
+        version: manifest.version.clone(),
+        platform,
+        bins: manifest.bin.clone(),
+    }
+    .write()?;
+
+    Ok(())
+}
+
+/// Validate that we aren't attempting to install a bin that is already installed by
+/// another package.
+fn validate_bins(package_name: &str, manifest: &PackageManifest) -> Fallible<()> {
+    let home = volta_home()?;
+    for bin_name in &manifest.bin {
+        // Check for name conflicts with already-installed bins
+        // Some packages may install bins with the same name
+        if let Ok(config) = BinConfig::from_file(home.default_tool_bin_config(&bin_name)) {
+            // The file exists, so there is a bin with this name
+            // That is okay iff it came from the package that is currently being installed
+            if package_name != config.package {
+                return Err(ErrorKind::BinaryAlreadyInstalled {
+                    bin_name: bin_name.into(),
+                    existing_package: config.package,
+                    new_package: package_name.into(),
                 }
+                .into());
             }
         }
-
-        Ok(())
     }
+
+    Ok(())
 }

--- a/crates/volta-core/src/tool/package_global/install.rs
+++ b/crates/volta-core/src/tool/package_global/install.rs
@@ -1,55 +1,57 @@
-use super::Package;
+use std::path::Path;
+
 use crate::command::create_command;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::platform::Image;
 use crate::style::progress_spinner;
 use log::debug;
 
-impl Package {
-    /// Use `npm install --global` to install the package
-    ///
-    /// Sets the environment variable `npm_config_prefix` to redirect the install to the Volta
-    /// data directory, taking advantage of the standard global install behavior with a custom
-    /// location
-    pub fn global_install(&self, platform_image: &Image) -> Fallible<()> {
-        let package = self.to_string();
-        let mut command = create_command("npm");
-        command.args(&[
-            "install",
-            "--global",
-            "--loglevel=warn",
-            "--no-update-notifier",
-            "--no-audit",
-        ]);
-        command.arg(&package);
-        command.env("PATH", platform_image.path()?);
-        command.env("npm_config_prefix", self.staging.path());
+/// Use `npm install --global` to install the package
+///
+/// Sets the environment variable `npm_config_prefix` to redirect the install to the Volta
+/// data directory, taking advantage of the standard global install behavior with a custom
+/// location
+pub(super) fn run_global_install(
+    package: String,
+    staging_dir: &Path,
+    platform_image: &Image,
+) -> Fallible<()> {
+    let mut command = create_command("npm");
+    command.args(&[
+        "install",
+        "--global",
+        "--loglevel=warn",
+        "--no-update-notifier",
+        "--no-audit",
+    ]);
+    command.arg(&package);
+    command.env("PATH", platform_image.path()?);
+    command.env("npm_config_prefix", staging_dir);
 
-        debug!("Installing {} with command: {:?}", package, command);
-        let spinner = progress_spinner(&format!("Installing {}", package));
-        let output_result = command
-            .output()
-            .with_context(|| ErrorKind::PackageInstallFailed {
-                package: package.clone(),
-            });
-        spinner.finish_and_clear();
-        let output = output_result?;
+    debug!("Installing {} with command: {:?}", package, command);
+    let spinner = progress_spinner(&format!("Installing {}", package));
+    let output_result = command
+        .output()
+        .with_context(|| ErrorKind::PackageInstallFailed {
+            package: package.clone(),
+        });
+    spinner.finish_and_clear();
+    let output = output_result?;
 
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        debug!("[install stderr]\n{}", stderr);
-        debug!(
-            "[install stdout]\n{}",
-            String::from_utf8_lossy(&output.stdout)
-        );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    debug!("[install stderr]\n{}", stderr);
+    debug!(
+        "[install stdout]\n{}",
+        String::from_utf8_lossy(&output.stdout)
+    );
 
-        if output.status.success() {
-            Ok(())
-        } else if stderr.contains("code E404") {
-            // npm outputs "code E404" as part of the error output when a package couldn't be found
-            // Detect that and show a nicer error message (since we likely know the problem in that case)
-            Err(ErrorKind::PackageNotFound { package }.into())
-        } else {
-            Err(ErrorKind::PackageInstallFailed { package }.into())
-        }
+    if output.status.success() {
+        Ok(())
+    } else if stderr.contains("code E404") {
+        // npm outputs "code E404" as part of the error output when a package couldn't be found
+        // Detect that and show a nicer error message (since we likely know the problem in that case)
+        Err(ErrorKind::PackageNotFound { package }.into())
+    } else {
+        Err(ErrorKind::PackageInstallFailed { package }.into())
     }
 }

--- a/crates/volta-migrate/src/v3.rs
+++ b/crates/volta-migrate/src/v3.rs
@@ -160,7 +160,7 @@ fn migrate_single_package(config: LegacyPackageConfig, session: &mut Session) ->
     let image = platform.as_binary().checkout(session)?;
 
     // Run the global install command
-    tool.global_install(&image)?;
+    tool.run_install(&image)?;
     // Overwrite the config files and image directory
     tool.complete_install(&image)?;
 


### PR DESCRIPTION
Info
-----
* The next phase of the package rework involves supporting direct global installs (e.g. `npm install --global typescript`) to work within Volta.
* To do this, we will need to support a similar, but not identical interface for the install steps.
* To allow for reuse across different interfaces, refactor the various supporting methods into bare functions, which avoids them being tied to one specific struct (`Package`).

Changes
-----
* Update the `configure` and `install` modules in `package_global` to use bare functions that accept what they need as parameters.
* Similarly, updated the `persist_install` method to be a bare function.
* Added `run_install` to the `impl Package` block directly, so the entire public interface is in one place.

Tested
-----
* There should be no functional change due to this refactor, all tests still pass.

Notes
-----
* The changes look somewhat substantial, but the majority of them are reformatting (one fewer level of indentation with bare functions as opposed to associated functions) or changes related to using parameters directly, instead of properties.