### PR TITLE
[Small] Add new layout for pnpm dirs

### DIFF
--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -6,7 +6,10 @@ use cfg_if::cfg_if;
 use double_checked_cell::DoubleCheckedCell;
 use dunce::canonicalize;
 use lazy_static::lazy_static;
+#[cfg(not(feature = "pnpm"))]
 use volta_layout::v3::{VoltaHome, VoltaInstall};
+#[cfg(feature = "pnpm")]
+use volta_layout::v4::{VoltaHome, VoltaInstall};
 
 cfg_if! {
     if #[cfg(unix)] {

--- a/crates/volta-layout/src/lib.rs
+++ b/crates/volta-layout/src/lib.rs
@@ -5,6 +5,8 @@ pub mod v0;
 pub mod v1;
 pub mod v2;
 pub mod v3;
+#[cfg(feature = "pnpm")]
+pub mod v4;
 
 fn executable(name: &str) -> String {
     format!("{}{}", name, std::env::consts::EXE_SUFFIX)

--- a/crates/volta-layout/src/v4.rs
+++ b/crates/volta-layout/src/v4.rs
@@ -1,0 +1,121 @@
+use std::path::PathBuf;
+
+use super::executable;
+use volta_layout_macro::layout;
+
+pub use crate::v1::VoltaInstall;
+
+layout! {
+    pub struct VoltaHome {
+        "cache": cache_dir {
+            "node": node_cache_dir {
+                "index.json": node_index_file;
+                "index.json.expires": node_index_expiry_file;
+            }
+        }
+        "bin": shim_dir {}
+        "log": log_dir {}
+        "tools": tools_dir {
+            "inventory": inventory_dir {
+                "node": node_inventory_dir {}
+                "npm": npm_inventory_dir {}
+                "pnpm": pnpm_inventory_dir {}
+                "yarn": yarn_inventory_dir {}
+            }
+            "image": image_dir {
+                "node": node_image_root_dir {}
+                "npm": npm_image_root_dir {}
+                "pnpm": pnpm_image_root_dir {}
+                "yarn": yarn_image_root_dir {}
+                "packages": package_image_root_dir {}
+            }
+            "shared": shared_lib_root {}
+            "user": default_toolchain_dir {
+                "bins": default_bin_dir {}
+                "packages": default_package_dir {}
+                "platform.json": default_platform_file;
+            }
+        }
+        "tmp": tmp_dir {}
+        "hooks.json": default_hooks_file;
+        "layout.v4": layout_file;
+    }
+}
+
+impl VoltaHome {
+    pub fn node_image_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_root_dir.clone(), node)
+    }
+
+    pub fn npm_image_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_root_dir.clone(), npm)
+    }
+
+    pub fn npm_image_bin_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_dir(npm), "bin")
+    }
+
+    pub fn pnpm_image_dir(&self, pnpm: &str) -> PathBuf {
+        path_buf!(self.pnpm_image_root_dir.clone(), pnpm)
+    }
+
+    pub fn pnpm_image_bin_dir(&self, pnpm: &str) -> PathBuf {
+        path_buf!(self.pnpm_image_dir(pnpm), "bin")
+    }
+
+    pub fn yarn_image_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_root_dir.clone(), version)
+    }
+
+    pub fn yarn_image_bin_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_dir(version), "bin")
+    }
+
+    pub fn package_image_dir(&self, name: &str) -> PathBuf {
+        path_buf!(self.package_image_root_dir.clone(), name)
+    }
+
+    pub fn default_package_config_file(&self, package_name: &str) -> PathBuf {
+        path_buf!(
+            self.default_package_dir.clone(),
+            format!("{}.json", package_name)
+        )
+    }
+
+    pub fn default_tool_bin_config(&self, bin_name: &str) -> PathBuf {
+        path_buf!(self.default_bin_dir.clone(), format!("{}.json", bin_name))
+    }
+
+    pub fn node_npm_version_file(&self, version: &str) -> PathBuf {
+        path_buf!(
+            self.node_inventory_dir.clone(),
+            format!("node-v{}-npm", version)
+        )
+    }
+
+    pub fn shim_file(&self, toolname: &str) -> PathBuf {
+        path_buf!(self.shim_dir.clone(), executable(toolname))
+    }
+
+    pub fn shared_lib_dir(&self, library: &str) -> PathBuf {
+        path_buf!(self.shared_lib_root.clone(), library)
+    }
+}
+
+#[cfg(windows)]
+impl VoltaHome {
+    pub fn shim_git_bash_script_file(&self, toolname: &str) -> PathBuf {
+        path_buf!(self.shim_dir.clone(), toolname)
+    }
+
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        self.node_image_dir(node)
+    }
+}
+
+#[cfg(unix)]
+impl VoltaHome {
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_dir(node), "bin")
+    }
+}

