### PR TITLE
[Small] Correctly Parse package versions and support internal installs

### DIFF
--- a/crates/volta-core/src/run_package_global/executor.rs
+++ b/crates/volta-core/src/run_package_global/executor.rs
@@ -237,7 +237,16 @@ impl InternalInstallCommand {
 
     /// Runs the install, using Volta's internal install logic for the appropriate tool
     fn execute(self, session: &mut Session) -> Fallible<ExitStatus> {
-        info!("{} using Volta to install {}", note_prefix(), self.tool);
+        info!(
+            "{} using Volta to install {}",
+            note_prefix(),
+            match &self.tool {
+                Spec::Node(_) => "Node",
+                Spec::Npm(_) => "npm",
+                Spec::Yarn(_) => "Yarn",
+                Spec::Package(name, _) => &name,
+            }
+        );
 
         self.tool.resolve(session)?.install(session)?;
 

--- a/crates/volta-core/src/run_package_global/mod.rs
+++ b/crates/volta-core/src/run_package_global/mod.rs
@@ -7,6 +7,7 @@ use std::process::ExitStatus;
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{CliPlatform, Image, Sourced};
 use crate::session::Session;
+use crate::tool;
 use log::debug;
 use semver::Version;
 
@@ -128,9 +129,9 @@ fn format_tool_version(version: &Sourced<Version>) -> String {
 }
 
 /// Distinguish global `add` commands in npm or yarn from all others
-enum CommandArg<'a> {
+enum CommandArg {
     /// The command is a *global* add command.
-    GlobalAdd(&'a OsStr),
+    GlobalAdd(tool::Spec),
     /// The command is *not* a global add
     NotGlobalAdd,
 }


### PR DESCRIPTION
Info
-----
* Improves on the Naive package installation implementation in #829 to:
    * Correctly parse and install versioned packages (e.g. `npm i -g typescript@3`)
    * Special-case handling of internal installs—installs for packages that Volta handles internally separate from the package manager behavior (like Node, Yarn, etc.).

Changes
-----
* Added `InternalInstallCommand` executor that delegates to Volta's existing install behavior (and writes a note to the user that we are changing how the command is handled).
* Used the existing parsing of `tool::Spec` to handle parsing the package to install correctly.

Tested
-----
* Local testing to confirm that installs work with and without versions, and that the appropriate packages are intercepted by Volta's logic.

Notes
-----
* There aren't any new tests yet, as there are still a few outstanding edge cases to resolve.
* This PR builds on #829 and so will remain a draft until that is merged. To see only the changes from this PR, use [this link](https://github.com/volta-cli/volta/pull/831/files/73eeca2c197db4820d8399ad34b7eb9dd9ba2305..5c8402e6889841d37fa3d466653882de155f2f06)