### PR TITLE
[Large] Refactor 'run' module to allow for better extensibility

### DIFF
--- a/crates/volta-core/src/lib.rs
+++ b/crates/volta-core/src/lib.rs
@@ -12,6 +12,10 @@ pub mod manifest;
 pub mod monitor;
 pub mod platform;
 pub mod project;
+#[cfg(not(feature = "package-global"))]
+pub mod run;
+#[cfg(feature = "package-global")]
+#[path = "run_package_global/mod.rs"]
 pub mod run;
 pub mod session;
 pub mod shim;

--- a/crates/volta-core/src/platform/mod.rs
+++ b/crates/volta-core/src/platform/mod.rs
@@ -274,6 +274,7 @@ impl Platform {
     }
 
     /// Returns the platform created by merging a `CliPartialPlatform` with the currently active platform
+    #[cfg(not(feature = "package-global"))]
     pub fn with_cli(cli: CliPlatform, session: &mut Session) -> Fallible<Option<Self>> {
         match Self::current(session)? {
             Some(current) => Ok(Some(cli.merge(current))),

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -5,7 +5,6 @@ use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::iter::empty;
 use std::path::Path;
-#[cfg(not(feature = "package-global"))]
 use std::process::Output;
 use std::process::{Command, ExitStatus};
 
@@ -125,7 +124,6 @@ impl ToolCommand {
     /// Add a single argument to the Command.
     ///
     /// The new argument will be added to the end of the current argument list
-    #[cfg(not(feature = "package-global"))]
     pub(crate) fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut ToolCommand {
         self.command.arg(arg);
         self
@@ -155,7 +153,6 @@ impl ToolCommand {
     }
 
     /// Set the current working directory for the Command
-    #[cfg(not(feature = "package-global"))]
     pub(crate) fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut ToolCommand {
         self.command.current_dir(dir);
         self
@@ -171,7 +168,6 @@ impl ToolCommand {
     /// Execute the command, returning all of its output to the caller
     ///
     /// Any failures will be wrapped with the Error value in `on_failure`
-    #[cfg(not(feature = "package-global"))]
     pub(crate) fn output(mut self) -> Fallible<Output> {
         self.command.output().with_context(|| self.on_failure)
     }

--- a/crates/volta-core/src/run_package_global/binary.rs
+++ b/crates/volta-core/src/run_package_global/binary.rs
@@ -1,0 +1,165 @@
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+
+use super::executor::{ToolCommand, ToolKind};
+use super::{debug_active_image, debug_no_platform};
+use crate::error::{ErrorKind, Fallible};
+use crate::layout::volta_home;
+use crate::platform::{Platform, Sourced, System};
+use crate::session::Session;
+use crate::tool::package::BinConfig;
+use log::debug;
+
+/// Determine the correct command to run for a 3rd-party binary
+///
+/// Will detect if we should delegate to the project-local version or use the default version
+pub(super) fn command(
+    exe: &OsStr,
+    args: &[OsString],
+    session: &mut Session,
+) -> Fallible<ToolCommand> {
+    let bin = exe.to_string_lossy().to_string();
+    // First try to use the project toolchain
+    if let Some(project) = session.project()? {
+        // Check if the executable is a direct dependency
+        if project.has_direct_bin(exe)? {
+            let path_to_bin =
+                project
+                    .find_bin(exe)
+                    .ok_or_else(|| ErrorKind::ProjectLocalBinaryNotFound {
+                        command: exe.to_string_lossy().to_string(),
+                    })?;
+
+            debug!("Found {} in project at '{}'", bin, path_to_bin.display());
+
+            let platform = Platform::current(session)?;
+            return Ok(ToolCommand::new(
+                path_to_bin,
+                args,
+                platform,
+                ToolKind::ProjectLocalBinary(bin),
+            ));
+        }
+    }
+
+    // Try to use the default toolchain
+    if let Some(default_tool) = DefaultBinary::from_name(exe, session)? {
+        debug!(
+            "Found default {} in '{}'",
+            bin,
+            default_tool.bin_path.display()
+        );
+
+        return Ok(ToolCommand::new(
+            default_tool.bin_path,
+            args,
+            Some(default_tool.platform),
+            ToolKind::DefaultBinary(bin),
+        ));
+    }
+
+    // At this point, the binary is not known to Volta, so we have no platform to use to execute it
+    // This should be rare, as anything we have a shim for should have a config file to load
+    Ok(ToolCommand::new(
+        exe,
+        args,
+        None,
+        ToolKind::DefaultBinary(bin),
+    ))
+}
+
+/// Determine the execution context (PATH and failure error message) for a project-local binary
+pub(super) fn local_execution_context(
+    tool: String,
+    platform: Option<Platform>,
+    session: &mut Session,
+) -> Fallible<(OsString, ErrorKind)> {
+    match platform {
+        Some(plat) => {
+            let image = plat.checkout(session)?;
+            let path = image.path()?;
+            debug_active_image(&image);
+
+            Ok((
+                path,
+                ErrorKind::ProjectLocalBinaryExecError { command: tool },
+            ))
+        }
+        None => {
+            let path = System::path()?;
+            debug_no_platform();
+
+            Ok((path, ErrorKind::NoPlatform))
+        }
+    }
+}
+
+/// Determine the execution context (PATH and failure error message) for a default binary
+pub(super) fn default_execution_context(
+    tool: String,
+    platform: Option<Platform>,
+    session: &mut Session,
+) -> Fallible<(OsString, ErrorKind)> {
+    match platform {
+        Some(plat) => {
+            let image = plat.checkout(session)?;
+            let path = image.path()?;
+            debug_active_image(&image);
+
+            Ok((path, ErrorKind::BinaryExecError))
+        }
+        None => {
+            let path = System::path()?;
+            debug_no_platform();
+
+            Ok((path, ErrorKind::BinaryNotFound { name: tool }))
+        }
+    }
+}
+
+/// Information about the location and execution context of default binaries
+///
+/// Fetched from the config files in the Volta directory, represents the binary that is executed
+/// when the user is outside of a project that has the given bin as a dependency.
+pub struct DefaultBinary {
+    pub bin_path: PathBuf,
+    pub platform: Platform,
+}
+
+impl DefaultBinary {
+    pub fn from_config(bin_config: BinConfig, session: &mut Session) -> Fallible<Self> {
+        let package_dir = volta_home()?.package_image_dir(&bin_config.package);
+        let mut bin_path = bin_config.manager.binary_dir(package_dir);
+        bin_path.push(&bin_config.name);
+
+        // If the user does not have yarn set in the platform for this binary, use the default
+        // This is necessary because some tools (e.g. ember-cli with the `--yarn` option) invoke `yarn`
+        let yarn = match bin_config.platform.yarn {
+            Some(yarn) => Some(yarn),
+            None => session
+                .default_platform()?
+                .and_then(|ref plat| plat.yarn.clone()),
+        };
+        let platform = Platform {
+            node: Sourced::with_binary(bin_config.platform.node),
+            npm: bin_config.platform.npm.map(Sourced::with_binary),
+            yarn: yarn.map(Sourced::with_binary),
+        };
+
+        Ok(DefaultBinary { bin_path, platform })
+    }
+
+    pub fn from_name(tool_name: &OsStr, session: &mut Session) -> Fallible<Option<Self>> {
+        let bin_config_file = match tool_name.to_str() {
+            Some(name) => volta_home()?.default_tool_bin_config(name),
+            None => return Ok(None),
+        };
+
+        if bin_config_file.exists() {
+            let bin_config = BinConfig::from_file(bin_config_file)?;
+            DefaultBinary::from_config(bin_config, session).map(Some)
+        } else {
+            Ok(None) // no config means the tool is not installed
+        }
+    }
+}

--- a/crates/volta-core/src/run_package_global/executor.rs
+++ b/crates/volta-core/src/run_package_global/executor.rs
@@ -1,0 +1,87 @@
+use std::ffi::OsStr;
+use std::process::{Command, ExitStatus};
+
+use crate::command::create_command;
+use crate::error::{Context, ErrorKind, Fallible};
+use crate::platform::{CliPlatform, Platform, System};
+use crate::session::Session;
+use crate::signal::pass_control_to_shim;
+
+/// Process builder for launching a Volta-managed tool
+///
+/// Tracks the Platform as well as what kind of tool is being executed, to allow individual tools
+/// to customize the behavior before execution.
+pub struct ToolCommand {
+    command: Command,
+    platform: Option<Platform>,
+    kind: ToolKind,
+}
+
+/// The kind of tool being executed, used to determine the correct execution context
+pub enum ToolKind {
+    Node,
+    Npm,
+    Npx,
+    Yarn,
+    ProjectLocalBinary(String),
+    DefaultBinary(String),
+    Bypass(String),
+}
+
+impl ToolCommand {
+    pub fn new<E, A, S>(exe: E, args: A, platform: Option<Platform>, kind: ToolKind) -> Self
+    where
+        E: AsRef<OsStr>,
+        A: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let mut command = create_command(exe);
+        command.args(args);
+
+        Self {
+            command,
+            platform,
+            kind,
+        }
+    }
+
+    /// Adds or updates environment variables that the command will use
+    pub fn envs<E, K, V>(&mut self, envs: E)
+    where
+        E: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.command.envs(envs);
+    }
+
+    /// Updates the Platform for the command to include values from the command-line
+    pub fn cli_platform(&mut self, cli: CliPlatform) {
+        self.platform = match self.platform.take() {
+            Some(base) => Some(cli.merge(base)),
+            None => cli.into(),
+        };
+    }
+
+    /// Runs the command, returning the `ExitStatus` if it successfully launches
+    pub fn execute(mut self, session: &mut Session) -> Fallible<ExitStatus> {
+        let (path, on_failure) = match self.kind {
+            ToolKind::Node => super::node::execution_context(self.platform, session)?,
+            ToolKind::Npm => super::npm::execution_context(self.platform, session)?,
+            ToolKind::Npx => super::npx::execution_context(self.platform, session)?,
+            ToolKind::Yarn => super::yarn::execution_context(self.platform, session)?,
+            ToolKind::DefaultBinary(bin) => {
+                super::binary::default_execution_context(bin, self.platform, session)?
+            }
+            ToolKind::ProjectLocalBinary(bin) => {
+                super::binary::local_execution_context(bin, self.platform, session)?
+            }
+            ToolKind::Bypass(command) => (System::path()?, ErrorKind::BypassError { command }),
+        };
+
+        self.command.env("PATH", path);
+
+        pass_control_to_shim();
+        self.command.status().with_context(|| on_failure)
+    }
+}

--- a/crates/volta-core/src/run_package_global/mod.rs
+++ b/crates/volta-core/src/run_package_global/mod.rs
@@ -1,0 +1,127 @@
+use std::env;
+use std::env::ArgsOs;
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+use std::process::ExitStatus;
+
+use crate::error::{ErrorKind, Fallible};
+use crate::platform::{CliPlatform, Image, Sourced};
+use crate::session::Session;
+use log::debug;
+use semver::Version;
+
+pub mod binary;
+mod executor;
+mod node;
+mod npm;
+mod npx;
+mod yarn;
+
+const VOLTA_BYPASS: &str = "VOLTA_BYPASS";
+
+/// Execute a shim command, based on the command-line arguments to the current process
+pub fn execute_shim(session: &mut Session) -> Fallible<ExitStatus> {
+    let mut native_args = env::args_os();
+    let exe = get_tool_name(&mut native_args)?;
+    let args: Vec<_> = native_args.collect();
+
+    get_command(&exe, &args, session)?.execute(session)
+}
+
+/// Execute a tool with the provided arguments
+pub fn execute_tool<E, K, V>(
+    exe: &OsStr,
+    args: &[OsString],
+    envs: E,
+    cli: CliPlatform,
+    session: &mut Session,
+) -> Fallible<ExitStatus>
+where
+    E: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    let mut runner = get_command(exe, args, session)?;
+    runner.cli_platform(cli);
+    runner.envs(envs);
+
+    runner.execute(session)
+}
+
+/// Get the appropriate Tool command, based on the requested executable and arguments
+fn get_command(
+    exe: &OsStr,
+    args: &[OsString],
+    session: &mut Session,
+) -> Fallible<executor::ToolCommand> {
+    if env::var_os(VOLTA_BYPASS).is_some() {
+        Ok(executor::ToolCommand::new(
+            exe,
+            args,
+            None,
+            executor::ToolKind::Bypass(exe.to_string_lossy().to_string()),
+        ))
+    } else {
+        match exe.to_str() {
+            Some("volta-shim") => Err(ErrorKind::RunShimDirectly.into()),
+            Some("node") => node::command(args, session),
+            Some("npm") => npm::command(args, session),
+            Some("npx") => npx::command(args, session),
+            Some("yarn") => yarn::command(args, session),
+            _ => binary::command(exe, args, session),
+        }
+    }
+}
+
+/// Determine the name of the command to run by inspecting the first argument to the active process
+fn get_tool_name(args: &mut ArgsOs) -> Fallible<OsString> {
+    args.next()
+        .and_then(|arg0| Path::new(&arg0).file_name().map(tool_name_from_file_name))
+        .ok_or_else(|| ErrorKind::CouldNotDetermineTool.into())
+}
+
+#[cfg(unix)]
+fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
+    file_name.to_os_string()
+}
+
+#[cfg(windows)]
+fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
+    // On Windows PowerShell, the file name includes the .exe suffix
+    // We need to remove that to get the raw tool name
+    match file_name.to_str() {
+        Some(file) => OsString::from(file.trim_end_matches(".exe")),
+        None => OsString::from(file_name),
+    }
+}
+
+#[inline]
+fn debug_no_platform() {
+    debug!("Could not find Volta-managed platform, delegating to system");
+}
+
+#[inline]
+fn debug_active_image(image: &Image) {
+    debug!(
+        "Active Image:
+    Node: {}
+    npm: {}
+    Yarn: {}",
+        format_tool_version(&image.node),
+        image
+            .resolve_npm()
+            .ok()
+            .as_ref()
+            .map(format_tool_version)
+            .unwrap_or_else(|| "Bundled with Node".into()),
+        image
+            .yarn
+            .as_ref()
+            .map(format_tool_version)
+            .unwrap_or_else(|| "None".into()),
+    )
+}
+
+fn format_tool_version(version: &Sourced<Version>) -> String {
+    format!("{} from {} configuration", version.value, version.source)
+}

--- a/crates/volta-core/src/run_package_global/node.rs
+++ b/crates/volta-core/src/run_package_global/node.rs
@@ -1,0 +1,35 @@
+use std::ffi::OsString;
+
+use super::executor::{ToolCommand, ToolKind};
+use super::{debug_active_image, debug_no_platform};
+use crate::error::{ErrorKind, Fallible};
+use crate::platform::{Platform, System};
+use crate::session::Session;
+
+/// Build a `ToolCommand` for Node
+pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<ToolCommand> {
+    let platform = Platform::current(session)?;
+
+    Ok(ToolCommand::new("node", args, platform, ToolKind::Node))
+}
+
+/// Determine the execution context (PATH and failure error message) for Node
+pub(super) fn execution_context(
+    platform: Option<Platform>,
+    session: &mut Session,
+) -> Fallible<(OsString, ErrorKind)> {
+    match platform {
+        Some(plat) => {
+            let image = plat.checkout(session)?;
+            let path = image.path()?;
+            debug_active_image(&image);
+
+            Ok((path, ErrorKind::BinaryExecError))
+        }
+        None => {
+            let path = System::path()?;
+            debug_no_platform();
+            Ok((path, ErrorKind::NoPlatform))
+        }
+    }
+}

--- a/crates/volta-core/src/run_package_global/npm.rs
+++ b/crates/volta-core/src/run_package_global/npm.rs
@@ -1,0 +1,35 @@
+use std::ffi::OsString;
+
+use super::executor::{ToolCommand, ToolKind};
+use super::{debug_active_image, debug_no_platform};
+use crate::error::{ErrorKind, Fallible};
+use crate::platform::{Platform, System};
+use crate::session::Session;
+
+/// Build a `ToolCommand` for npm
+pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<ToolCommand> {
+    let platform = Platform::current(session)?;
+
+    Ok(ToolCommand::new("npm", args, platform, ToolKind::Npm))
+}
+
+/// Determine the execution context (PATH and failure error message) for npm
+pub(super) fn execution_context(
+    platform: Option<Platform>,
+    session: &mut Session,
+) -> Fallible<(OsString, ErrorKind)> {
+    match platform {
+        Some(plat) => {
+            let image = plat.checkout(session)?;
+            let path = image.path()?;
+            debug_active_image(&image);
+
+            Ok((path, ErrorKind::BinaryExecError))
+        }
+        None => {
+            let path = System::path()?;
+            debug_no_platform();
+            Ok((path, ErrorKind::NoPlatform))
+        }
+    }
+}

--- a/crates/volta-core/src/run_package_global/npx.rs
+++ b/crates/volta-core/src/run_package_global/npx.rs
@@ -5,7 +5,13 @@ use super::{debug_active_image, debug_no_platform};
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{Platform, System};
 use crate::session::Session;
-use crate::version::parse_version;
+use lazy_static::lazy_static;
+use semver::Version;
+
+lazy_static! {
+    /// The minimum required npm version that includes npx (5.2.0)
+    static ref REQUIRED_NPM_VERSION: Version = Version::new(5, 2, 0);
+}
 
 /// Build a `ToolCommand` for npx
 pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<ToolCommand> {
@@ -23,11 +29,10 @@ pub(super) fn execution_context(
         Some(plat) => {
             let image = plat.checkout(session)?;
 
-            // npx was only included with npm 5.2.0 and higher. If the npm version is lower
-            // that that, we should include a helpful error message
-            let required_npm = parse_version("5.2.0")?;
+            // If the npm version is lower than the minimum required, we can show a helpful error
+            // message instead of a 'command not found' error.
             let active_npm = image.resolve_npm()?;
-            if active_npm.value < required_npm {
+            if active_npm.value < *REQUIRED_NPM_VERSION {
                 return Err(ErrorKind::NpxNotAvailable {
                     version: active_npm.value.to_string(),
                 }

--- a/crates/volta-core/src/run_package_global/npx.rs
+++ b/crates/volta-core/src/run_package_global/npx.rs
@@ -1,0 +1,48 @@
+use std::ffi::OsString;
+
+use super::executor::{ToolCommand, ToolKind};
+use super::{debug_active_image, debug_no_platform};
+use crate::error::{ErrorKind, Fallible};
+use crate::platform::{Platform, System};
+use crate::session::Session;
+use crate::version::parse_version;
+
+/// Build a `ToolCommand` for npx
+pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<ToolCommand> {
+    let platform = Platform::current(session)?;
+
+    Ok(ToolCommand::new("npx", args, platform, ToolKind::Npx))
+}
+
+/// Determine the execution context (PATH and failure error message) for npx
+pub(super) fn execution_context(
+    platform: Option<Platform>,
+    session: &mut Session,
+) -> Fallible<(OsString, ErrorKind)> {
+    match platform {
+        Some(plat) => {
+            let image = plat.checkout(session)?;
+
+            // npx was only included with npm 5.2.0 and higher. If the npm version is lower
+            // that that, we should include a helpful error message
+            let required_npm = parse_version("5.2.0")?;
+            let active_npm = image.resolve_npm()?;
+            if active_npm.value < required_npm {
+                return Err(ErrorKind::NpxNotAvailable {
+                    version: active_npm.value.to_string(),
+                }
+                .into());
+            }
+
+            let path = image.path()?;
+            debug_active_image(&image);
+
+            Ok((path, ErrorKind::BinaryExecError))
+        }
+        None => {
+            let path = System::path()?;
+            debug_no_platform();
+            Ok((path, ErrorKind::NoPlatform))
+        }
+    }
+}

--- a/crates/volta-core/src/run_package_global/yarn.rs
+++ b/crates/volta-core/src/run_package_global/yarn.rs
@@ -1,0 +1,48 @@
+use std::ffi::OsString;
+
+use super::executor::{ToolCommand, ToolKind};
+use super::{debug_active_image, debug_no_platform};
+use crate::error::{ErrorKind, Fallible};
+use crate::platform::{Platform, Source, System};
+use crate::session::Session;
+
+/// Build a `ToolCommand` for Yarn
+pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<ToolCommand> {
+    let platform = Platform::current(session)?;
+
+    Ok(ToolCommand::new("yarn", args, platform, ToolKind::Yarn))
+}
+
+/// Determine the execution context (PATH and failure error message) for Yarn
+pub(super) fn execution_context(
+    platform: Option<Platform>,
+    session: &mut Session,
+) -> Fallible<(OsString, ErrorKind)> {
+    match platform {
+        Some(plat) => {
+            validate_platform_yarn(&plat)?;
+
+            let image = plat.checkout(session)?;
+            let path = image.path()?;
+            debug_active_image(&image);
+
+            Ok((path, ErrorKind::BinaryExecError))
+        }
+        None => {
+            let path = System::path()?;
+            debug_no_platform();
+            Ok((path, ErrorKind::NoPlatform))
+        }
+    }
+}
+
+fn validate_platform_yarn(platform: &Platform) -> Fallible<()> {
+    match &platform.yarn {
+        Some(_) => Ok(()),
+        None => match platform.node.source {
+            Source::Project => Err(ErrorKind::NoProjectYarn.into()),
+            Source::Default | Source::Binary => Err(ErrorKind::NoDefaultYarn.into()),
+            Source::CommandLine => Err(ErrorKind::NoCommandLineYarn.into()),
+        },
+    }
+}

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -7,6 +7,7 @@ cfg_if! {
         // test files
         mod corrupted_download;
         mod hooks;
+        #[cfg(not(feature = "package-global"))]
         mod intercept_global_installs;
         mod merged_platform;
         mod migrations;

--- a/tests/acceptance/merged_platform.rs
+++ b/tests/acceptance/merged_platform.rs
@@ -1,4 +1,4 @@
-use crate::support::sandbox::sandbox;
+use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, YarnFixture};
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
@@ -8,48 +8,119 @@ use volta_core::error::ExitCode;
 const PACKAGE_JSON_WITH_YARN: &str = r#"{
     "name": "with-yarn",
     "volta": {
-        "node": "10.22.123",
-        "yarn": "4.55.633"
+        "node": "10.99.1040",
+        "yarn": "1.12.99"
     }
 }"#;
 
 const PACKAGE_JSON_NO_YARN: &str = r#"{
     "name": "without-yarn",
     "volta": {
-        "node": "10.22.123"
+        "node": "10.99.1040"
     }
 }"#;
 
 const PLATFORM_WITH_YARN: &str = r#"{
     "node":{
-        "runtime":"9.11.2",
-        "npm":"5.6.0"
+        "runtime":"9.27.6",
+        "npm":null
     },
-    "yarn": "1.22.300"
+    "yarn": "1.7.71"
 }"#;
 
 const PLATFORM_NO_YARN: &str = r#"{
     "node":{
-        "runtime":"9.11.2",
-        "npm":"5.6.0"
+        "runtime":"9.27.6",
+        "npm":null
     }
 }"#;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "macos")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 2] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "9.27.6",
+                compressed_size: 272,
+                uncompressed_size: Some(0x0028_0000),
+            },
+        ];
+    } else if #[cfg(target_os = "linux")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 2] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "9.27.6",
+                compressed_size: 272,
+                uncompressed_size: Some(0x0028_0000),
+            },
+        ];
+    } else if #[cfg(target_os = "windows")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 2] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 1096,
+                uncompressed_size: None,
+            },
+            DistroMetadata {
+                version: "9.27.6",
+                compressed_size: 1068,
+                uncompressed_size: None,
+            },
+        ];
+    } else {
+        compile_error!("Unsupported target_os for tests (expected 'macos', 'linux', or 'windows').");
+    }
+}
+
+const YARN_VERSION_FIXTURES: [DistroMetadata; 2] = [
+    DistroMetadata {
+        version: "1.12.99",
+        compressed_size: 178,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.7.71",
+        compressed_size: 176,
+        uncompressed_size: Some(0x0028_0000),
+    },
+];
 
 #[test]
 fn uses_project_yarn_if_available() {
     let s = sandbox()
         .platform(PLATFORM_WITH_YARN)
         .package_json(PACKAGE_JSON_WITH_YARN)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
         .env("VOLTA_LOGLEVEL", "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.yarn("--version"),
         execs()
-            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_status(ExitCode::Success as i32)
             .with_stderr_does_not_contain("[..]Yarn is not available.")
             .with_stderr_does_not_contain("[..]No Yarn version found in this project.")
-            .with_stderr_contains("[..]Using yarn@4.55.633 from project configuration")
+            .with_stderr_contains("[..]Using yarn@1.12.99 from project configuration")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.yarn("--version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_does_not_contain("[..]Yarn is not available.")
+            .with_stderr_does_not_contain("[..]No Yarn version found in this project.")
+            .with_stderr_contains("[..]Yarn: 1.12.99 from project configuration")
     );
 }
 
@@ -58,16 +129,29 @@ fn uses_default_yarn_in_project_without_yarn() {
     let s = sandbox()
         .platform(PLATFORM_WITH_YARN)
         .package_json(PACKAGE_JSON_NO_YARN)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
         .env("VOLTA_LOGLEVEL", "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.yarn("--version"),
         execs()
-            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_status(ExitCode::Success as i32)
             .with_stderr_does_not_contain("[..]Yarn is not available.")
             .with_stderr_does_not_contain("[..]No Yarn version found in this project.")
-            .with_stderr_contains("[..]Using yarn@1.22.300 from default configuration")
+            .with_stderr_contains("[..]Using yarn@1.7.71 from default configuration")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.yarn("--version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_does_not_contain("[..]Yarn is not available.")
+            .with_stderr_does_not_contain("[..]No Yarn version found in this project.")
+            .with_stderr_contains("[..]Yarn: 1.7.71 from default configuration")
     );
 }
 
@@ -75,16 +159,29 @@ fn uses_default_yarn_in_project_without_yarn() {
 fn uses_default_yarn_outside_project() {
     let s = sandbox()
         .platform(PLATFORM_WITH_YARN)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
         .env("VOLTA_LOGLEVEL", "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.yarn("--version"),
         execs()
-            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_status(ExitCode::Success as i32)
             .with_stderr_does_not_contain("[..]Yarn is not available.")
             .with_stderr_does_not_contain("[..]No Yarn version found in this project.")
-            .with_stderr_contains("[..]Using yarn@1.22.300 from default configuration")
+            .with_stderr_contains("[..]Using yarn@1.7.71 from default configuration")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.yarn("--version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_does_not_contain("[..]Yarn is not available.")
+            .with_stderr_does_not_contain("[..]No Yarn version found in this project.")
+            .with_stderr_contains("[..]Yarn: 1.7.71 from default configuration")
     );
 }
 

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -613,6 +613,7 @@ impl Sandbox {
     /// Arguments can be separated by spaces.
     /// Example:
     ///     assert_that(p.npm("install ember-cli"), execs());
+    #[cfg(not(feature = "package-global"))]
     pub fn npm(&self, cmd: &str) -> ProcessBuilder {
         let mut p = self.process(shim_file("npm"));
         split_and_add_args(&mut p, cmd);

--- a/tests/acceptance/volta_run.rs
+++ b/tests/acceptance/volta_run.rs
@@ -200,11 +200,20 @@ fn command_line_node() {
         .env(VOLTA_LOGLEVEL, "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.volta("run --node 10.99.1040 node --version"),
         execs()
             .with_status(ExitCode::Success as i32)
             .with_stderr_contains("[..]Using node@10.99.1040 from command-line configuration")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.volta("run --node 10.99.1040 node --version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]Node: 10.99.1040 from command-line configuration")
     );
 }
 
@@ -217,11 +226,20 @@ fn inherited_node() {
         .env(VOLTA_LOGLEVEL, "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.volta("run node --version"),
         execs()
             .with_status(ExitCode::Success as i32)
             .with_stderr_contains("[..]Using node@9.27.6 from project configuration")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.volta("run node --version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]Node: 9.27.6 from project configuration")
     );
 }
 
@@ -235,11 +253,20 @@ fn command_line_npm() {
         .env(VOLTA_LOGLEVEL, "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.volta("run --node 10.99.1040 --npm 8.1.5 npm --version"),
         execs()
             .with_status(ExitCode::Success as i32)
             .with_stderr_contains("[..]Using npm@8.1.5 from command-line configuration")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.volta("run --node 10.99.1040 --npm 8.1.5 npm --version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]npm: 8.1.5 from command-line configuration")
     );
 }
 
@@ -254,11 +281,20 @@ fn inherited_npm() {
         .env(VOLTA_LOGLEVEL, "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.volta("run --node 10.99.1040 npm --version"),
         execs()
             .with_status(ExitCode::Success as i32)
             .with_stderr_contains("[..]Using npm@4.5.6 from project configuration")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.volta("run --node 10.99.1040 npm --version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]npm: 4.5.6 from project configuration")
     );
 }
 
@@ -273,11 +309,20 @@ fn force_bundled_npm() {
         .env(VOLTA_LOGLEVEL, "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.volta("run --bundled-npm npm --version"),
         execs()
             .with_status(ExitCode::Success as i32)
-            .with_stderr_contains("[..]Using npm@5.6.17 from project configuration")
+            .with_stderr_contains("[..]Using npm@5.6.17[..]")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.volta("run --bundled-npm npm --version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]npm: 5.6.17[..]")
     );
 }
 
@@ -291,11 +336,20 @@ fn command_line_yarn() {
         .env(VOLTA_LOGLEVEL, "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.volta("run --node 10.99.1040 --yarn 1.7.71 yarn --version"),
         execs()
             .with_status(ExitCode::Success as i32)
             .with_stderr_contains("[..]Using yarn@1.7.71 from command-line configuration")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.volta("run --node 10.99.1040 --yarn 1.7.71 yarn --version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]Yarn: 1.7.71 from command-line configuration")
     );
 }
 
@@ -310,11 +364,20 @@ fn inherited_yarn() {
         .env(VOLTA_LOGLEVEL, "debug")
         .build();
 
+    #[cfg(not(feature = "package-global"))]
     assert_that!(
         s.volta("run --node 10.99.1040 yarn --version"),
         execs()
             .with_status(ExitCode::Success as i32)
             .with_stderr_contains("[..]Using yarn@1.2.42 from project configuration")
+    );
+
+    #[cfg(feature = "package-global")]
+    assert_that!(
+        s.volta("run --node 10.99.1040 yarn --version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]Yarn: 1.2.42 from project configuration")
     );
 }
 


### PR DESCRIPTION
Info
-----
* Looking forward to allowing `npm i -g <package>` to work seamlessly within Volta, we need to ensure that the `run` module can handle more extensibility.
* Since there will be more possible branches (`npm i -g` will need to include extra behavior both before and after running a command), we will want to allow a command to be built up more piecemeal than is currently supported.
* We also want to leave things in a state that they can be easily extended to new use-cases (i.e. `npm i -g yarn` should delegate to the `volta install yarn` behavior, instead of treating it like any other package).

Changes
-----
* Added new `run_package_global` directory, used as the `run` module when the feature flag is enabled.
* Removed all the feature flag attributes from `run`, as it is now only enabled when the feature flag is off.
* Split the customization logic (error messages, specific Platform modifications, project-local delegations, etc.) into 2 phases:
    * First, on creation: Each submodule of `run_package_global` provides a function to create a new `ToolCommand`, annotated with the appropriate `ToolKind` so that it knows which command is being run.
    * Second, on execution: Each submodule _also_ provides a function to get the execution context (`PATH` value and happy error message if launching the tool fails), which is called by `ToolCommand` immediately before executing the command.
* This separation allows us to handle common modifications (like adding the CLI-provided Platform from `volta run`) in between the two customizations without having to duplicate / thread those modifications through the entire creation process.
* The implementation of the two points of customization in each submodule is based entirely on the existing implementation in the `run` directory, modified to handle the two points in the process as appropriate.
* Updated the duplicated debug output of `Using <tool>@<version> from <configuration>` to instead print out the entire `Image`, including Node, npm, and Yarn versions where appropriate.

Tested
-----
* Locally confirmed that running commands works as expected.
* Updated the acceptance tests to handle the new output format for the platform.

Notes
-----
* While there is a lot of new code, the bulk of the change is in the `run_package_global/mod.rs` and `run_package_global/executor.rs`. Everything else is the re-implementation of the existing tool-specific logic.
* The plan for customizing the install command is to add an `enum` wrapper around `ToolCommand` that allows different command variants (including ones that call the `volta install node`, `volta install yarn`, etc. logic, as well as the package logic).
* Since the next step is to implement the `npm i -g` logic, the global install interception was intentionally omitted.