--- a/crates/volta-migrate/src/v4.rs
+++ b/crates/volta-migrate/src/v4.rs
@@ -1,0 +1,76 @@
+use std::convert::TryFrom;
+use std::fs::File;
+use std::path::PathBuf;
+
+use crate::empty::Empty;
+use crate::v3::V3;
+use log::debug;
+use volta_core::error::{Context, ErrorKind, Fallible, VoltaError};
+use volta_core::fs::remove_file_if_exists;
+use volta_layout::v4;
+
+/// Represents a V3 Volta layout (used by Volta v0.9.0 and above)
+///
+/// Holds a reference to the V3 layout struct to support future migrations
+pub struct V4 {
+    pub home: v4::VoltaHome,
+}
+
+impl V4 {
+    pub fn new(home: PathBuf) -> Self {
+        V4 {
+            home: v4::VoltaHome::new(home),
+        }
+    }
+
+    /// Write the layout file to mark migration to V2 as complete
+    ///
+    /// Should only be called once all other migration steps are finished, so that we don't
+    /// accidentally mark an incomplete migration as completed
+    fn complete_migration(home: v4::VoltaHome) -> Fallible<Self> {
+        debug!("Writing layout marker file");
+        File::create(home.layout_file()).with_context(|| ErrorKind::CreateLayoutFileError {
+            file: home.layout_file().to_owned(),
+        })?;
+
+        Ok(V4 { home })
+    }
+}
+
+impl TryFrom<Empty> for V4 {
+    type Error = VoltaError;
+
+    fn try_from(old: Empty) -> Fallible<Self> {
+        debug!("New Volta installation detected, creating fresh layout");
+
+        let home = v4::VoltaHome::new(old.home);
+        home.create().with_context(|| ErrorKind::CreateDirError {
+            dir: home.root().to_owned(),
+        })?;
+
+        V4::complete_migration(home)
+    }
+}
+
+impl TryFrom<V3> for V4 {
+    type Error = VoltaError;
+
+    fn try_from(old: V3) -> Fallible<Self> {
+        debug!("Migrating from V3 layout");
+
+        let new_home = v4::VoltaHome::new(old.home.root().to_owned());
+        new_home
+            .create()
+            .with_context(|| ErrorKind::CreateDirError {
+                dir: new_home.root().to_owned(),
+            })?;
+
+        // Complete the migration, writing the V3 layout file
+        let layout = V4::complete_migration(new_home)?;
+
+        // Remove the V2 layout file, since we're now on V3 (do this after writing the V3 file so that we know the migration succeeded)
+        remove_file_if_exists(old.home.layout_file())?;
+
+        Ok(layout)
+    }
+}

--- a/tests/acceptance/migrations.rs
+++ b/tests/acceptance/migrations.rs
@@ -30,7 +30,10 @@ fn empty_volta_home_is_created() {
     assert!(Sandbox::path_exists(".volta/tools/user"));
 
     // Layout file should now exist
+    #[cfg(not(feature = "pnpm"))]
     assert!(Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -58,6 +61,8 @@ fn legacy_v0_volta_home_is_upgraded() {
     // Layout file is not there
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
     assert!(!Sandbox::path_exists(".volta/layout.v2"));
+    #[cfg(feature = "pnpm")]
+    assert!(!Sandbox::path_exists(".volta/layout.v3"));
 
     // running volta should not create anything else
     assert_that!(s.volta("--version"), execs().with_status(0));
@@ -73,7 +78,12 @@ fn legacy_v0_volta_home_is_upgraded() {
     // Most recent layout file should exist, others should not
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
     assert!(!Sandbox::path_exists(".volta/layout.v2"));
+    #[cfg(not(feature = "pnpm"))]
     assert!(Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(!Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -141,7 +151,12 @@ fn tagged_v1_volta_home_is_upgraded() {
     // Most recent layout file should exist, others should not
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
     assert!(!Sandbox::path_exists(".volta/layout.v2"));
+    #[cfg(not(feature = "pnpm"))]
     assert!(Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(!Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -206,6 +221,7 @@ fn tagged_v1_to_v2_keeps_migrated_node_images() {
 }
 
 #[test]
+#[cfg(not(feature = "pnpm"))]
 fn current_v3_volta_home_is_unchanged() {
     let s = sandbox().layout_file("v3").build();
 
@@ -223,6 +239,31 @@ fn current_v3_volta_home_is_unchanged() {
     // everything should be the same as before running the command
     assert!(Sandbox::path_exists(".volta"));
     assert!(Sandbox::path_exists(".volta/layout.v3"));
+    assert!(Sandbox::path_exists(".volta/cache/node"));
+    assert!(Sandbox::path_exists(".volta/tmp"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
+}
+
+#[test]
+#[cfg(feature = "pnpm")]
+fn current_v4_volta_home_is_unchanged() {
+    let s = sandbox().layout_file("v4").build();
+
+    // directories that are already created by the test framework
+    assert!(Sandbox::path_exists(".volta"));
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
+    assert!(Sandbox::path_exists(".volta/cache/node"));
+    assert!(Sandbox::path_exists(".volta/tmp"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
+
+    // running volta should not create anything else
+    assert_that!(s.volta("--version"), execs().with_status(0));
+
+    // everything should be the same as before running the command
+    assert!(Sandbox::path_exists(".volta"));
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));


### PR DESCRIPTION
Info
-----
* To add support for pnpm, we need to have a `pnpm` image & inventory directories to store the installed files.
* We also want to automatically generate that directory when necessary.

Changes
-----
* Added a `v4` layout and migration, which is primarily a copy of the `v3` layout except that it adds the `pnpm` inventory & image directories (and functions to access the subdirectories).
* Updated the `layout` module in `volta_core` to use `v4` when the feature flag is set.

Tested
-----
* Confirmed that everything compiles correctly both with and without the feature flag enabled.