### PR TITLE
[Small] Implement direct global uninstalls

### DIFF
--- a/crates/volta-core/src/run_package_global/executor.rs
+++ b/crates/volta-core/src/run_package_global/executor.rs
@@ -246,7 +246,7 @@ impl InternalInstallCommand {
         info!(
             "{} using Volta to install {}",
             note_prefix(),
-            tool_name(&self.tool)
+            self.tool.name()
         );
 
         self.tool.resolve(session)?.install(session)?;
@@ -279,7 +279,7 @@ impl UninstallCommand {
         info!(
             "{} using Volta to uninstall {}",
             note_prefix(),
-            tool_name(&self.tool)
+            self.tool.name()
         );
 
         self.tool.uninstall()?;
@@ -291,14 +291,5 @@ impl UninstallCommand {
 impl From<UninstallCommand> for Executor {
     fn from(cmd: UninstallCommand) -> Self {
         Executor::Uninstall(Box::new(cmd))
-    }
-}
-
-fn tool_name(tool: &Spec) -> &str {
-    match tool {
-        Spec::Node(_) => "Node",
-        Spec::Npm(_) => "npm",
-        Spec::Yarn(_) => "Yarn",
-        Spec::Package(name, _) => &name,
     }
 }

--- a/crates/volta-core/src/run_package_global/executor.rs
+++ b/crates/volta-core/src/run_package_global/executor.rs
@@ -19,6 +19,7 @@ pub enum Executor {
     Tool(Box<ToolCommand>),
     PackageInstall(Box<PackageInstallCommand>),
     InternalInstall(Box<InternalInstallCommand>),
+    Uninstall(Box<UninstallCommand>),
 }
 
 impl Executor {
@@ -33,6 +34,8 @@ impl Executor {
             Executor::PackageInstall(cmd) => cmd.envs(envs),
             // Internal installs use Volta's logic and don't rely on the environment variables
             Executor::InternalInstall(_) => {}
+            // Uninstalls use Volta's logic and don't rely on environment variables
+            Executor::Uninstall(_) => {}
         }
     }
 
@@ -42,6 +45,8 @@ impl Executor {
             Executor::PackageInstall(cmd) => cmd.cli_platform(cli),
             // Internal installs use Volta's logic and don't rely on the Node platform
             Executor::InternalInstall(_) => {}
+            // Uninstall use Volta's logic and don't rely on the Node platform
+            Executor::Uninstall(_) => {}
         }
     }
 
@@ -50,6 +55,7 @@ impl Executor {
             Executor::Tool(cmd) => cmd.execute(session),
             Executor::PackageInstall(cmd) => cmd.execute(session),
             Executor::InternalInstall(cmd) => cmd.execute(session),
+            Executor::Uninstall(cmd) => cmd.execute(),
         }
     }
 }
