### PR TITLE
[Small] Add tests for new direct package install flows

### DIFF
--- a/crates/volta-core/src/run_package_global/yarn.rs
+++ b/crates/volta-core/src/run_package_global/yarn.rs
@@ -94,3 +94,55 @@ fn check_yarn_add(args: &[OsString]) -> CommandArg {
         _ => CommandArg::NotGlobalAdd,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::CommandArg;
+    use super::check_yarn_add;
+    use crate::tool::Spec;
+    use std::ffi::{OsStr, OsString};
+
+    fn arg_list<A, S>(args: A) -> Vec<OsString>
+    where
+        A: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        args.into_iter().map(|a| a.as_ref().to_owned()).collect()
+    }
+
+    #[test]
+    fn handles_global_adds() {
+        match check_yarn_add(&arg_list(&["global", "add", "typescript"])) {
+            CommandArg::GlobalAdd(_) => (),
+            _ => panic!("Doesn't handle global add"),
+        };
+
+        match check_yarn_add(&arg_list(&["add", "global", "typescript"])) {
+            CommandArg::NotGlobalAdd => (),
+            _ => panic!("Doesn't handle wrong order"),
+        };
+    }
+
+    #[test]
+    fn ignores_interspersed_flags() {
+        match check_yarn_add(&arg_list(&[
+            "--no-update-notifier",
+            "global",
+            "--no-audit",
+            "add",
+            "--fake-flag",
+            "cowsay",
+        ])) {
+            CommandArg::GlobalAdd(Spec::Package(name, _)) if name == "cowsay" => (),
+            _ => panic!("Doesn't handle flags correctly"),
+        };
+    }
+
+    #[test]
+    fn treats_invalid_package_as_not_global() {
+        match check_yarn_add(&arg_list(&["global", "add", "//invalid//"])) {
+            CommandArg::NotGlobalAdd => (),
+            _ => panic!("Doesn't handle invalid packages"),
+        };
+    }
+}

