### PR TITLE
[Small] Add VOLTA_UNSAFE_GLOBAL env variable to new package install

### DIFF
--- a/crates/volta-core/src/run_package_global/mod.rs
+++ b/crates/volta-core/src/run_package_global/mod.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
-use std::env;
-use std::env::ArgsOs;
+use std::env::{self, ArgsOs};
 use std::ffi::{OsStr, OsString};
 use std::path::Path;
 use std::process::ExitStatus;
@@ -97,11 +96,13 @@ fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
     }
 }
 
+/// Write a debug message that there is no platform available
 #[inline]
 fn debug_no_platform() {
     debug!("Could not find Volta-managed platform, delegating to system");
 }
 
+/// Write a debug message with the full image that will be used to execute a command
 #[inline]
 fn debug_active_image(image: &Image) {
     debug!(

--- a/crates/volta-core/src/run_package_global/parser.rs
+++ b/crates/volta-core/src/run_package_global/parser.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::ffi::OsStr;
 use std::iter::once;
 
@@ -6,6 +7,8 @@ use crate::error::Fallible;
 use crate::platform::PlatformSpec;
 use crate::tool::package::PackageManager;
 use crate::tool::Spec;
+
+const UNSAFE_GLOBAL: &str = "VOLTA_UNSAFE_GLOBAL";
 
 pub enum CommandArg<'a> {
     Global(GlobalCommand<'a>),
@@ -18,6 +21,11 @@ impl<'a> CommandArg<'a> {
     where
         S: AsRef<OsStr>,
     {
+        // If VOLTA_UNSAFE_GLOBAL is set, then we always skip any global parsing
+        if env::var_os(UNSAFE_GLOBAL).is_some() {
+            return CommandArg::NotGlobal;
+        }
+
         // npm global installs will always have `-g` or `--global` somewhere in the argument list
         if !args
             .iter()
@@ -67,6 +75,11 @@ impl<'a> CommandArg<'a> {
     where
         S: AsRef<OsStr>,
     {
+        // If VOLTA_UNSAFE_GLOBAL is set, then we always skip any global parsing
+        if env::var_os(UNSAFE_GLOBAL).is_some() {
+            return CommandArg::NotGlobal;
+        }
+
         let mut positionals = args.iter().filter(is_positional).map(AsRef::as_ref);
 
         // Yarn globals must always start with `global <command>`


### PR DESCRIPTION
Info
-----
* Previously, we used the (undocumented) environment variable `VOLTA_UNSAFE_GLOBAL` to disable the global install interception.
* While our new logic allows global installs, it still makes modifications to the process, so we should keep the escape valve to run the bare command.

Changes
-----
* Updated the `CommandArg::for_npm` and `CommandArg::for_yarn` to short-circuit to `NotGlobal` (No interception) if the `VOLTA_UNSAFE_GLOBAL` environment variable is set.

Tested
-----
* Added acceptance tests to confirm that global installs are not modified when the environment variable is set.