### PR TITLE
[Small] Leave shim directory on PATH to allow bins to call other bins

### DIFF
--- a/crates/volta-core/src/platform/image.rs
+++ b/crates/volta-core/src/platform/image.rs
@@ -3,7 +3,9 @@ use std::path::PathBuf;
 
 use super::{build_path_error, Sourced};
 use crate::error::{Context, Fallible};
-use crate::layout::{env_paths, volta_home};
+#[cfg(not(feature = "package-global"))]
+use crate::layout::env_paths;
+use crate::layout::volta_home;
 use crate::tool::load_default_npm_version;
 use semver::Version;
 
@@ -43,16 +45,29 @@ impl Image {
     /// for the given versions instead of in the Volta shim directory.
     pub fn path(&self) -> Fallible<OsString> {
         let old_path = envoy::path().unwrap_or_else(|| envoy::Var::from(""));
-        let mut new_path = old_path.split();
 
-        for remove_path in env_paths()? {
-            new_path = new_path.remove(remove_path);
+        #[cfg(not(feature = "package-global"))]
+        {
+            let mut new_path = old_path.split();
+
+            for remove_path in env_paths()? {
+                new_path = new_path.remove(remove_path);
+            }
+
+            new_path
+                .prefix(self.bins()?)
+                .join()
+                .with_context(build_path_error)
         }
 
-        new_path
-            .prefix(self.bins()?)
-            .join()
-            .with_context(build_path_error)
+        #[cfg(feature = "package-global")]
+        {
+            old_path
+                .split()
+                .prefix(self.bins()?)
+                .join()
+                .with_context(build_path_error)
+        }
     }
 
     /// Determines the sourced version of npm that will be available, resolving the version bundled with Node, if needed

--- a/crates/volta-core/src/platform/tests.rs
+++ b/crates/volta-core/src/platform/tests.rs
@@ -16,13 +16,11 @@ fn test_paths() {
 
 #[cfg(unix)]
 fn test_image_path() {
-    std::env::set_var(
-        "PATH",
-        format!(
-            "/usr/bin:/blah:{}:/doesnt/matter/bin",
-            volta_home().unwrap().shim_dir().to_string_lossy()
-        ),
+    let starting_path = format!(
+        "/usr/bin:/blah:{}:/doesnt/matter/bin",
+        volta_home().unwrap().shim_dir().to_string_lossy()
     );
+    std::env::set_var("PATH", &starting_path);
 
     let node_bin = volta_home().unwrap().node_image_bin_dir("1.2.3");
     let expected_node_bin = node_bin.to_str().unwrap();
@@ -43,9 +41,15 @@ fn test_image_path() {
         yarn: None,
     };
 
+    #[cfg(not(feature = "package-global"))]
     assert_eq!(
         only_node.path().unwrap().into_string().unwrap(),
         format!("{}:/usr/bin:/blah:/doesnt/matter/bin", expected_node_bin),
+    );
+    #[cfg(feature = "package-global")]
+    assert_eq!(
+        only_node.path().unwrap().into_string().unwrap(),
+        format!("{}:{}", expected_node_bin, starting_path)
     );
 
     let node_npm = Image {
@@ -54,12 +58,21 @@ fn test_image_path() {
         yarn: None,
     };
 
+    #[cfg(not(feature = "package-global"))]
     assert_eq!(
         node_npm.path().unwrap().into_string().unwrap(),
         format!(
             "{}:{}:/usr/bin:/blah:/doesnt/matter/bin",
             expected_npm_bin, expected_node_bin
         ),
+    );
+    #[cfg(feature = "package-global")]
+    assert_eq!(
+        node_npm.path().unwrap().into_string().unwrap(),
+        format!(
+            "{}:{}:{}",
+            expected_npm_bin, expected_node_bin, starting_path
+        )
     );
 
     let node_yarn = Image {
@@ -68,12 +81,21 @@ fn test_image_path() {
         yarn: Some(Sourced::with_default(v457.clone())),
     };
 
+    #[cfg(not(feature = "package-global"))]
     assert_eq!(
         node_yarn.path().unwrap().into_string().unwrap(),
         format!(
             "{}:{}:/usr/bin:/blah:/doesnt/matter/bin",
             expected_yarn_bin, expected_node_bin
         ),
+    );
+    #[cfg(feature = "package-global")]
+    assert_eq!(
+        node_yarn.path().unwrap().into_string().unwrap(),
+        format!(
+            "{}:{}:{}",
+            expected_yarn_bin, expected_node_bin, starting_path
+        )
     );
 
     let node_npm_yarn = Image {
@@ -82,12 +104,21 @@ fn test_image_path() {
         yarn: Some(Sourced::with_default(v457)),
     };
 
+    #[cfg(not(feature = "package-global"))]
     assert_eq!(
         node_npm_yarn.path().unwrap().into_string().unwrap(),
         format!(
             "{}:{}:{}:/usr/bin:/blah:/doesnt/matter/bin",
             expected_npm_bin, expected_yarn_bin, expected_node_bin
         ),
+    );
+    #[cfg(feature = "package-global")]
+    assert_eq!(
+        node_npm_yarn.path().unwrap().into_string().unwrap(),
+        format!(
+            "{}:{}:{}:{}",
+            expected_npm_bin, expected_yarn_bin, expected_node_bin, starting_path
+        )
     );
 }
 
@@ -104,7 +135,7 @@ fn test_image_path() {
         .into_string()
         .expect("Could not create path containing shim dir");
 
-    std::env::set_var("PATH", path_with_shims);
+    std::env::set_var("PATH", &path_with_shims);
 
     let node_bin = volta_home().unwrap().node_image_bin_dir("1.2.3");
     let expected_node_bin = node_bin.to_str().unwrap();
@@ -125,9 +156,15 @@ fn test_image_path() {
         yarn: None,
     };
 
+    #[cfg(not(feature = "package-global"))]
     assert_eq!(
         only_node.path().unwrap().into_string().unwrap(),
         format!("{};C:\\\\somebin;D:\\\\ProbramFlies", expected_node_bin),
+    );
+    #[cfg(feature = "package-global")]
+    assert_eq!(
+        only_node.path().unwrap().into_string().unwrap(),
+        format!("{};{}", expected_node_bin, path_with_shims),
     );
 
     let node_npm = Image {
@@ -136,12 +173,21 @@ fn test_image_path() {
         yarn: None,
     };
 
+    #[cfg(not(feature = "package-global"))]
     assert_eq!(
         node_npm.path().unwrap().into_string().unwrap(),
         format!(
             "{};{};C:\\\\somebin;D:\\\\ProbramFlies",
             expected_npm_bin, expected_node_bin
         ),
+    );
+    #[cfg(feature = "package-global")]
+    assert_eq!(
+        node_npm.path().unwrap().into_string().unwrap(),
+        format!(
+            "{};{};{}",
+            expected_npm_bin, expected_node_bin, path_with_shims
+        )
     );
 
     let node_yarn = Image {
@@ -150,12 +196,21 @@ fn test_image_path() {
         yarn: Some(Sourced::with_default(v457.clone())),
     };
 
+    #[cfg(not(feature = "package-global"))]
     assert_eq!(
         node_yarn.path().unwrap().into_string().unwrap(),
         format!(
             "{};{};C:\\\\somebin;D:\\\\ProbramFlies",
             expected_yarn_bin, expected_node_bin
         ),
+    );
+    #[cfg(feature = "package-global")]
+    assert_eq!(
+        node_yarn.path().unwrap().into_string().unwrap(),
+        format!(
+            "{};{};{}",
+            expected_yarn_bin, expected_node_bin, path_with_shims
+        )
     );
 
     let node_npm_yarn = Image {
@@ -164,6 +219,7 @@ fn test_image_path() {
         yarn: Some(Sourced::with_default(v457)),
     };
 
+    #[cfg(not(feature = "package-global"))]
     assert_eq!(
         node_npm_yarn.path().unwrap().into_string().unwrap(),
         format!(
@@ -171,6 +227,14 @@ fn test_image_path() {
             expected_npm_bin, expected_yarn_bin, expected_node_bin
         ),
     );
+    #[cfg(feature = "package-global")]
+    assert_eq!(
+        node_npm_yarn.path().unwrap().into_string().unwrap(),
+        format!(
+            "{};{};{};{}",
+            expected_npm_bin, expected_yarn_bin, expected_node_bin, path_with_shims
+        )
+    )
 }
 
 #[cfg(unix)]

--- a/crates/volta-core/src/run_package_global/executor.rs
+++ b/crates/volta-core/src/run_package_global/executor.rs
@@ -6,6 +6,7 @@ use std::os::unix::process::ExitStatusExt;
 use std::os::windows::process::ExitStatusExt;
 use std::process::{Command, ExitStatus};
 
+use super::RECURSION_ENV_VAR;
 use crate::command::create_command;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::platform::{CliPlatform, Platform, System};
@@ -179,6 +180,7 @@ impl ToolCommand {
             ToolKind::Bypass(command) => (System::path()?, ErrorKind::BypassError { command }),
         };
 
+        self.command.env(RECURSION_ENV_VAR, "1");
         self.command.env("PATH", path);
 
         pass_control_to_shim();
@@ -248,6 +250,7 @@ impl PackageInstallCommand {
         let image = self.platform.checkout(session)?;
         let path = image.path()?;
 
+        self.command.env(RECURSION_ENV_VAR, "1");
         self.command.env("PATH", path);
         self.installer.setup_command(&mut self.command);
 

--- a/crates/volta-core/src/run_package_global/node.rs
+++ b/crates/volta-core/src/run_package_global/node.rs
@@ -1,14 +1,19 @@
+use std::env;
 use std::ffi::OsString;
 
 use super::executor::{Executor, ToolCommand, ToolKind};
-use super::{debug_active_image, debug_no_platform};
+use super::{debug_active_image, debug_no_platform, RECURSION_ENV_VAR};
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{Platform, System};
 use crate::session::Session;
 
 /// Build a `ToolCommand` for Node
 pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
-    let platform = Platform::current(session)?;
+    // Don't re-evaluate the platform if this is a recursive call
+    let platform = match env::var_os(RECURSION_ENV_VAR) {
+        Some(_) => None,
+        None => Platform::current(session)?,
+    };
 
     Ok(ToolCommand::new("node", args, platform, ToolKind::Node).into())
 }

--- a/crates/volta-core/src/run_package_global/npm.rs
+++ b/crates/volta-core/src/run_package_global/npm.rs
@@ -1,8 +1,9 @@
+use std::env;
 use std::ffi::OsString;
 
 use super::executor::{Executor, ToolCommand, ToolKind};
 use super::parser::CommandArg;
-use super::{debug_active_image, debug_no_platform};
+use super::{debug_active_image, debug_no_platform, RECURSION_ENV_VAR};
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{Platform, System};
 use crate::session::Session;
@@ -16,13 +17,19 @@ use crate::session::Session;
 /// If the command is _not_ a global install / uninstall or we don't have a default platform, then
 /// we will allow npm to execute the command as usual.
 pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
-    if let CommandArg::Global(cmd) = CommandArg::for_npm(args) {
-        if let Some(default_platform) = session.default_platform()? {
-            return cmd.executor(default_platform);
-        }
-    }
+    // Don't re-evaluate the context or global install interception if this is a recursive call
+    let platform = match env::var_os(RECURSION_ENV_VAR) {
+        Some(_) => None,
+        None => {
+            if let CommandArg::Global(cmd) = CommandArg::for_npm(args) {
+                if let Some(default_platform) = session.default_platform()? {
+                    return cmd.executor(default_platform);
+                }
+            }
 
-    let platform = Platform::current(session)?;
+            Platform::current(session)?
+        }
+    };
 
     Ok(ToolCommand::new("npm", args, platform, ToolKind::Npm).into())
 }


### PR DESCRIPTION
Info
-----
* In a non-Volta environment, global bins are put on the PATH and can freely call one another.
* Volta should allow that behavior as well, since there are cases where it is needed (multiple related bins delivered as a single package, for example).
* To do that, we need to leave the shim directory on the PATH when executing a command.
* However, since the Volta shims for global packages are located in the same directory as the shims for node, npm, yarn, etc., we need to make sure that a bad state doesn't cause an infinite recursion.
    * The built-in shims (Node, npm, npx, and Yarn) each call their command by putting the appropriate directory on the PATH and then calling the bare command.
    * This is in contrast to the binary shims, which call their command directly with the path to the executable.
    * For the former case, if something is misconfigured, it could happen that the shim directory is the earliest valid location on the PATH with that command, which would cause the shim to call itself recursively over and over.
* To avoid infinite recursion, we set an environment variable `_VOLTA_TOOL_RECURSION` when executing a command. Then, when one of the built-in shims tries to execute, iff that environment variable is already set, it will instead use the pass-through logic (which _does_ remove the shim directory from the PATH), breaking the recursive chain.
* One caveat is that when we execute `volta run <command>`, we explicitly remove the environment variable, because it is perfectly valid for e.g. a Node script to call `volta run npm` to force re-evaluation of the context (maybe in a different directory). Since `volta run` can never call itself directly, there's no risk of an infinite recursion.

Changes
-----
* Updated `Image::path` to no longer remove the shim directory from the PATH.
* Set the recursion environment variable when executing a shim command (either directly or a global install).
* Explicitly un-set the environment variable when executing a `volta run` command.
* Updated the logic on the built-in shims to detect the environment variable and skip platform detection if it is set.

Tested
-----
* Updated the `Image::path` tests to account for the new behavior.
* Locally tested that two separate globally installed binaries can see one another.
* Also tested that directly breaking the environment doesn't result in an infinite recursion.

Notes
-----
* The Binaries ignore the recursion environment variable for two reasons:
    1. Binaries are called directly, so it's not possible for executing the shim to immediately re-invoke itself.
    2. Different binaries may have different platforms, so we need to make sure to re-evaluate when they run.