--- a/tests/acceptance/direct_install.rs
+++ b/tests/acceptance/direct_install.rs
@@ -1,0 +1,277 @@
+use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, NpmFixture, YarnFixture};
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+use volta_core::error::ExitCode;
+
+fn platform_with_node(node: &str) -> String {
+    format!(
+        r#"{{
+  "node": {{
+    "runtime": "{}",
+    "npm": null
+  }},
+  "yarn": null
+}}"#,
+        node
+    )
+}
+
+const NODE_VERSION_INFO: &str = r#"[
+{"version":"v10.99.1040","npm":"6.2.26","lts": "Dubnium","files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip", "linux-arm64"]},
+{"version":"v9.27.6","npm":"5.6.17","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip", "linux-arm64"]},
+{"version":"v8.9.10","npm":"5.6.7","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip", "linux-arm64"]},
+{"version":"v6.19.62","npm":"3.10.1066","lts": false,"files":["linux-x64","osx-x64-tar","win-x64-zip","win-x86-zip", "linux-arm64"]}
+]
+"#;
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "macos")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 4] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "9.27.6",
+                compressed_size: 272,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "8.9.10",
+                compressed_size: 272,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "6.19.62",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+        ];
+    } else if #[cfg(target_os = "linux")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 4] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "9.27.6",
+                compressed_size: 272,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "8.9.10",
+                compressed_size: 270,
+                uncompressed_size: Some(0x0028_0000),
+            },
+            DistroMetadata {
+                version: "6.19.62",
+                compressed_size: 273,
+                uncompressed_size: Some(0x0028_0000),
+            },
+        ];
+    } else if #[cfg(target_os = "windows")] {
+        const NODE_VERSION_FIXTURES: [DistroMetadata; 4] = [
+            DistroMetadata {
+                version: "10.99.1040",
+                compressed_size: 1096,
+                uncompressed_size: None,
+            },
+            DistroMetadata {
+                version: "9.27.6",
+                compressed_size: 1068,
+                uncompressed_size: None,
+            },
+            DistroMetadata {
+                version: "8.9.10",
+                compressed_size: 1055,
+                uncompressed_size: None,
+            },
+            DistroMetadata {
+                version: "6.19.62",
+                compressed_size: 1056,
+                uncompressed_size: None,
+            },
+        ];
+    } else {
+        compile_error!("Unsupported target_os for tests (expected 'macos', 'linux', or 'windows').");
+    }
+}
+
+const YARN_VERSION_INFO: &str = r#"[
+{"tag_name":"v1.2.42","assets":[{"name":"yarn-v1.2.42.tar.gz"}]},
+{"tag_name":"v1.3.1","assets":[{"name":"yarn-v1.3.1.msi"}]},
+{"tag_name":"v1.4.159","assets":[{"name":"yarn-v1.4.159.tar.gz"}]},
+{"tag_name":"v1.7.71","assets":[{"name":"yarn-v1.7.71.tar.gz"}]},
+{"tag_name":"v1.12.99","assets":[{"name":"yarn-v1.12.99.tar.gz"}]}
+]"#;
+
+const YARN_VERSION_FIXTURES: [DistroMetadata; 4] = [
+    DistroMetadata {
+        version: "1.12.99",
+        compressed_size: 178,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.7.71",
+        compressed_size: 176,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.4.159",
+        compressed_size: 177,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "1.2.42",
+        compressed_size: 174,
+        uncompressed_size: Some(0x0028_0000),
+    },
+];
+
+const NPM_VERSION_INFO: &str = r#"
+{
+    "name":"npm",
+    "dist-tags": { "latest":"8.1.5" },
+    "versions": {
+        "1.2.3": { "version":"1.2.3", "dist": { "shasum":"", "tarball":"" }},
+        "4.5.6": { "version":"4.5.6", "dist": { "shasum":"", "tarball":"" }},
+        "8.1.5": { "version":"8.1.5", "dist": { "shasum":"", "tarball":"" }}
+    }
+}
+"#;
+
+const NPM_VERSION_FIXTURES: [DistroMetadata; 3] = [
+    DistroMetadata {
+        version: "1.2.3",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "4.5.6",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "8.1.5",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+];
+
+#[test]
+fn npm_global_install_node_intercepts() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.npm("i -g node@10.99.1040"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_contains("[..]using Volta to install Node")
+            .with_stdout_contains("[..]installed and set node@10.99.1040[..]")
+    );
+}
+
+#[test]
+fn yarn_global_add_node_intercepts() {
+    let s = sandbox()
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.yarn("global add node@9.27.6"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_contains("[..]using Volta to install Node")
+            .with_stdout_contains("[..]installed and set node@9.27.6[..]")
+    );
+}
+
+#[test]
+fn npm_global_install_npm_intercepts() {
+    let s = sandbox()
+        .platform(&platform_with_node("10.99.1040"))
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .npm_available_versions(NPM_VERSION_INFO)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.npm("i -g npm@8.1.5"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_contains("[..]using Volta to install npm")
+            .with_stdout_contains("[..]installed and set npm@8.1.5 as default")
+    );
+}
+
+#[test]
+fn yarn_global_add_npm_intercepts() {
+    let s = sandbox()
+        .platform(&platform_with_node("10.99.1040"))
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .npm_available_versions(NPM_VERSION_INFO)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.yarn("global add npm@4.5.6"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_contains("[..]using Volta to install npm")
+            .with_stdout_contains("[..]installed and set npm@4.5.6 as default")
+    );
+}
+
+#[test]
+fn npm_global_install_yarn_intercepts() {
+    let s = sandbox()
+        .platform(&platform_with_node("10.99.1040"))
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.npm("i -g yarn@1.12.99"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_contains("[..]using Volta to install Yarn")
+            .with_stdout_contains("[..]installed and set yarn@1.12.99 as default")
+    );
+}
+
+#[test]
+fn yarn_global_add_yarn_intercepts() {
+    let s = sandbox()
+        .platform(&platform_with_node("10.99.1040"))
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.yarn("global add yarn@1.7.71"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_contains("[..]using Volta to install Yarn")
+            .with_stdout_contains("[..]installed and set yarn@1.7.71 as default")
+    );
+}

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -6,6 +6,8 @@ cfg_if! {
 
         // test files
         mod corrupted_download;
+        #[cfg(feature = "package-global")]
+        mod direct_install;
         mod hooks;
         #[cfg(not(feature = "package-global"))]
         mod intercept_global_installs;

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -613,7 +613,6 @@ impl Sandbox {
     /// Arguments can be separated by spaces.
     /// Example:
     ///     assert_that(p.npm("install ember-cli"), execs());
-    #[cfg(not(feature = "package-global"))]
     pub fn npm(&self, cmd: &str) -> ProcessBuilder {
         let mut p = self.process(shim_file("npm"));
         split_and_add_args(&mut p, cmd);

--- a/tests/smoke/direct_install.rs
+++ b/tests/smoke/direct_install.rs
@@ -1,0 +1,49 @@
+use crate::support::temp_project::temp_project;
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+#[test]
+fn npm_global_install() {
+    let p = temp_project().build();
+
+    // Have to install node to ensure npm is available
+    assert_that!(p.volta("install node@14.1.0"), execs().with_status(0));
+
+    assert_that!(
+        p.npm("install --global typescript@3.9.4"),
+        execs().with_status(0)
+    );
+    assert!(p.shim_exists("tsc"));
+
+    assert!(p.package_is_installed("typescript"));
+
+    assert_that!(
+        p.exec_shim("tsc", "--version"),
+        execs().with_status(0).with_stdout_contains("Version 3.9.4")
+    );
+}
+
+#[test]
+fn yarn_global_add() {
+    let p = temp_project().build();
+
+    // Have to install node and yarn first
+    assert_that!(
+        p.volta("install node@14.2.0 yarn@1.22.5"),
+        execs().with_status(0)
+    );
+
+    assert_that!(
+        p.yarn("global add typescript@4.0.2"),
+        execs().with_status(0)
+    );
+    assert!(p.shim_exists("tsc"));
+
+    assert!(p.package_is_installed("typescript"));
+
+    assert_that!(
+        p.exec_shim("tsc", "--version"),
+        execs().with_status(0).with_stdout_contains("Version 4.0.2")
+    );
+}

--- a/tests/smoke/main.rs
+++ b/tests/smoke/main.rs
@@ -13,12 +13,14 @@
 
 cfg_if::cfg_if! {
     if #[cfg(all(unix, feature = "smoke-tests"))] {
+        mod autodownload;
+        #[cfg(feature = "package-global")]
+        mod direct_install;
+        #[cfg(feature = "package-global")]
+        mod package_migration;
         mod support;
         mod volta_fetch;
         mod volta_install;
         mod volta_run;
-        mod autodownload;
-        #[cfg(feature = "package-global")]
-        mod package_migration;
     }
 }


### PR DESCRIPTION
Info
-----
* Now that the new flows work end-to-end in specific cases, we should have tests that verify the functionality.

Changes
-----
* Added smoke tests to confirm that installing packages directly with `npm i -g` and `yarn global add` works as expected.
* Added acceptance tests to confirm the correct interception of internal tool installs.
* Added unit tests to cover the argument parsing logic.

Notes
-----
* This PR builds on #831 so it will remain a draft until that is merged. To view only the changes from this PR, use [this link](https://github.com/volta-cli/volta/pull/832/files/5c8402e6889841d37fa3d466653882de155f2f06..12007c4477725102100d592f9ce0fc88cbf5df59)