### PR TITLE
Remove pre-release flag from auto-generated releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,6 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ github.ref }}
           draft: true
-          prerelease: true
       - name: Upload CentOS artifact
         uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
As discussed in #803, though we aren't yet at 1.0, Volta is production-ready (and we're using it at scale within LinkedIn). We have been committed to stability and backwards-compatibility for some time, so it is reasonable to no longer use the "Pre-release" flag on GitHub releases.

This also unlocks updates to the Volta formula in Homebrew, which requires that packages not be pre-release to be included in the public repo.

Updating the CI script that creates the draft release to _not_ set the pre-release flag.