### PR TITLE
[Tiny] Ensure a VoltaLock is acquired when installing packages directly

### DIFF
--- a/crates/volta-core/src/run_package_global/executor.rs
+++ b/crates/volta-core/src/run_package_global/executor.rs
@@ -12,6 +12,7 @@ use crate::platform::{CliPlatform, Platform, System};
 use crate::session::Session;
 use crate::signal::pass_control_to_shim;
 use crate::style::note_prefix;
+use crate::sync::VoltaLock;
 use crate::tool::package::{DirectInstall, PackageManager};
 use crate::tool::Spec;
 use log::info;
@@ -239,6 +240,7 @@ impl PackageInstallCommand {
     /// Runs the install command, applying the necessary modifications to install into the Volta
     /// data directory
     pub fn execute(mut self, session: &mut Session) -> Fallible<ExitStatus> {
+        let _lock = VoltaLock::acquire();
         let image = self.platform.checkout(session)?;
         let path = image.path()?;
 

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -71,7 +71,7 @@ impl Tool for Package {
     }
 
     fn install(self: Box<Self>, session: &mut Session) -> Fallible<()> {
-        let _lock = VoltaLock::acquire()?;
+        let _lock = VoltaLock::acquire();
 
         let default_image = session
             .default_platform()?


### PR DESCRIPTION
Info
-----
* When installing a package with `npm i -g` or `yarn global add`, we are still modifying the Volta directory, so we still should have a lock on the process.

Changes
-----
* Added a call to `VoltaLock::acquire()` in the `execute` method of the `PackageInstallCommand` executor.
* Removed an erroneous `?` on the call to `VoltaLock::acquire()` in the `Package` implementation of `Tool`