### PR TITLE
Use the matches! macro instead of manual match blocks

### DIFF
--- a/crates/validate-npm-package-name/src/lib.rs
+++ b/crates/validate-npm-package-name/src/lib.rs
@@ -73,17 +73,11 @@ pub enum Validity {
 
 impl Validity {
     pub fn valid_for_old_packages(&self) -> bool {
-        match self {
-            Validity::Invalid { .. } => false,
-            _ => true,
-        }
+        matches!(self, Validity::Valid | Validity::ValidForOldPackages { .. })
     }
 
     pub fn valid_for_new_packages(&self) -> bool {
-        match self {
-            Validity::Valid => true,
-            _ => false,
-        }
+        matches!(self, Validity::Valid)
     }
 }
 

--- a/crates/volta-core/src/tool/serial.rs
+++ b/crates/volta-core/src/tool/serial.rs
@@ -137,13 +137,13 @@ impl Spec {
 ///
 /// This means it is either 'latest', 'lts', a Version, or a Version Range.
 fn is_version_like(value: &str) -> bool {
-    match value.parse() {
+    matches!(
+        value.parse(),
         Ok(VersionSpec::Exact(_))
         | Ok(VersionSpec::Semver(_))
         | Ok(VersionSpec::Tag(VersionTag::Latest))
-        | Ok(VersionSpec::Tag(VersionTag::Lts)) => true,
-        _ => false,
-    }
+        | Ok(VersionSpec::Tag(VersionTag::Lts))
+    )
 }
 
 #[cfg(test)]

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -55,10 +55,7 @@ impl Source {
     fn allowed_with(&self, filter: &Filter) -> bool {
         match filter {
             Filter::Default => self == &Source::Default,
-            Filter::Current => match self {
-                Source::Default | Source::Project(_) => true,
-                _ => false,
-            },
+            Filter::Current => matches!(self, Source::Default | Source::Project(_)),
             Filter::None => true,
         }
     }


### PR DESCRIPTION
Info
-----
Clippy now gives warnings about match expressions that could be better written using the [`matches!`](https://doc.rust-lang.org/std/macro.matches.html) macro.

Changes
-----
Updated each expression to use `matches!` instead of a hand-written match block.

Note
-----
The `matches!` macro was added in Rust 1.42, so we need to bump our MSRV. It's currently at 1.41, so it's not a huge bump. Created https://github.com/volta-cli/website/pull/86 to update the documentation to better reflect our workflow.