### PR TITLE
Remove 'tar' output from installer

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -377,7 +377,7 @@ install_from_file() {
 
   info 'Extracting' "Volta binaries and launchers"
   # extract the files to the specified directory
-  tar -xzvf "$archive" -C "$install_dir"/bin
+  tar -xf "$archive" -C "$install_dir"/bin
 }
 
 check_architecture() {


### PR DESCRIPTION
As pointed out on Discord, the installer currently includes some output from `tar` that looks out of place:

```
x volta
x volta-shim
x volta-migrate
```

This is because `tar` is invoked with `-v` for verbose output. We actually don't need that output to be part of the install process, so removing that flag from the installer.

Note: Also removed `-z` which has no use when extracting a tarball.