### PR TITLE
[Small] Add PackageManger type to install logic

### DIFF
--- a/crates/volta-core/src/run/binary.rs
+++ b/crates/volta-core/src/run/binary.rs
@@ -110,14 +110,8 @@ pub struct DefaultBinary {
 impl DefaultBinary {
     #[cfg(feature = "package-global")]
     pub fn from_config(bin_config: BinConfig, session: &mut Session) -> Fallible<Self> {
-        // Looking forward to supporting installs from all package managers, we will want this
-        // logic to support the various possible directory structures for each package manager
-        let mut bin_path = volta_home()?.package_image_dir(&bin_config.package);
-        // On Windows, the binaries are in the root of the `prefix` directory
-        // On other OSes, they are in a `bin` subdirectory
-        #[cfg(not(windows))]
-        bin_path.push("bin");
-
+        let package_dir = volta_home()?.package_image_dir(&bin_config.package);
+        let mut bin_path = bin_config.manager.binary_dir(package_dir);
         bin_path.push(&bin_config.name);
 
         // If the user does not have yarn set in the platform for this binary, use the default

--- a/crates/volta-core/src/tool/package_global/install.rs
+++ b/crates/volta-core/src/tool/package_global/install.rs
@@ -1,5 +1,6 @@
-use std::path::Path;
+use std::path::PathBuf;
 
+use super::manager::PackageManager;
 use crate::command::create_command;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::platform::Image;
@@ -13,7 +14,7 @@ use log::debug;
 /// location
 pub(super) fn run_global_install(
     package: String,
-    staging_dir: &Path,
+    staging_dir: PathBuf,
     platform_image: &Image,
 ) -> Fallible<()> {
     let mut command = create_command("npm");
@@ -26,7 +27,7 @@ pub(super) fn run_global_install(
     ]);
     command.arg(&package);
     command.env("PATH", platform_image.path()?);
-    command.env("npm_config_prefix", staging_dir);
+    PackageManager::Npm.setup_global_command(&mut command, staging_dir);
 
     debug!("Installing {} with command: {:?}", package, command);
     let spinner = progress_spinner(&format!("Installing {}", package));

--- a/crates/volta-core/src/tool/package_global/manager.rs
+++ b/crates/volta-core/src/tool/package_global/manager.rs
@@ -1,0 +1,85 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+/// The package manager used to install a given package
+#[derive(Copy, Clone, serde::Serialize, serde::Deserialize, PartialOrd, Ord, PartialEq, Eq)]
+pub enum PackageManager {
+    Npm,
+    Yarn,
+}
+
+impl PackageManager {
+    /// Given the `package_root`, returns the directory where the source is stored for this
+    /// package manager. This will include the top-level `node_modules`, where appropriate.
+    pub fn source_dir(self, package_root: PathBuf) -> PathBuf {
+        let mut path = self.source_root(package_root);
+        path.push("node_modules");
+
+        path
+    }
+
+    /// Given the `package_root`, returns the root of the source directory. This directory will
+    /// contain the top-level `node-modules`
+    #[cfg(unix)]
+    fn source_root(self, package_root: PathBuf) -> PathBuf {
+        // On Unix, the source is always within a `lib` subdirectory, with both npm and Yarn
+        let mut path = package_root;
+        path.push("lib");
+
+        path
+    }
+
+    /// Given the `package_root`, returns the root of the source directory. This directory will
+    /// contain the top-level `node-modules`
+    #[cfg(windows)]
+    fn source_root(self, package_root: PathBuf) -> PathBuf {
+        match self {
+            // On Windows, npm puts the source node_modules directory in the root of the `prefix`
+            PackageManager::Npm => package_root,
+            // On Windows, we still tell yarn to use the `lib` subdirectory
+            PackageManager::Yarn => {
+                let mut path = package_root;
+                path.push("lib");
+
+                path
+            }
+        }
+    }
+
+    /// Given the `package_root`, returns the directory where binaries are stored for this package
+    /// manager.
+    #[cfg(unix)]
+    pub fn binary_dir(self, package_root: PathBuf) -> PathBuf {
+        // On Unix, the binaries are always within a `bin` subdirectory for both npm and Yarn
+        let mut path = package_root;
+        path.push("bin");
+
+        path
+    }
+
+    /// Given the `package_root`, returns the directory where binaries are stored for this package
+    /// manager.
+    #[cfg(windows)]
+    pub fn binary_dir(self, package_root: PathBuf) -> PathBuf {
+        match self {
+            // On Windows, npm leaves the binaries at the root of the `prefix` directory
+            PackageManager::Npm => package_root,
+            // On Windows, Yarn still includes the `bin` subdirectory
+            PackageManager::Yarn => {
+                let mut path = package_root;
+                path.push("bin");
+
+                path
+            }
+        }
+    }
+
+    /// Modify a given `Command` to be set up for global installs, given the package root
+    pub(super) fn setup_global_command(self, command: &mut Command, package_root: PathBuf) {
+        command.env("npm_config_prefix", &package_root);
+
+        if let PackageManager::Yarn = self {
+            command.env("npm_config_global_folder", self.source_root(package_root));
+        }
+    }
+}

--- a/crates/volta-core/src/tool/package_global/metadata.rs
+++ b/crates/volta-core/src/tool/package_global/metadata.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::path::Path;
 
+use super::manager::PackageManager;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::layout::volta_home;
 use crate::platform::PlatformSpec;
@@ -23,6 +24,8 @@ pub struct PackageConfig {
     pub platform: PlatformSpec,
     /// The binaries installed by this package
     pub bins: Vec<String>,
+    /// The package manager that was used to install this package
+    pub manager: PackageManager,
 }
 
 impl PackageConfig {
@@ -72,6 +75,8 @@ pub struct BinConfig {
     /// The platform used to install this binary
     #[serde(with = "RawPlatformSpec")]
     pub platform: PlatformSpec,
+    /// The package manager used to install this binary
+    pub manager: PackageManager,
 }
 
 impl BinConfig {

--- a/tests/acceptance/volta_uninstall.rs
+++ b/tests/acceptance/volta_uninstall.rs
@@ -15,7 +15,8 @@ const PKG_CONFIG_BASIC: &str = r#"{
   "bins": [
     "cowsay",
     "cowthink"
-  ]
+  ],
+  "manager": "Npm"
 }"#;
 
 #[cfg(not(feature = "package-global"))]
@@ -44,7 +45,8 @@ const PKG_CONFIG_NO_BINS: &str = r#"{
     "npm": "6.7.0",
     "yarn": null
   },
-  "bins": []
+  "bins": [],
+  "manager": "Npm"
 }"#;
 
 #[cfg(not(feature = "package-global"))]
@@ -72,7 +74,8 @@ fn bin_config(name: &str) -> String {
     "node": "11.10.1",
     "npm": "6.7.0",
     "yarn": null
-  }}
+  }},
+  "manager": "Npm"
 }}"#,
         name
     )


### PR DESCRIPTION
Info
-----
* In order to support direct global installs, we need to track the idiosyncrasies of the different package manager installs.
* This requires us to keep track of which package manager actually performed the install of a package.

Changes
-----
* Added a `PackageManager` enum to the `tool::package` module. This type has associated functions to determine the bin and source locations for a package and to set up a command to install into the appropriate directory.
* Updated all of the existing install logic to use the `PackageManager::Npm` type, since it uses `npm install --global` internally.
* Included the package manager in the package and bin config files, so they can be used on lookup if needed.
* Updated the binary execution to take advantage of the stored package manager and correctly locate the binary file.
* Added the package manager to the fixture data on the `volta_uninstall` tests.

Tested
-----
* Confirmed that all existing tests pass.
* Confirmed that the package manager is written into the package and binary configs when installing a package.