### PR TITLE
Allow installs of MacOS version on Apple ARM architecture

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -385,10 +385,19 @@ check_architecture() {
   local arch="$2"
 
   if [[ "$version" != "local"* ]]; then
-    if [ "$arch" != "x86_64" ]; then
-      error "Sorry! Volta currently only provides pre-built binaries for x86_64 architectures."
-      return 1
-    fi
+    case "$arch" in
+      x86_64)
+        return 0
+        ;;
+      arm64)
+        if [ "$(uname -s)" = "Darwin" ]; then
+          return 0
+        fi
+        ;;
+    esac
+
+    error "Sorry! Volta currently only provides pre-built binaries for x86_64 architectures."
+    return 1
   fi
 }
 


### PR DESCRIPTION
Closes #870 

Info
-----
* Though we don't have native builds for Apple Silicon machines yet, the existing MacOS builds should continue to work under Rosetta.
* However, the installer currently shows an early error when the architecture isn't x86_64

Changes
-----
* Updated the installer to allow Apple ARM machines to pass the `check_architecture` function, after which they will install the existing MacOS build.

Testing
-----
* I don't currently have access to an M1 machine, so I could use confirmation from someone who does (cc @stefanpenner). The updated installer is at https://raw.githubusercontent.com/charlespierce/volta/ec2ba8bc2cfb4fa60b1ce4e0069e44f7a783b7bd/dev/unix/volta-install.sh, so a test would be to run the following on a standard, non-Rosetta terminal:
```
curl https://raw.githubusercontent.com/charlespierce/volta/ec2ba8bc2cfb4fa60b1ce4e0069e44f7a783b7bd/dev/unix/volta-install.sh | bash
```