### PR TITLE
Run CI tests with pnpm feature active

### DIFF
--- a/.github/workflows/test-pnpm.yml
+++ b/.github/workflows/test-pnpm.yml
@@ -1,0 +1,67 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+name: Test (pnpm feature)
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        os:
+          - ubuntu
+          - macos
+          - windows
+    name: Acceptance Tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}-latest
+    env:
+      RUST_BACKTRACE: full
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all --features mock-network,pnpm
+      - name: Lint with clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --features pnpm
+      - name: Lint tests with clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --tests --features mock-network,pnpm
+
+  smoke-tests:
+    name: Smoke Tests
+    runs-on: macos-latest
+    env:
+      RUST_BACKTRACE: full
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --test smoke --features smoke-tests,pnpm -- --test-threads 1


### PR DESCRIPTION
With development happening behind the `pnpm` feature flag, we should make sure that all tests are run with the feature flag enabled as well, to confirm that any changes don't break that work.