@@ -240,12 +246,7 @@ impl InternalInstallCommand {
         info!(
             "{} using Volta to install {}",
             note_prefix(),
-            match &self.tool {
-                Spec::Node(_) => "Node",
-                Spec::Npm(_) => "npm",
-                Spec::Yarn(_) => "Yarn",
-                Spec::Package(name, _) => &name,
-            }
+            tool_name(&self.tool)
         );
 
         self.tool.resolve(session)?.install(session)?;
@@ -257,5 +258,47 @@ impl InternalInstallCommand {
 impl From<InternalInstallCommand> for Executor {
     fn from(cmd: InternalInstallCommand) -> Self {
         Executor::InternalInstall(Box::new(cmd))
+    }
+}
+
+/// Executor for running a tool uninstall command.
+///
+/// This will use the `volta uninstall` logic to correctly ensure that the package is fully
+/// uninstalled
+pub struct UninstallCommand {
+    tool: Spec,
+}
+
+impl UninstallCommand {
+    pub fn new(tool: Spec) -> Self {
+        UninstallCommand { tool }
+    }
+
+    /// Runs the uninstall with Volta's internal uninstall logic
+    fn execute(self) -> Fallible<ExitStatus> {
+        info!(
+            "{} using Volta to uninstall {}",
+            note_prefix(),
+            tool_name(&self.tool)
+        );
+
+        self.tool.uninstall()?;
+
+        Ok(ExitStatus::from_raw(0))
+    }
+}
+
+impl From<UninstallCommand> for Executor {
+    fn from(cmd: UninstallCommand) -> Self {
+        Executor::Uninstall(Box::new(cmd))
+    }
+}
+
+fn tool_name(tool: &Spec) -> &str {
+    match tool {
+        Spec::Node(_) => "Node",
+        Spec::Npm(_) => "npm",
+        Spec::Yarn(_) => "Yarn",
+        Spec::Package(name, _) => &name,
     }
 }

--- a/crates/volta-core/src/run_package_global/mod.rs
+++ b/crates/volta-core/src/run_package_global/mod.rs
@@ -130,8 +130,10 @@ fn format_tool_version(version: &Sourced<Version>) -> String {
 
 /// Distinguish global `add` commands in npm or yarn from all others
 enum CommandArg {
-    /// The command is a *global* add command.
+    /// The command is a global add command
     GlobalAdd(tool::Spec),
-    /// The command is *not* a global add
-    NotGlobalAdd,
+    /// The command is a global remove command
+    GlobalRemove(tool::Spec),
+    /// The command is *not* a global command
+    NotGlobal,
 }

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -129,6 +129,17 @@ impl Spec {
             Spec::Package(name, _) => package::uninstall(&name),
         }
     }
+
+    /// The name of the tool, without the version, used for messaging
+    #[cfg(feature = "package-global")]
+    pub fn name(&self) -> &str {
+        match self {
+            Spec::Node(_) => "Node",
+            Spec::Npm(_) => "npm",
+            Spec::Yarn(_) => "Yarn",
+            Spec::Package(name, _) => &name,
+        }
+    }
 }
 
 impl Display for Spec {

--- a/tests/acceptance/direct_uninstall.rs
+++ b/tests/acceptance/direct_uninstall.rs
@@ -1,0 +1,98 @@
+use crate::support::sandbox::{sandbox, Sandbox};
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+const PKG_CONFIG_BASIC: &str = r#"{
+    "name": "cowsay",
+    "version": "1.4.0",
+    "platform": {
+      "node": "11.10.1",
+      "npm": "6.7.0",
+      "yarn": null
+    },
+    "bins": [
+      "cowsay",
+      "cowthink"
+    ],
+    "manager": "Npm"
+  }"#;
+
+fn bin_config(name: &str) -> String {
+    format!(
+        r#"{{
+  "name": "{}",
+  "package": "cowsay",
+  "version": "1.4.0",
+  "platform": {{
+    "node": "11.10.1",
+    "npm": "6.7.0",
+    "yarn": null
+  }},
+  "manager": "Npm"
+}}"#,
+        name
+    )
+}
+
+#[test]
+fn npm_uninstall_uses_volta_logic() {
+    let s = sandbox()
+        .package_config("cowsay", PKG_CONFIG_BASIC)
+        .binary_config("cowsay", &bin_config("cowsay"))
+        .binary_config("cowthink", &bin_config("cowthink"))
+        .shim("cowsay")
+        .shim("cowthink")
+        .package_image("cowsay", "1.4.0")
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.npm("uninstall --global cowsay"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("[..]using Volta to uninstall cowsay")
+            .with_stdout_contains("Removed executable 'cowsay' installed by 'cowsay'")
+            .with_stdout_contains("Removed executable 'cowthink' installed by 'cowsay'")
+            .with_stdout_contains("[..]package 'cowsay' uninstalled")
+    );
+
+    // check that everything is deleted
+    assert!(!Sandbox::package_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowthink"));
+    assert!(!Sandbox::shim_exists("cowsay"));
+    assert!(!Sandbox::shim_exists("cowthink"));
+    assert!(!Sandbox::package_image_exists("cowsay", "1.4.0"));
+}
+
+#[test]
+fn yarn_remove_uses_volta_logic() {
+    let s = sandbox()
+        .package_config("cowsay", PKG_CONFIG_BASIC)
+        .binary_config("cowsay", &bin_config("cowsay"))
+        .binary_config("cowthink", &bin_config("cowthink"))
+        .shim("cowsay")
+        .shim("cowthink")
+        .package_image("cowsay", "1.4.0")
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.yarn("global remove cowsay"),
+        execs()
+            .with_status(0)
+            .with_stdout_contains("[..]using Volta to uninstall cowsay")
+            .with_stdout_contains("Removed executable 'cowsay' installed by 'cowsay'")
+            .with_stdout_contains("Removed executable 'cowthink' installed by 'cowsay'")
+            .with_stdout_contains("[..]package 'cowsay' uninstalled")
+    );
+
+    // check that everything is deleted
+    assert!(!Sandbox::package_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowsay"));
+    assert!(!Sandbox::bin_config_exists("cowthink"));
+    assert!(!Sandbox::shim_exists("cowsay"));
+    assert!(!Sandbox::shim_exists("cowthink"));
+    assert!(!Sandbox::package_image_exists("cowsay", "1.4.0"));
+}

--- a/tests/acceptance/main.rs
+++ b/tests/acceptance/main.rs
@@ -8,6 +8,8 @@ cfg_if! {
         mod corrupted_download;
         #[cfg(feature = "package-global")]
         mod direct_install;
+        #[cfg(feature = "package-global")]
+        mod direct_uninstall;
         mod hooks;
         #[cfg(not(feature = "package-global"))]
         mod intercept_global_installs;


### PR DESCRIPTION
Info
-----
* Since we now support installing globals directly with `npm i -g <package>`, we should also support removing them with `npm uninstall -g <package>`
* This should always delegate to the internal Volta logic, so we can be sure that the shims and config files are correctly cleaned up.

Changes
-----
* Added a new `Executor` for uninstall commands, which calls out to the `tool::Spec::uninstall` method.
* Updated the parsing of npm and Yarn commands to check for global uninstalls and use the new Executor.

Tested
-----
* Added new tests to the parsing logic to confirm `uninstall` / `remove` are handled correctly.
* Added new acceptance tests to confirm that running `npm uninstall -g` or `yarn global remove` correctly uninstall all of the Volta extras.

Notes
-----
* As with the global installs, this currently doesn't support uninstalling multiple packages at once, only the first is read. That functionality will be added in a future PR.