### PR TITLE
[Medium] Allow global binaries to access global libraries

### DIFF
--- a/crates/volta-core/src/error/kind.rs
+++ b/crates/volta-core/src/error/kind.rs
@@ -76,6 +76,12 @@ pub enum ErrorKind {
         file: PathBuf,
     },
 
+    /// Thrown when unable to create a link to the shared global library directory
+    #[cfg(feature = "package-global")]
+    CreateSharedLinkError {
+        name: String,
+    },
+
     /// Thrown when creating a temporary directory fails
     CreateTempDirError {
         in_dir: PathBuf,
@@ -661,6 +667,14 @@ Please ensure that you have the correct permissions.",
 
 {}",
                 file.display(), PERMISSIONS_CTA
+            ),
+            #[cfg(feature = "package-global")]
+            ErrorKind::CreateSharedLinkError { name } => write!(
+                f,
+                "Could not create shared environment for package '{}'
+
+{}",
+                name, PERMISSIONS_CTA
             ),
             ErrorKind::CreateTempDirError { in_dir } => write!(
                 f,
@@ -1525,6 +1539,8 @@ impl ErrorKind {
             ErrorKind::CouldNotStartMigration => ExitCode::EnvironmentError,
             ErrorKind::CreateDirError { .. } => ExitCode::FileSystemError,
             ErrorKind::CreateLayoutFileError { .. } => ExitCode::FileSystemError,
+            #[cfg(feature = "package-global")]
+            ErrorKind::CreateSharedLinkError { .. } => ExitCode::FileSystemError,
             ErrorKind::CreateTempDirError { .. } => ExitCode::FileSystemError,
             ErrorKind::CreateTempFileError { .. } => ExitCode::FileSystemError,
             ErrorKind::CurrentDirError => ExitCode::EnvironmentError,

--- a/crates/volta-core/src/fs.rs
+++ b/crates/volta-core/src/fs.rs
@@ -118,7 +118,7 @@ pub fn create_staging_dir() -> Fallible<TempDir> {
     })
 }
 
-/// Create a symlink. The `dst` path will be a symbolic link pointing to the `src` path.
+/// Create a file symlink. The `dst` path will be a symbolic link pointing to the `src` path.
 pub fn symlink_file<S, D>(src: S, dest: D) -> io::Result<()>
 where
     S: AsRef<Path>,
@@ -126,6 +126,19 @@ where
 {
     #[cfg(windows)]
     return std::os::windows::fs::symlink_file(src, dest);
+
+    #[cfg(unix)]
+    return std::os::unix::fs::symlink(src, dest);
+}
+
+/// Create a directory symlink. The `dst` path will be a symbolic link pointing to the `src` path
+pub fn symlink_dir<S, D>(src: S, dest: D) -> io::Result<()>
+where
+    S: AsRef<Path>,
+    D: AsRef<Path>,
+{
+    #[cfg(windows)]
+    return std::os::windows::fs::symlink_dir(src, dest);
 
     #[cfg(unix)]
     return std::os::unix::fs::symlink(src, dest);

--- a/crates/volta-core/src/run_package_global/executor.rs
+++ b/crates/volta-core/src/run_package_global/executor.rs
@@ -146,6 +146,15 @@ impl ToolCommand {
         self.command.envs(envs);
     }
 
+    /// Adds or updates a single environment variable that the command will use
+    pub fn env<K, V>(&mut self, key: K, value: V)
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.command.env(key, value);
+    }
+
     /// Updates the Platform for the command to include values from the command-line
     pub fn cli_platform(&mut self, cli: CliPlatform) {
         self.platform = match self.platform.take() {

--- a/crates/volta-core/src/tool/package_global/mod.rs
+++ b/crates/volta-core/src/tool/package_global/mod.rs
@@ -165,7 +165,7 @@ where
     rename(staging_dir, &package_dir).with_context(|| ErrorKind::SetupToolImageError {
         tool: package_name.into(),
         version: package_version.to_string(),
-        dir: package_dir.clone(),
+        dir: package_dir,
     })?;
 
     Ok(())

--- a/crates/volta-layout/src/v3.rs
+++ b/crates/volta-layout/src/v3.rs
@@ -27,6 +27,7 @@ layout! {
                 "yarn": yarn_image_root_dir {}
                 "packages": package_image_root_dir {}
             }
+            "shared": shared_lib_root {}
             "user": default_toolchain_dir {
                 "bins": default_bin_dir {}
                 "packages": default_package_dir {}
@@ -84,6 +85,10 @@ impl VoltaHome {
 
     pub fn shim_file(&self, toolname: &str) -> PathBuf {
         path_buf!(self.shim_dir.clone(), executable(toolname))
+    }
+
+    pub fn shared_lib_dir(&self, library: &str) -> PathBuf {
+        path_buf!(self.shared_lib_root.clone(), library)
     }
 }
 


### PR DESCRIPTION
Info
-----
* As described in [the RFC](https://github.com/volta-cli/rfcs/pull/45), we want to provide a way for global packages to "see" other global packages when running a `require` statement, to match up with the standard global install behavior.
* To do this, we create a shared directory with symlinks to each of the global packages and add it to the `NODE_PATH` environment variable when executing a global binary.

Changes
-----
* Added the `shared_lib_root` and `shared_lib_dir` to the V3 layout (no change to the migration is necessary as the directory is already created by the `create()` method).
* Updated the global install process (for both `volta install` and `npm i -g`) to create a symlink from the package directory into the `shared_lib_root`
* Updated the global uninstall process to clean up the symlink.
* Modified the execution of a global package to append the `shared_lib_root` (which will have sub-directory symlinks for each globally installed package) to the `NODE_PATH` environment variable, making sure that the global packages can be found by the Node module resolution algorithm.

Tested
-----
* Tested locally that `ts-node` works and can find a globally-installed peer dependency on `typescript`.
* Tested locally and confirmed that `yo` can find Yeoman generators installed globally as well.