### PR TITLE
[Tiny] Correctly locate install_dir

### DIFF
--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -53,10 +53,10 @@ pub fn volta_install<'a>() -> Fallible<&'a VoltaInstall> {
 /// actual binary files
 fn default_install_dir() -> Fallible<PathBuf> {
     env::current_exe()
+        .and_then(canonicalize)
         .map(|mut path| {
             path.pop(); // Remove the executable name from the path
             path
         })
-        .and_then(canonicalize)
         .with_context(|| ErrorKind::NoInstallDir)
 }


### PR DESCRIPTION
Info
-----
Since Volta 0.9.0, there have been a few reports of `volta_migrate` failing to launch even though the binary is available, both from managed corporate environments and from `brew` installs. It turns out our logic for finding the install directory (which we then use to locate the `volta_migrate` executable) had a very subtle defect: It was stripping off the file to locate the directory _before_ canonicalizing the path. This meant that if the executable _itself_ was a symlink, but the parent directory wasn't, that we wouldn't correctly resolve location of the _actual_ binaries. For example:

* Volta is installed in `/home/user/volta/bin/{volta,volta-shim,volta-migrate}`
* `/home/user/links/volta` is a symlink to `/home/user/volta/bin/volta`, but the other two binaries aren't linked there.
* When we execute `/home/user/links/volta`, to determine the "install path", we would first remove the file and turn it into `/home/user/links`.
* Then we would canonicalize the path, which would still give us `/home/user/links`, because that is an actual directory.
* Finally, we would add `volta-migrate` to the path and come up with the (incorrect) `/home/user/links/volta-migrate`

Instead, we should canonicalize the path following symlinks _before_ removing the file part, which would give us:

* Executing `/home/user/links/volta` is canonicalized to `/home/user/volta/bin/volta`
* Then we strip the file to get `/home/user/volta/bin`
* Finally, we add `volta-migrate` to build the (correct) path `/home/user/volta/bin/volta-migrate`

Changes
-----
* Moved the call to `canonicalize` in `default_install_dir` to happen before stripping off the file part of the path.

Tested
-----
* Confirmed locally that the path is resolved correctly and `volta-migrate` can start, even if _only_ `volta` is symlinked.