### PR TITLE
[Small] Add support for running 'pnpm' and 'pnpx' through the shims

### DIFF
--- a/crates/volta-core/src/error/kind.rs
+++ b/crates/volta-core/src/error/kind.rs
@@ -307,6 +307,12 @@ pub enum ErrorKind {
         tool: String,
     },
 
+    /// Thrown when there is no pnpm version matching the requested Semver/Tag
+    #[cfg(feature = "pnpm")]
+    PnpmVersionNotFound {
+        matching: String,
+    },
+
     /// Thrown when executing a project-local binary fails
     ProjectLocalBinaryExecError {
         command: String,
@@ -864,7 +870,7 @@ Use `volta install yarn` to select a default version (see `volta help install` f
             ),
             ErrorKind::NpmVersionNotFound { matching } => write!(
                 f,
-                r#"Could not find Node version matching "{}" in the version registry.
+                r#"Could not find npm version matching "{}" in the version registry.
 
 Please verify that the version is correct."#,
                 matching
@@ -1004,6 +1010,14 @@ Please supply a spec in the format `<tool name>[@<version>]`.",
 
 {}",
                 tool, PERMISSIONS_CTA
+            ),
+            #[cfg(feature = "pnpm")]
+            ErrorKind::PnpmVersionNotFound { matching } => write!(
+                f,
+                r#"Could not find pnpm version matching "{}" in the version registry.
+
+Please verify that the version is correct."#,
+                matching
             ),
             ErrorKind::ProjectLocalBinaryExecError { command } => write!(
                 f,
@@ -1358,6 +1372,8 @@ impl ErrorKind {
             ErrorKind::ParsePackageConfigError => ExitCode::UnknownError,
             ErrorKind::ParsePlatformError => ExitCode::ConfigurationError,
             ErrorKind::PersistInventoryError { .. } => ExitCode::FileSystemError,
+            #[cfg(feature = "pnpm")]
+            ErrorKind::PnpmVersionNotFound { .. } => ExitCode::NoVersionMatch,
             ErrorKind::ProjectLocalBinaryExecError { .. } => ExitCode::ExecutionFailure,
             ErrorKind::ProjectLocalBinaryNotFound { .. } => ExitCode::FileSystemError,
             ErrorKind::PublishHookBothUrlAndBin => ExitCode::ConfigurationError,

--- a/crates/volta-core/src/hook/mod.rs
+++ b/crates/volta-core/src/hook/mod.rs
@@ -9,6 +9,8 @@ use std::path::Path;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::layout::volta_home;
 use crate::project::Project;
+#[cfg(feature = "pnpm")]
+use crate::tool::Pnpm;
 use crate::tool::{Node, Npm, Tool, Yarn};
 use lazycell::LazyCell;
 use log::debug;
@@ -50,6 +52,8 @@ impl LazyHookConfig {
 pub struct HookConfig {
     node: Option<ToolHooks<Node>>,
     npm: Option<ToolHooks<Npm>>,
+    #[cfg(feature = "pnpm")]
+    pnpm: Option<ToolHooks<Pnpm>>,
     yarn: Option<ToolHooks<Yarn>>,
     events: Option<EventHooks>,
 }
@@ -95,6 +99,11 @@ impl HookConfig {
 
     pub fn npm(&self) -> Option<&ToolHooks<Npm>> {
         self.npm.as_ref()
+    }
+
+    #[cfg(feature = "pnpm")]
+    pub fn pnpm(&self) -> Option<&ToolHooks<Pnpm>> {
+        self.pnpm.as_ref()
     }
 
     pub fn yarn(&self) -> Option<&ToolHooks<Yarn>> {
@@ -161,6 +170,8 @@ impl HookConfig {
                     Self {
                         node: None,
                         npm: None,
+                        #[cfg(feature = "pnpm")]
+                        pnpm: None,
                         yarn: None,
                         events: None,
                     }
@@ -193,6 +204,8 @@ impl HookConfig {
         Self {
             node: merge_hooks!(self, other, node),
             npm: merge_hooks!(self, other, npm),
+            #[cfg(feature = "pnpm")]
+            pnpm: merge_hooks!(self, other, pnpm),
             yarn: merge_hooks!(self, other, yarn),
             events: merge_hooks!(self, other, events),
         }

--- a/crates/volta-core/src/hook/serial.rs
+++ b/crates/volta-core/src/hook/serial.rs
@@ -4,6 +4,8 @@ use std::path::Path;
 
 use super::tool;
 use crate::error::{ErrorKind, Fallible, VoltaError};
+#[cfg(feature = "pnpm")]
+use crate::tool::Pnpm;
 use crate::tool::{Node, Npm, Tool, Yarn};
 use serde::{Deserialize, Serialize};
 
@@ -101,6 +103,8 @@ impl TryFrom<RawPublishHook> for super::Publish {
 pub struct RawHookConfig {
     pub node: Option<RawToolHooks<Node>>,
     pub npm: Option<RawToolHooks<Npm>>,
+    #[cfg(feature = "pnpm")]
+    pub pnpm: Option<RawToolHooks<Pnpm>>,
     pub yarn: Option<RawToolHooks<Yarn>>,
     pub events: Option<RawEventHooks>,
 }
@@ -136,11 +140,15 @@ impl RawHookConfig {
     pub fn into_hook_config(self, base_dir: &Path) -> Fallible<super::HookConfig> {
         let node = self.node.map(|n| n.into_tool_hooks(base_dir)).transpose()?;
         let npm = self.npm.map(|n| n.into_tool_hooks(base_dir)).transpose()?;
+        #[cfg(feature = "pnpm")]
+        let pnpm = self.pnpm.map(|p| p.into_tool_hooks(base_dir)).transpose()?;
         let yarn = self.yarn.map(|y| y.into_tool_hooks(base_dir)).transpose()?;
         let events = self.events.map(|e| e.try_into()).transpose()?;
         Ok(super::HookConfig {
             node,
             npm,
+            #[cfg(feature = "pnpm")]
+            pnpm,
             yarn,
             events,
         })

--- a/crates/volta-core/src/inventory.rs
+++ b/crates/volta-core/src/inventory.rs
@@ -37,6 +37,18 @@ pub fn npm_versions() -> Fallible<BTreeSet<Version>> {
     volta_home().and_then(|home| read_versions(home.npm_image_root_dir()))
 }
 
+/// Checks if a given pnpm version image is available on the local machine
+#[cfg(feature = "pnpm")]
+pub fn pnpm_available(version: &Version) -> Fallible<bool> {
+    volta_home().map(|home| home.pnpm_image_dir(&version.to_string()).exists())
+}
+
+/// Collects a set of all pnpm versions fetched on the local machine
+#[cfg(feature = "pnpm")]
+pub fn pnpm_versions() -> Fallible<BTreeSet<Version>> {
+    volta_home().and_then(|home| read_versions(home.pnpm_image_root_dir()))
+}
+
 /// Checks if a given Yarn version image is available on the local machine
 pub fn yarn_available(version: &Version) -> Fallible<bool> {
     volta_home().map(|home| home.yarn_image_dir(&version.to_string()).exists())

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -6,7 +6,10 @@ use cfg_if::cfg_if;
 use double_checked_cell::DoubleCheckedCell;
 use dunce::canonicalize;
 use lazy_static::lazy_static;
+#[cfg(not(feature = "pnpm"))]
 use volta_layout::v3::{VoltaHome, VoltaInstall};
+#[cfg(feature = "pnpm")]
+use volta_layout::v4::{VoltaHome, VoltaInstall};
 
 cfg_if! {
     if #[cfg(unix)] {

--- a/crates/volta-core/src/platform/image.rs
+++ b/crates/volta-core/src/platform/image.rs
@@ -13,6 +13,9 @@ pub struct Image {
     pub node: Sourced<Version>,
     /// The custom version of npm, if any. `None` represents using the npm that is bundled with Node
     pub npm: Option<Sourced<Version>>,
+    /// The pinned version of pnpm, if any.
+    #[cfg(feature = "pnpm")]
+    pub pnpm: Option<Sourced<Version>>,
     /// The pinned version of Yarn, if any.
     pub yarn: Option<Sourced<Version>>,
 }
@@ -25,6 +28,12 @@ impl Image {
         if let Some(npm) = &self.npm {
             let npm_str = npm.value.to_string();
             bins.push(home.npm_image_bin_dir(&npm_str));
+        }
+
+        #[cfg(feature = "pnpm")]
+        if let Some(pnpm) = &self.pnpm {
+            let pnpm_str = pnpm.value.to_string();
+            bins.push(home.pnpm_image_bin_dir(&pnpm_str));
         }
 
         if let Some(yarn) = &self.yarn {

--- a/crates/volta-core/src/platform/tests.rs
+++ b/crates/volta-core/src/platform/tests.rs
@@ -1,3 +1,8 @@
+// Suppressing the redundant clone warning while the `pnpm` feature is active, as that makes it
+// difficult to properly avoid redundant clones. This should be removed when the feature flag is
+// disabled (#[cfg(feature = "pnpm")])
+#![allow(clippy::redundant_clone)]
+
 use super::*;
 use crate::layout::volta_home;
 #[cfg(windows)]
@@ -28,16 +33,25 @@ fn test_image_path() {
     let npm_bin = volta_home().unwrap().npm_image_bin_dir("6.4.3");
     let expected_npm_bin = npm_bin.to_str().unwrap();
 
+    #[cfg(feature = "pnpm")]
+    let pnpm_bin = volta_home().unwrap().pnpm_image_bin_dir("5.1.3");
+    #[cfg(feature = "pnpm")]
+    let expected_pnpm_bin = pnpm_bin.to_str().unwrap();
+
     let yarn_bin = volta_home().unwrap().yarn_image_bin_dir("4.5.7");
     let expected_yarn_bin = yarn_bin.to_str().unwrap();
 
     let v123 = Version::parse("1.2.3").unwrap();
     let v457 = Version::parse("4.5.7").unwrap();
+    #[cfg(feature = "pnpm")]
+    let v513 = Version::parse("5.1.3").unwrap();
     let v643 = Version::parse("6.4.3").unwrap();
 
     let only_node = Image {
         node: Sourced::with_default(v123.clone()),
         npm: None,
+        #[cfg(feature = "pnpm")]
+        pnpm: None,
         yarn: None,
     };
 
@@ -49,6 +63,8 @@ fn test_image_path() {
     let node_npm = Image {
         node: Sourced::with_default(v123.clone()),
         npm: Some(Sourced::with_default(v643.clone())),
+        #[cfg(feature = "pnpm")]
+        pnpm: None,
         yarn: None,
     };
 
@@ -60,9 +76,29 @@ fn test_image_path() {
         )
     );
 
+    #[cfg(feature = "pnpm")]
+    {
+        let node_pnpm = Image {
+            node: Sourced::with_default(v123.clone()),
+            npm: None,
+            pnpm: Some(Sourced::with_default(v513.clone())),
+            yarn: None,
+        };
+
+        assert_eq!(
+            node_pnpm.path().unwrap().into_string().unwrap(),
+            format!(
+                "{}:{}:{}",
+                expected_pnpm_bin, expected_node_bin, starting_path
+            )
+        );
+    }
+
     let node_yarn = Image {
         node: Sourced::with_default(v123.clone()),
         npm: None,
+        #[cfg(feature = "pnpm")]
+        pnpm: None,
         yarn: Some(Sourced::with_default(v457.clone())),
     };
 
@@ -75,9 +111,11 @@ fn test_image_path() {
     );
 
     let node_npm_yarn = Image {
-        node: Sourced::with_default(v123),
-        npm: Some(Sourced::with_default(v643)),
-        yarn: Some(Sourced::with_default(v457)),
+        node: Sourced::with_default(v123.clone()),
+        npm: Some(Sourced::with_default(v643.clone())),
+        #[cfg(feature = "pnpm")]
+        pnpm: None,
+        yarn: Some(Sourced::with_default(v457.clone())),
     };
 
     assert_eq!(
@@ -87,6 +125,28 @@ fn test_image_path() {
             expected_npm_bin, expected_yarn_bin, expected_node_bin, starting_path
         )
     );
+
+    #[cfg(feature = "pnpm")]
+    {
+        let all = Image {
+            node: Sourced::with_default(v123.clone()),
+            npm: Some(Sourced::with_default(v643.clone())),
+            pnpm: Some(Sourced::with_default(v513.clone())),
+            yarn: Some(Sourced::with_default(v457.clone())),
+        };
+
+        assert_eq!(
+            all.path().unwrap().into_string().unwrap(),
+            format!(
+                "{}:{}:{}:{}:{}",
+                expected_npm_bin,
+                expected_pnpm_bin,
+                expected_yarn_bin,
+                expected_node_bin,
+                starting_path
+            )
+        );
+    }
 }
 
 #[cfg(windows)]
@@ -110,16 +170,25 @@ fn test_image_path() {
     let npm_bin = volta_home().unwrap().npm_image_bin_dir("6.4.3");
     let expected_npm_bin = npm_bin.to_str().unwrap();
 
+    #[cfg(feature = "pnpm")]
+    let pnpm_bin = volta_home().unwrap().pnpm_image_bin_dir("5.1.3");
+    #[cfg(feature = "pnpm")]
+    let expected_pnpm_bin = pnpm_bin.to_str().unwrap();
+
     let yarn_bin = volta_home().unwrap().yarn_image_bin_dir("4.5.7");
     let expected_yarn_bin = yarn_bin.to_str().unwrap();
 
     let v123 = Version::parse("1.2.3").unwrap();
     let v457 = Version::parse("4.5.7").unwrap();
+    #[cfg(feature = "pnpm")]
+    let v513 = Version::parse("5.1.3").unwrap();
     let v643 = Version::parse("6.4.3").unwrap();
 
     let only_node = Image {
         node: Sourced::with_default(v123.clone()),
         npm: None,
+        #[cfg(feature = "pnpm")]
+        pnpm: None,
         yarn: None,
     };
 
@@ -131,6 +200,8 @@ fn test_image_path() {
     let node_npm = Image {
         node: Sourced::with_default(v123.clone()),
         npm: Some(Sourced::with_default(v643.clone())),
+        #[cfg(feature = "pnpm")]
+        pnpm: None,
         yarn: None,
     };
 
@@ -142,9 +213,29 @@ fn test_image_path() {
         )
     );
 
+    #[cfg(feature = "pnpm")]
+    {
+        let node_pnpm = Image {
+            node: Sourced::with_default(v123.clone()),
+            npm: None,
+            pnpm: Some(Sourced::with_default(v513.clone())),
+            yarn: None,
+        };
+
+        assert_eq!(
+            node_pnpm.path().unwrap().into_string().unwrap(),
+            format!(
+                "{};{};{}",
+                expected_pnpm_bin, expected_node_bin, path_with_shims
+            )
+        );
+    }
+
     let node_yarn = Image {
         node: Sourced::with_default(v123.clone()),
         npm: None,
+        #[cfg(feature = "pnpm")]
+        pnpm: None,
         yarn: Some(Sourced::with_default(v457.clone())),
     };
 
@@ -157,9 +248,11 @@ fn test_image_path() {
     );
 
     let node_npm_yarn = Image {
-        node: Sourced::with_default(v123),
-        npm: Some(Sourced::with_default(v643)),
-        yarn: Some(Sourced::with_default(v457)),
+        node: Sourced::with_default(v123.clone()),
+        npm: Some(Sourced::with_default(v643.clone())),
+        #[cfg(feature = "pnpm")]
+        pnpm: None,
+        yarn: Some(Sourced::with_default(v457.clone())),
     };
 
     assert_eq!(
@@ -168,7 +261,29 @@ fn test_image_path() {
             "{};{};{};{}",
             expected_npm_bin, expected_yarn_bin, expected_node_bin, path_with_shims
         )
-    )
+    );
+
+    #[cfg(feature = "pnpm")]
+    {
+        let all = Image {
+            node: Sourced::with_default(v123.clone()),
+            npm: Some(Sourced::with_default(v643.clone())),
+            pnpm: Some(Sourced::with_default(v513.clone())),
+            yarn: Some(Sourced::with_default(v457.clone())),
+        };
+
+        assert_eq!(
+            all.path().unwrap().into_string().unwrap(),
+            format!(
+                "{};{};{};{};{}",
+                expected_npm_bin,
+                expected_pnpm_bin,
+                expected_yarn_bin,
+                expected_node_bin,
+                path_with_shims
+            )
+        );
+    }
 }
 
 #[cfg(unix)]
@@ -271,6 +386,7 @@ mod cli_platform {
     lazy_static! {
         static ref NODE_VERSION: Version = Version::from((12, 14, 1));
         static ref NPM_VERSION: Version = Version::from((6, 13, 2));
+        static ref PNPM_VERSION: Version = Version::from((5, 2, 15));
         static ref YARN_VERSION: Version = Version::from((1, 17, 0));
     }
 
@@ -283,12 +399,16 @@ mod cli_platform {
             let test = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
             let base = Platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
                 npm: None,
+                #[cfg(feature = "pnpm")]
+                pnpm: None,
                 yarn: None,
             };
 
@@ -303,12 +423,16 @@ mod cli_platform {
             let test = CliPlatform {
                 node: None,
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
             let base = Platform {
                 node: Sourced::with_default(NODE_VERSION.clone()),
                 npm: None,
+                #[cfg(feature = "pnpm")]
+                pnpm: None,
                 yarn: None,
             };
 
@@ -323,12 +447,16 @@ mod cli_platform {
             let test = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::Some(NPM_VERSION.clone()),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
             let base = Platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
                 npm: Some(Sourced::with_default(Version::from((5, 6, 3)))),
+                #[cfg(feature = "pnpm")]
+                pnpm: None,
                 yarn: None,
             };
 
@@ -344,12 +472,16 @@ mod cli_platform {
             let test = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::Inherit,
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
             let base = Platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
                 npm: Some(Sourced::with_default(NPM_VERSION.clone())),
+                #[cfg(feature = "pnpm")]
+                pnpm: None,
                 yarn: None,
             };
 
@@ -365,12 +497,16 @@ mod cli_platform {
             let test = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::None,
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
             let base = Platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
                 npm: Some(Sourced::with_default(NPM_VERSION.clone())),
+                #[cfg(feature = "pnpm")]
+                pnpm: None,
                 yarn: None,
             };
 
@@ -380,16 +516,90 @@ mod cli_platform {
         }
 
         #[test]
+        #[cfg(feature = "pnpm")]
+        fn uses_pnpm() {
+            let test = CliPlatform {
+                node: Some(NODE_VERSION.clone()),
+                npm: InheritOption::default(),
+                pnpm: InheritOption::Some(PNPM_VERSION.clone()),
+                yarn: InheritOption::default(),
+            };
+
+            let base = Platform {
+                node: Sourced::with_default(Version::from((10, 10, 10))),
+                npm: None,
+                pnpm: Some(Sourced::with_default(Version::from((1, 10, 3)))),
+                yarn: None,
+            };
+
+            let merged = test.merge(base);
+
+            let merged_pnpm = merged.pnpm.unwrap();
+            assert_eq!(merged_pnpm.value, PNPM_VERSION.clone());
+            assert_eq!(merged_pnpm.source, Source::CommandLine);
+        }
+
+        #[test]
+        #[cfg(feature = "pnpm")]
+        fn inherits_pnpm() {
+            let test = CliPlatform {
+                node: Some(NODE_VERSION.clone()),
+                npm: InheritOption::default(),
+                pnpm: InheritOption::Inherit,
+                yarn: InheritOption::default(),
+            };
+
+            let base = Platform {
+                node: Sourced::with_default(Version::from((10, 10, 10))),
+                npm: None,
+                pnpm: Some(Sourced::with_default(PNPM_VERSION.clone())),
+                yarn: None,
+            };
+
+            let merged = test.merge(base);
+
+            let merged_pnpm = merged.pnpm.unwrap();
+            assert_eq!(merged_pnpm.value, PNPM_VERSION.clone());
+            assert_eq!(merged_pnpm.source, Source::Default);
+        }
+
+        #[test]
+        #[cfg(feature = "pnpm")]
+        fn none_does_not_inherit_pnpm() {
+            let test = CliPlatform {
+                node: Some(NODE_VERSION.clone()),
+                npm: InheritOption::default(),
+                pnpm: InheritOption::None,
+                yarn: InheritOption::default(),
+            };
+
+            let base = Platform {
+                node: Sourced::with_default(Version::from((10, 10, 10))),
+                npm: None,
+                pnpm: Some(Sourced::with_default(PNPM_VERSION.clone())),
+                yarn: None,
+            };
+
+            let merged = test.merge(base);
+
+            assert!(merged.pnpm.is_none());
+        }
+
+        #[test]
         fn uses_yarn() {
             let test = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::Some(YARN_VERSION.clone()),
             };
 
             let base = Platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
                 npm: None,
+                #[cfg(feature = "pnpm")]
+                pnpm: None,
                 yarn: Some(Sourced::with_default(Version::from((1, 10, 3)))),
             };
 
@@ -405,12 +615,16 @@ mod cli_platform {
             let test = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::Inherit,
             };
 
             let base = Platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
                 npm: None,
+                #[cfg(feature = "pnpm")]
+                pnpm: None,
                 yarn: Some(Sourced::with_default(YARN_VERSION.clone())),
             };
 
@@ -426,12 +640,16 @@ mod cli_platform {
             let test = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::None,
             };
 
             let base = Platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
                 npm: None,
+                #[cfg(feature = "pnpm")]
+                pnpm: None,
                 yarn: Some(Sourced::with_default(YARN_VERSION.clone())),
             };
 
@@ -450,6 +668,8 @@ mod cli_platform {
             let cli = CliPlatform {
                 node: None,
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
@@ -463,6 +683,8 @@ mod cli_platform {
             let cli = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
@@ -478,6 +700,8 @@ mod cli_platform {
             let cli = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::Some(NPM_VERSION.clone()),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
@@ -493,6 +717,8 @@ mod cli_platform {
             let cli = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::None,
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
@@ -506,6 +732,8 @@ mod cli_platform {
             let cli = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::Inherit,
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
 
@@ -515,10 +743,57 @@ mod cli_platform {
         }
 
         #[test]
+        #[cfg(feature = "pnpm")]
+        fn uses_cli_pnpm() {
+            let cli = CliPlatform {
+                node: Some(NODE_VERSION.clone()),
+                npm: InheritOption::default(),
+                pnpm: InheritOption::Some(PNPM_VERSION.clone()),
+                yarn: InheritOption::default(),
+            };
+
+            let transformed: Option<Platform> = cli.into();
+
+            let pnpm = transformed.unwrap().pnpm.unwrap();
+            assert_eq!(pnpm.value, PNPM_VERSION.clone());
+            assert_eq!(pnpm.source, Source::CommandLine);
+        }
+
+        #[test]
+        #[cfg(feature = "pnpm")]
+        fn no_pnpm() {
+            let cli = CliPlatform {
+                node: Some(NODE_VERSION.clone()),
+                npm: InheritOption::default(),
+                pnpm: InheritOption::None,
+                yarn: InheritOption::default(),
+            };
+
+            let transformed: Option<Platform> = cli.into();
+            assert!(transformed.unwrap().pnpm.is_none());
+        }
+
+        #[test]
+        #[cfg(feature = "pnpm")]
+        fn inherit_pnpm_becomes_none() {
+            let cli = CliPlatform {
+                node: Some(NODE_VERSION.clone()),
+                npm: InheritOption::default(),
+                pnpm: InheritOption::Inherit,
+                yarn: InheritOption::default(),
+            };
+
+            let transformed: Option<Platform> = cli.into();
+            assert!(transformed.unwrap().pnpm.is_none());
+        }
+
+        #[test]
         fn uses_cli_yarn() {
             let cli = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::Some(YARN_VERSION.clone()),
             };
 
@@ -534,6 +809,8 @@ mod cli_platform {
             let cli = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::None,
             };
 
@@ -547,6 +824,8 @@ mod cli_platform {
             let cli = CliPlatform {
                 node: Some(NODE_VERSION.clone()),
                 npm: InheritOption::default(),
+                #[cfg(feature = "pnpm")]
+                pnpm: InheritOption::default(),
                 yarn: InheritOption::Inherit,
             };
 

--- a/crates/volta-core/src/project/serial.rs
+++ b/crates/volta-core/src/project/serial.rs
@@ -63,6 +63,8 @@ impl Manifest {
 pub(super) enum ManifestKey {
     Node,
     Npm,
+    #[cfg(feature = "pnpm")]
+    Pnpm,
     Yarn,
 }
 
@@ -71,6 +73,8 @@ impl fmt::Display for ManifestKey {
         f.write_str(match self {
             ManifestKey::Node => "node",
             ManifestKey::Npm => "npm",
+            #[cfg(feature = "pnpm")]
+            ManifestKey::Pnpm => "pnpm",
             ManifestKey::Yarn => "yarn",
         })
     }
@@ -168,6 +172,9 @@ struct ToolchainSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     npm: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(feature = "pnpm")]
+    pnpm: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     yarn: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     extends: Option<PathBuf>,
@@ -178,9 +185,17 @@ impl ToolchainSpec {
     fn parse_split(self) -> Fallible<(PartialPlatform, Option<PathBuf>)> {
         let node = self.node.map(parse_version).transpose()?;
         let npm = self.npm.map(parse_version).transpose()?;
+        #[cfg(feature = "pnpm")]
+        let pnpm = self.pnpm.map(parse_version).transpose()?;
         let yarn = self.yarn.map(parse_version).transpose()?;
 
-        let platform = PartialPlatform { node, npm, yarn };
+        let platform = PartialPlatform {
+            node,
+            npm,
+            #[cfg(feature = "pnpm")]
+            pnpm,
+            yarn,
+        };
 
         Ok((platform, self.extends))
     }

--- a/crates/volta-core/src/run/binary.rs
+++ b/crates/volta-core/src/run/binary.rs
@@ -136,9 +136,20 @@ impl DefaultBinary {
                 .default_platform()?
                 .and_then(|ref plat| plat.yarn.clone()),
         };
+        // Similarly, if the user doesn't have `pnpm` set in the platform for this binary, use the default
+        #[cfg(feature = "pnpm")]
+        let pnpm = match bin_config.platform.pnpm {
+            Some(pnpm) => Some(pnpm),
+            None => session
+                .default_platform()?
+                .and_then(|ref plat| plat.pnpm.clone()),
+        };
+
         let platform = Platform {
             node: Sourced::with_binary(bin_config.platform.node),
             npm: bin_config.platform.npm.map(Sourced::with_binary),
+            #[cfg(feature = "pnpm")]
+            pnpm: pnpm.map(Sourced::with_binary),
             yarn: yarn.map(Sourced::with_binary),
         };
 

--- a/crates/volta-core/src/run/executor.rs
+++ b/crates/volta-core/src/run/executor.rs
@@ -114,6 +114,10 @@ pub enum ToolKind {
     Node,
     Npm,
     Npx,
+    #[cfg(feature = "pnpm")]
+    Pnpm,
+    #[cfg(feature = "pnpm")]
+    Pnpx,
     Yarn,
     ProjectLocalBinary(String),
     DefaultBinary(String),
@@ -170,6 +174,10 @@ impl ToolCommand {
             ToolKind::Node => super::node::execution_context(self.platform, session)?,
             ToolKind::Npm => super::npm::execution_context(self.platform, session)?,
             ToolKind::Npx => super::npx::execution_context(self.platform, session)?,
+            #[cfg(feature = "pnpm")]
+            ToolKind::Pnpm => super::pnpm::execution_context(self.platform, session)?,
+            #[cfg(feature = "pnpm")]
+            ToolKind::Pnpx => super::pnpx::execution_context(self.platform, session)?,
             ToolKind::Yarn => super::yarn::execution_context(self.platform, session)?,
             ToolKind::DefaultBinary(bin) => {
                 super::binary::default_execution_context(bin, self.platform, session)?

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -16,6 +16,10 @@ mod node;
 mod npm;
 mod npx;
 mod parser;
+#[cfg(feature = "pnpm")]
+mod pnpm;
+#[cfg(feature = "pnpm")]
+mod pnpx;
 mod yarn;
 
 /// Environment variable set internally when a shim has been executed and the context evaluated
@@ -84,6 +88,10 @@ fn get_executor(
             Some("node") => node::command(args, session),
             Some("npm") => npm::command(args, session),
             Some("npx") => npx::command(args, session),
+            #[cfg(feature = "pnpm")]
+            Some("pnpm") => pnpm::command(args, session),
+            #[cfg(feature = "pnpm")]
+            Some("pnpx") => pnpx::command(args, session),
             Some("yarn") => yarn::command(args, session),
             _ => binary::command(exe, args, session),
         }

--- a/crates/volta-core/src/run/pnpm.rs
+++ b/crates/volta-core/src/run/pnpm.rs
@@ -1,0 +1,40 @@
+use std::env;
+use std::ffi::OsString;
+
+use super::executor::{Executor, ToolCommand, ToolKind};
+use super::{debug_active_image, debug_no_platform, RECURSION_ENV_VAR};
+use crate::error::{ErrorKind, Fallible};
+use crate::platform::{Platform, System};
+use crate::session::Session;
+
+/// Build a `ToolCommand` for pnpm
+pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
+    // Don't re-evaluate the context if this is a recursive call
+    let platform = match env::var_os(RECURSION_ENV_VAR) {
+        Some(_) => None,
+        None => Platform::current(session)?,
+    };
+
+    Ok(ToolCommand::new("pnpm", args, platform, ToolKind::Pnpm).into())
+}
+
+/// Determine the execution context (PATH and failure error message) for pnpm
+pub(super) fn execution_context(
+    platform: Option<Platform>,
+    session: &mut Session,
+) -> Fallible<(OsString, ErrorKind)> {
+    match platform {
+        Some(plat) => {
+            let image = plat.checkout(session)?;
+            let path = image.path()?;
+            debug_active_image(&image);
+
+            Ok((path, ErrorKind::BinaryExecError))
+        }
+        None => {
+            let path = System::path()?;
+            debug_no_platform();
+            Ok((path, ErrorKind::NoPlatform))
+        }
+    }
+}

--- a/crates/volta-core/src/run/pnpx.rs
+++ b/crates/volta-core/src/run/pnpx.rs
@@ -1,0 +1,40 @@
+use std::env;
+use std::ffi::OsString;
+
+use super::executor::{Executor, ToolCommand, ToolKind};
+use super::{debug_active_image, debug_no_platform, RECURSION_ENV_VAR};
+use crate::error::{ErrorKind, Fallible};
+use crate::platform::{Platform, System};
+use crate::session::Session;
+
+/// Build a `ToolCommand` for pnpx
+pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
+    // Don't re-evaluate the context if this is a recursive call
+    let platform = match env::var_os(RECURSION_ENV_VAR) {
+        Some(_) => None,
+        None => Platform::current(session)?,
+    };
+
+    Ok(ToolCommand::new("pnpx", args, platform, ToolKind::Pnpx).into())
+}
+
+/// Determine the execution context (PATH and failure error message) for pnpx
+pub(super) fn execution_context(
+    platform: Option<Platform>,
+    session: &mut Session,
+) -> Fallible<(OsString, ErrorKind)> {
+    match platform {
+        Some(plat) => {
+            let image = plat.checkout(session)?;
+            let path = image.path()?;
+            debug_active_image(&image);
+
+            Ok((path, ErrorKind::BinaryExecError))
+        }
+        None => {
+            let path = System::path()?;
+            debug_no_platform();
+            Ok((path, ErrorKind::NoPlatform))
+        }
+    }
+}

--- a/crates/volta-core/src/shim.rs
+++ b/crates/volta-core/src/shim.rs
@@ -34,6 +34,10 @@ fn get_shim_list_deduped(dir: &Path) -> Fallible<HashSet<String>> {
         shims.insert("node".into());
         shims.insert("npm".into());
         shims.insert("npx".into());
+        #[cfg(feature = "pnpm")]
+        shims.insert("pnpm".into());
+        #[cfg(feature = "pnpm")]
+        shims.insert("pnpx".into());
         shims.insert("yarn".into());
         Ok(shims)
     }

--- a/crates/volta-core/src/tool/node/metadata.rs
+++ b/crates/volta-core/src/tool/node/metadata.rs
@@ -42,8 +42,7 @@ pub struct RawNodeIndex(Vec<RawNodeEntry>);
 pub struct RawNodeEntry {
     #[serde(with = "version_serde")]
     version: Version,
-    #[serde(default)] // handles Option
-    #[serde(with = "option_version_serde")]
+    #[serde(default, with = "option_version_serde")]
     npm: Option<Version>,
     files: Vec<String>,
     #[serde(deserialize_with = "lts_version_serde")]

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -87,7 +87,7 @@ impl Display for NodeVersion {
 
 /// The Tool implementation for fetching and installing Node
 pub struct Node {
-    pub(super) version: Version,
+    version: Version,
 }
 
 impl Node {

--- a/crates/volta-core/src/tool/npm/mod.rs
+++ b/crates/volta-core/src/tool/npm/mod.rs
@@ -20,7 +20,7 @@ pub use resolve::resolve;
 
 /// The Tool implementation for fetching and installing npm
 pub struct Npm {
-    pub(super) version: Version,
+    version: Version,
 }
 
 impl Npm {

--- a/crates/volta-core/src/tool/package/configure.rs
+++ b/crates/volta-core/src/tool/package/configure.rs
@@ -31,6 +31,8 @@ pub(super) fn write_config_and_shims(
     let platform = PlatformSpec {
         node: image.node.value.clone(),
         npm: image.npm.clone().map(|s| s.value),
+        #[cfg(feature = "pnpm")]
+        pnpm: image.pnpm.clone().map(|s| s.value),
         yarn: image.yarn.clone().map(|s| s.value),
     };
 

--- a/crates/volta-core/src/tool/package/metadata.rs
+++ b/crates/volta-core/src/tool/package/metadata.rs
@@ -163,9 +163,12 @@ impl BinConfig {
 struct RawPlatformSpec {
     #[serde(with = "version_serde")]
     node: Version,
-    #[serde(with = "option_version_serde")]
+    #[serde(default, with = "option_version_serde")]
     npm: Option<Version>,
-    #[serde(with = "option_version_serde")]
+    #[serde(default, with = "option_version_serde")]
+    #[cfg(feature = "pnpm")]
+    pnpm: Option<Version>,
+    #[serde(default, with = "option_version_serde")]
     yarn: Option<Version>,
 }
 

--- a/crates/volta-core/src/tool/pnpm/fetch.rs
+++ b/crates/volta-core/src/tool/pnpm/fetch.rs
@@ -1,0 +1,187 @@
+//! Provides fetcher for npm distributions
+
+use std::fs::{write, File};
+use std::path::{Path, PathBuf};
+
+use super::super::download_tool_error;
+use super::super::registry::public_registry_package;
+use crate::error::{Context, ErrorKind, Fallible};
+use crate::fs::{create_staging_dir, create_staging_file, rename, set_executable};
+use crate::hook::ToolHooks;
+use crate::layout::volta_home;
+use crate::style::{progress_bar, tool_version};
+use crate::tool::{self, Pnpm};
+use crate::version::VersionSpec;
+use archive::{Archive, Tarball};
+use fs_utils::ensure_containing_dir_exists;
+use log::debug;
+use semver::Version;
+
+pub fn fetch(version: &Version, hooks: Option<&ToolHooks<Pnpm>>) -> Fallible<()> {
+    let pnpm_dir = volta_home()?.pnpm_inventory_dir();
+    let cache_file = pnpm_dir.join(Pnpm::archive_filename(&version.to_string()));
+
+    let (archive, staging) = match load_cached_distro(&cache_file) {
+        Some(archive) => {
+            debug!(
+                "Loading {} from cached archive at '{}'",
+                tool_version("pnpm", &version),
+                cache_file.display()
+            );
+            (archive, None)
+        }
+        None => {
+            let staging = create_staging_file()?;
+            let remote_url = determine_remote_url(&version, hooks)?;
+            let archive = fetch_remote_distro(&version, &remote_url, staging.path())?;
+            (archive, Some(staging))
+        }
+    };
+
+    unpack_archive(archive, version)?;
+
+    if let Some(staging_file) = staging {
+        ensure_containing_dir_exists(&cache_file).with_context(|| {
+            ErrorKind::ContainingDirError {
+                path: cache_file.clone(),
+            }
+        })?;
+        staging_file
+            .persist(cache_file)
+            .with_context(|| ErrorKind::PersistInventoryError {
+                tool: "pnpm".into(),
+            })?;
+    }
+
+    Ok(())
+}
+
+/// Unpack the pnpm archive into the image directory so that it is ready for use
+fn unpack_archive(archive: Box<dyn Archive>, version: &Version) -> Fallible<()> {
+    let temp = create_staging_dir()?;
+    debug!("Unpacking pnpm into '{}'", temp.path().display());
+
+    let progress = progress_bar(
+        archive.origin(),
+        &tool_version("pnpm", version),
+        archive
+            .uncompressed_size()
+            .unwrap_or_else(|| archive.compressed_size()),
+    );
+    let version_string = version.to_string();
+
+    archive
+        .unpack(temp.path(), &mut |_, read| {
+            progress.inc(read as u64);
+        })
+        .with_context(|| ErrorKind::UnpackArchiveError {
+            tool: "pnpm".into(),
+            version: version_string.clone(),
+        })?;
+
+    let bin_path = temp.path().join("package").join("bin");
+    create_launcher(&bin_path, "pnpm")?;
+    create_launcher(&bin_path, "pnpx")?;
+
+    #[cfg(windows)]
+    {
+        create_cmd_launcher(&bin_path, "pnpm")?;
+        create_cmd_launcher(&bin_path, "pnpx")?;
+    }
+
+    let dest = volta_home()?.pnpm_image_dir(&version_string);
+    ensure_containing_dir_exists(&dest)
+        .with_context(|| ErrorKind::ContainingDirError { path: dest.clone() })?;
+
+    rename(temp.path().join("package"), &dest).with_context(|| ErrorKind::SetupToolImageError {
+        tool: "pnpm".into(),
+        version: version_string.clone(),
+        dir: dest.clone(),
+    })?;
+
+    progress.finish_and_clear();
+
+    // Note: We write this after the progress bar is finished to avoid display bugs with re-renders of the progress
+    debug!("Installing pnpm in '{}'", dest.display());
+
+    Ok(())
+}
+
+/// Return the archive if it is valid. It may have been corrupted or interrupted in the middle of
+/// downloading.
+/// ISSUE(#134) - verify checksum
+fn load_cached_distro(file: &PathBuf) -> Option<Box<dyn Archive>> {
+    let file = File::open(file).ok()?;
+    Tarball::load(file).ok()
+}
+
+/// Determine the remote URL to download from, using the hooks if avaialble
+fn determine_remote_url(version: &Version, hooks: Option<&ToolHooks<Pnpm>>) -> Fallible<String> {
+    let version_str = version.to_string();
+    match hooks {
+        Some(&ToolHooks {
+            distro: Some(ref hook),
+            ..
+        }) => {
+            debug!("Using pnpm.distro hook to determine download URL");
+            let distro_file_name = Pnpm::archive_filename(&version_str);
+            hook.resolve(&version, &distro_file_name)
+        }
+        _ => Ok(public_registry_package("pnpm", &version_str)),
+    }
+}
+
+/// Fetch the distro archive from the internet
+fn fetch_remote_distro(
+    version: &Version,
+    url: &str,
+    staging_path: &Path,
+) -> Fallible<Box<dyn Archive>> {
+    debug!("Downloading {} from {}", tool_version("pnpm", version), url);
+    Tarball::fetch(url, staging_path).with_context(download_tool_error(
+        tool::Spec::Pnpm(VersionSpec::Exact(version.clone())),
+        url,
+    ))
+}
+
+/// Create the launcher script
+fn create_launcher(base_path: &Path, tool: &str) -> Fallible<()> {
+    let path = base_path.join(tool);
+    write(
+        &path,
+        // Note: Adapted from the existing npm/npx launcher, without unnecessary detection of Node location
+        format!(
+            r#"#!/bin/sh
+(set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
+
+basedir=`dirname "$0"`
+
+case `uname` in
+    *CYGWIN*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+node "$basedir/{}.js" "$@"
+"#,
+            tool
+        ),
+    )
+    .and_then(|_| set_executable(&path))
+    .with_context(|| ErrorKind::WriteLauncherError { tool: tool.into() })
+}
+
+/// Create the CMD launcher
+#[cfg(windows)]
+fn create_cmd_launcher(base_path: &Path, tool: &str) -> Fallible<()> {
+    write(
+        base_path.join(format!("{}.cmd", tool)),
+        // Note: Adapted from the existing npm/npx cmd launcher, without unnecessary detection of Node location
+        format!(
+            r#"@ECHO OFF
+
+node "%~dp0\{}.js" %*
+"#,
+            tool
+        ),
+    )
+    .with_context(|| ErrorKind::WriteLauncherError { tool: tool.into() })
+}

--- a/crates/volta-core/src/tool/pnpm/mod.rs
+++ b/crates/volta-core/src/tool/pnpm/mod.rs
@@ -1,30 +1,55 @@
 use std::fmt;
 
-use super::Tool;
+use super::{check_fetched, debug_already_fetched, info_fetched, FetchStatus, Tool};
 use crate::error::Fallible;
+use crate::inventory::pnpm_available;
 use crate::session::Session;
+use crate::style::tool_version;
 use semver::Version;
 
+mod fetch;
 mod resolve;
 
 pub use resolve::resolve;
 
-pub struct Pnpm {}
+pub struct Pnpm {
+    pub(super) version: Version,
+}
 
 impl Pnpm {
-    pub fn new(_version: Version) -> Self {
-        println!("Found version: {}", _version.to_string());
-        todo!();
+    pub fn new(version: Version) -> Self {
+        Pnpm { version }
+    }
+
+    pub fn archive_basename(version: &str) -> String {
+        format!("pnpm-{}", version)
+    }
+
+    pub fn archive_filename(version: &str) -> String {
+        format!("{}.tgz", Pnpm::archive_basename(version))
+    }
+
+    pub(crate) fn ensure_fetched(&self, session: &mut Session) -> Fallible<()> {
+        match check_fetched(|| pnpm_available(&self.version))? {
+            FetchStatus::AlreadyFetched => {
+                debug_already_fetched(self);
+                Ok(())
+            }
+            FetchStatus::FetchNeeded(_lock) => fetch::fetch(&self.version, session.hooks()?.pnpm()),
+        }
     }
 }
 
 impl Tool for Pnpm {
-    fn fetch(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
-        todo!()
+    fn fetch(self: Box<Self>, session: &mut Session) -> Fallible<()> {
+        self.ensure_fetched(session)?;
+
+        info_fetched(self);
+        Ok(())
     }
 
     fn install(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
-        todo!()
+        todo!();
     }
 
     fn pin(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
@@ -33,7 +58,22 @@ impl Tool for Pnpm {
 }
 
 impl fmt::Display for Pnpm {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        todo!();
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&tool_version("pnpm", &self.version))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pnpm_archive_basename() {
+        assert_eq!(Pnpm::archive_basename("3.4.1"), "pnpm-3.4.1");
+    }
+
+    #[test]
+    fn test_pnpm_archive_filename() {
+        assert_eq!(Pnpm::archive_filename("3.2.4"), "pnpm-3.2.4.tgz");
     }
 }

--- a/crates/volta-core/src/tool/pnpm/mod.rs
+++ b/crates/volta-core/src/tool/pnpm/mod.rs
@@ -1,0 +1,39 @@
+use std::fmt;
+
+use super::Tool;
+use crate::error::Fallible;
+use crate::session::Session;
+use semver::Version;
+
+mod resolve;
+
+pub use resolve::resolve;
+
+pub struct Pnpm {}
+
+impl Pnpm {
+    pub fn new(_version: Version) -> Self {
+        println!("Found version: {}", _version.to_string());
+        todo!();
+    }
+}
+
+impl Tool for Pnpm {
+    fn fetch(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
+        todo!()
+    }
+
+    fn install(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
+        todo!()
+    }
+
+    fn pin(self: Box<Self>, _session: &mut Session) -> Fallible<()> {
+        todo!()
+    }
+}
+
+impl fmt::Display for Pnpm {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        todo!();
+    }
+}

--- a/crates/volta-core/src/tool/pnpm/resolve.rs
+++ b/crates/volta-core/src/tool/pnpm/resolve.rs
@@ -1,0 +1,85 @@
+use super::super::registry::{
+    public_registry_index, PackageDetails, PackageIndex, RawPackageMetadata,
+    NPM_ABBREVIATED_ACCEPT_HEADER,
+};
+use super::super::registry_fetch_error;
+use super::Pnpm;
+use crate::error::{Context, ErrorKind, Fallible};
+use crate::hook::ToolHooks;
+use crate::session::Session;
+use crate::style::progress_spinner;
+use crate::version::{VersionSpec, VersionTag};
+use attohttpc::header::ACCEPT;
+use attohttpc::Response;
+use log::debug;
+use semver::{Version, VersionReq};
+
+pub fn resolve(matching: VersionSpec, session: &mut Session) -> Fallible<Version> {
+    let hooks = session.hooks()?.pnpm();
+    match matching {
+        VersionSpec::Semver(requirement) => resolve_semver(requirement, hooks),
+        VersionSpec::Exact(version) => Ok(version),
+        VersionSpec::None => resolve_tag(VersionTag::Latest, hooks),
+        VersionSpec::Tag(tag) => resolve_tag(tag, hooks),
+    }
+}
+
+fn resolve_tag(tag: VersionTag, hooks: Option<&ToolHooks<Pnpm>>) -> Fallible<Version> {
+    let (url, mut index) = fetch_pnpm_index(hooks)?;
+    let tag = tag.to_string();
+
+    match index.tags.remove(&tag) {
+        Some(version) => {
+            debug!("Found pnpm@{} matching tag '{}' from {}", version, tag, url);
+            Ok(version)
+        }
+        None => Err(ErrorKind::PnpmVersionNotFound { matching: tag }.into()),
+    }
+}
+
+fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Pnpm>>) -> Fallible<Version> {
+    let (url, index) = fetch_pnpm_index(hooks)?;
+
+    let details_opt = index
+        .entries
+        .into_iter()
+        .find(|PackageDetails { version, .. }| matching.matches(&version));
+
+    match details_opt {
+        Some(details) => {
+            debug!(
+                "Found npm@{} matching requirement '{}' from {}",
+                details.version, matching, url
+            );
+            Ok(details.version)
+        }
+        None => Err(ErrorKind::PnpmVersionNotFound {
+            matching: matching.to_string(),
+        }
+        .into()),
+    }
+}
+
+fn fetch_pnpm_index(hooks: Option<&ToolHooks<Pnpm>>) -> Fallible<(String, PackageIndex)> {
+    let url = match hooks {
+        Some(&ToolHooks {
+            index: Some(ref hook),
+            ..
+        }) => {
+            debug!("Using pnpm.index hook to determing pnpm index URL");
+            hook.resolve("pnpm")?
+        }
+        _ => public_registry_index("pnpm"),
+    };
+
+    let spinner = progress_spinner(&format!("Fetching public registry: {}", url));
+    let metadata: RawPackageMetadata = attohttpc::get(&url)
+        .header(ACCEPT, NPM_ABBREVIATED_ACCEPT_HEADER)
+        .send()
+        .and_then(Response::error_for_status)
+        .and_then(Response::json)
+        .with_context(registry_fetch_error("pnpm", &url))?;
+
+    spinner.finish_and_clear();
+    Ok((url, metadata.into()))
+}

--- a/crates/volta-core/src/tool/serial.rs
+++ b/crates/volta-core/src/tool/serial.rs
@@ -20,6 +20,8 @@ impl Spec {
         match tool_name {
             "node" => Spec::Node(version),
             "npm" => Spec::Npm(version),
+            #[cfg(feature = "pnpm")]
+            "pnpm" => Spec::Pnpm(version),
             "yarn" => Spec::Yarn(version),
             package => Spec::Package(package.to_string(), version),
         }
@@ -53,6 +55,8 @@ impl Spec {
         Ok(match name {
             "node" => Spec::Node(version),
             "npm" => Spec::Npm(version),
+            #[cfg(feature = "pnpm")]
+            "pnpm" => Spec::Pnpm(version),
             "yarn" => Spec::Yarn(version),
             package => Spec::Package(package.into(), version),
         })
@@ -125,6 +129,12 @@ impl Spec {
             (Spec::Npm(_), Spec::Npm(_)) => Ordering::Equal,
             (Spec::Npm(_), _) => Ordering::Less,
             (_, Spec::Npm(_)) => Ordering::Greater,
+            #[cfg(feature = "pnpm")]
+            (Spec::Pnpm(_), Spec::Pnpm(_)) => Ordering::Equal,
+            #[cfg(feature = "pnpm")]
+            (Spec::Pnpm(_), _) => Ordering::Less,
+            #[cfg(feature = "pnpm")]
+            (_, Spec::Pnpm(_)) => Ordering::Greater,
             (Spec::Yarn(_), Spec::Yarn(_)) => Ordering::Equal,
             (Spec::Yarn(_), _) => Ordering::Less,
             (_, Spec::Yarn(_)) => Ordering::Greater,

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -19,7 +19,7 @@ pub use resolve::resolve;
 
 /// The Tool implementation for fetching and installing Yarn
 pub struct Yarn {
-    pub(super) version: Version,
+    version: Version,
 }
 
 impl Yarn {

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -74,6 +74,8 @@ impl Toolchain {
                 self.platform = Some(PlatformSpec {
                     node: node_version.clone(),
                     npm: None,
+                    #[cfg(feature = "pnpm")]
+                    pnpm: None,
                     yarn: None,
                 });
                 dirty = true;
@@ -113,6 +115,24 @@ impl Toolchain {
             }
         } else if npm.is_some() {
             return Err(ErrorKind::NoDefaultNodeVersion { tool: "npm".into() }.into());
+        }
+
+        Ok(())
+    }
+
+    /// Set the active Pnpm version in the default platform file.
+    #[cfg(feature = "pnpm")]
+    pub fn set_active_pnpm(&mut self, pnpm: Option<Version>) -> Fallible<()> {
+        if let Some(platform) = self.platform.as_mut() {
+            if platform.pnpm != pnpm {
+                platform.pnpm = pnpm;
+                self.save()?;
+            }
+        } else if pnpm.is_some() {
+            return Err(ErrorKind::NoDefaultNodeVersion {
+                tool: "pnpm".into(),
+            }
+            .into());
         }
 
         Ok(())

--- a/crates/volta-layout/src/lib.rs
+++ b/crates/volta-layout/src/lib.rs
@@ -5,6 +5,8 @@ pub mod v0;
 pub mod v1;
 pub mod v2;
 pub mod v3;
+#[cfg(feature = "pnpm")]
+pub mod v4;
 
 fn executable(name: &str) -> String {
     format!("{}{}", name, std::env::consts::EXE_SUFFIX)

--- a/crates/volta-layout/src/v4.rs
+++ b/crates/volta-layout/src/v4.rs
@@ -1,0 +1,121 @@
+use std::path::PathBuf;
+
+use super::executable;
+use volta_layout_macro::layout;
+
+pub use crate::v1::VoltaInstall;
+
+layout! {
+    pub struct VoltaHome {
+        "cache": cache_dir {
+            "node": node_cache_dir {
+                "index.json": node_index_file;
+                "index.json.expires": node_index_expiry_file;
+            }
+        }
+        "bin": shim_dir {}
+        "log": log_dir {}
+        "tools": tools_dir {
+            "inventory": inventory_dir {
+                "node": node_inventory_dir {}
+                "npm": npm_inventory_dir {}
+                "pnpm": pnpm_inventory_dir {}
+                "yarn": yarn_inventory_dir {}
+            }
+            "image": image_dir {
+                "node": node_image_root_dir {}
+                "npm": npm_image_root_dir {}
+                "pnpm": pnpm_image_root_dir {}
+                "yarn": yarn_image_root_dir {}
+                "packages": package_image_root_dir {}
+            }
+            "shared": shared_lib_root {}
+            "user": default_toolchain_dir {
+                "bins": default_bin_dir {}
+                "packages": default_package_dir {}
+                "platform.json": default_platform_file;
+            }
+        }
+        "tmp": tmp_dir {}
+        "hooks.json": default_hooks_file;
+        "layout.v4": layout_file;
+    }
+}
+
+impl VoltaHome {
+    pub fn node_image_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_root_dir.clone(), node)
+    }
+
+    pub fn npm_image_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_root_dir.clone(), npm)
+    }
+
+    pub fn npm_image_bin_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_dir(npm), "bin")
+    }
+
+    pub fn pnpm_image_dir(&self, pnpm: &str) -> PathBuf {
+        path_buf!(self.pnpm_image_root_dir.clone(), pnpm)
+    }
+
+    pub fn pnpm_image_bin_dir(&self, pnpm: &str) -> PathBuf {
+        path_buf!(self.pnpm_image_dir(pnpm), "bin")
+    }
+
+    pub fn yarn_image_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_root_dir.clone(), version)
+    }
+
+    pub fn yarn_image_bin_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_dir(version), "bin")
+    }
+
+    pub fn package_image_dir(&self, name: &str) -> PathBuf {
+        path_buf!(self.package_image_root_dir.clone(), name)
+    }
+
+    pub fn default_package_config_file(&self, package_name: &str) -> PathBuf {
+        path_buf!(
+            self.default_package_dir.clone(),
+            format!("{}.json", package_name)
+        )
+    }
+
+    pub fn default_tool_bin_config(&self, bin_name: &str) -> PathBuf {
+        path_buf!(self.default_bin_dir.clone(), format!("{}.json", bin_name))
+    }
+
+    pub fn node_npm_version_file(&self, version: &str) -> PathBuf {
+        path_buf!(
+            self.node_inventory_dir.clone(),
+            format!("node-v{}-npm", version)
+        )
+    }
+
+    pub fn shim_file(&self, toolname: &str) -> PathBuf {
+        path_buf!(self.shim_dir.clone(), executable(toolname))
+    }
+
+    pub fn shared_lib_dir(&self, library: &str) -> PathBuf {
+        path_buf!(self.shared_lib_root.clone(), library)
+    }
+}
+
+#[cfg(windows)]
+impl VoltaHome {
+    pub fn shim_git_bash_script_file(&self, toolname: &str) -> PathBuf {
+        path_buf!(self.shim_dir.clone(), toolname)
+    }
+
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        self.node_image_dir(node)
+    }
+}
+
+#[cfg(unix)]
+impl VoltaHome {
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_dir(node), "bin")
+    }
+}

--- a/crates/volta-migrate/src/v3/config.rs
+++ b/crates/volta-migrate/src/v3/config.rs
@@ -42,6 +42,8 @@ impl From<LegacyPlatform> for PlatformSpec {
         PlatformSpec {
             node: config_platform.node.runtime,
             npm: config_platform.node.npm,
+            #[cfg(feature = "pnpm")]
+            pnpm: None,
             yarn: config_platform.yarn,
         }
     }

--- a/crates/volta-migrate/src/v4.rs
+++ b/crates/volta-migrate/src/v4.rs
@@ -1,0 +1,76 @@
+use std::convert::TryFrom;
+use std::fs::File;
+use std::path::PathBuf;
+
+use crate::empty::Empty;
+use crate::v3::V3;
+use log::debug;
+use volta_core::error::{Context, ErrorKind, Fallible, VoltaError};
+use volta_core::fs::remove_file_if_exists;
+use volta_layout::v4;
+
+/// Represents a V3 Volta layout (used by Volta v0.9.0 and above)
+///
+/// Holds a reference to the V3 layout struct to support future migrations
+pub struct V4 {
+    pub home: v4::VoltaHome,
+}
+
+impl V4 {
+    pub fn new(home: PathBuf) -> Self {
+        V4 {
+            home: v4::VoltaHome::new(home),
+        }
+    }
+
+    /// Write the layout file to mark migration to V2 as complete
+    ///
+    /// Should only be called once all other migration steps are finished, so that we don't
+    /// accidentally mark an incomplete migration as completed
+    fn complete_migration(home: v4::VoltaHome) -> Fallible<Self> {
+        debug!("Writing layout marker file");
+        File::create(home.layout_file()).with_context(|| ErrorKind::CreateLayoutFileError {
+            file: home.layout_file().to_owned(),
+        })?;
+
+        Ok(V4 { home })
+    }
+}
+
+impl TryFrom<Empty> for V4 {
+    type Error = VoltaError;
+
+    fn try_from(old: Empty) -> Fallible<Self> {
+        debug!("New Volta installation detected, creating fresh layout");
+
+        let home = v4::VoltaHome::new(old.home);
+        home.create().with_context(|| ErrorKind::CreateDirError {
+            dir: home.root().to_owned(),
+        })?;
+
+        V4::complete_migration(home)
+    }
+}
+
+impl TryFrom<V3> for V4 {
+    type Error = VoltaError;
+
+    fn try_from(old: V3) -> Fallible<Self> {
+        debug!("Migrating from V3 layout");
+
+        let new_home = v4::VoltaHome::new(old.home.root().to_owned());
+        new_home
+            .create()
+            .with_context(|| ErrorKind::CreateDirError {
+                dir: new_home.root().to_owned(),
+            })?;
+
+        // Complete the migration, writing the V3 layout file
+        let layout = V4::complete_migration(new_home)?;
+
+        // Remove the V2 layout file, since we're now on V3 (do this after writing the V3 file so that we know the migration succeeded)
+        remove_file_if_exists(old.home.layout_file())?;
+
+        Ok(layout)
+    }
+}

--- a/tests/acceptance/migrations.rs
+++ b/tests/acceptance/migrations.rs
@@ -43,6 +43,10 @@ fn empty_volta_home_is_created() {
         assert!(Sandbox::shim_exists("yarn"));
         assert!(Sandbox::shim_exists("npm"));
         assert!(Sandbox::shim_exists("npx"));
+        #[cfg(feature = "pnpm")]
+        assert!(Sandbox::shim_exists("pnpm"));
+        #[cfg(feature = "pnpm")]
+        assert!(Sandbox::shim_exists("pnpx"));
     }
 }
 
@@ -93,6 +97,10 @@ fn legacy_v0_volta_home_is_upgraded() {
         assert!(Sandbox::shim_exists("yarn"));
         assert!(Sandbox::shim_exists("npm"));
         assert!(Sandbox::shim_exists("npx"));
+        #[cfg(feature = "pnpm")]
+        assert!(Sandbox::shim_exists("pnpm"));
+        #[cfg(feature = "pnpm")]
+        assert!(Sandbox::shim_exists("pnpx"));
     }
 }
 
@@ -166,6 +174,10 @@ fn tagged_v1_volta_home_is_upgraded() {
         assert!(Sandbox::shim_exists("yarn"));
         assert!(Sandbox::shim_exists("npm"));
         assert!(Sandbox::shim_exists("npx"));
+        #[cfg(feature = "pnpm")]
+        assert!(Sandbox::shim_exists("pnpm"));
+        #[cfg(feature = "pnpm")]
+        assert!(Sandbox::shim_exists("pnpx"));
     }
 }
 

--- a/tests/acceptance/migrations.rs
+++ b/tests/acceptance/migrations.rs
@@ -30,7 +30,10 @@ fn empty_volta_home_is_created() {
     assert!(Sandbox::path_exists(".volta/tools/user"));
 
     // Layout file should now exist
+    #[cfg(not(feature = "pnpm"))]
     assert!(Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -58,6 +61,8 @@ fn legacy_v0_volta_home_is_upgraded() {
     // Layout file is not there
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
     assert!(!Sandbox::path_exists(".volta/layout.v2"));
+    #[cfg(feature = "pnpm")]
+    assert!(!Sandbox::path_exists(".volta/layout.v3"));
 
     // running volta should not create anything else
     assert_that!(s.volta("--version"), execs().with_status(0));
@@ -73,7 +78,12 @@ fn legacy_v0_volta_home_is_upgraded() {
     // Most recent layout file should exist, others should not
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
     assert!(!Sandbox::path_exists(".volta/layout.v2"));
+    #[cfg(not(feature = "pnpm"))]
     assert!(Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(!Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -141,7 +151,12 @@ fn tagged_v1_volta_home_is_upgraded() {
     // Most recent layout file should exist, others should not
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
     assert!(!Sandbox::path_exists(".volta/layout.v2"));
+    #[cfg(not(feature = "pnpm"))]
     assert!(Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(!Sandbox::path_exists(".volta/layout.v3"));
+    #[cfg(feature = "pnpm")]
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -206,6 +221,7 @@ fn tagged_v1_to_v2_keeps_migrated_node_images() {
 }
 
 #[test]
+#[cfg(not(feature = "pnpm"))]
 fn current_v3_volta_home_is_unchanged() {
     let s = sandbox().layout_file("v3").build();
 
@@ -223,6 +239,31 @@ fn current_v3_volta_home_is_unchanged() {
     // everything should be the same as before running the command
     assert!(Sandbox::path_exists(".volta"));
     assert!(Sandbox::path_exists(".volta/layout.v3"));
+    assert!(Sandbox::path_exists(".volta/cache/node"));
+    assert!(Sandbox::path_exists(".volta/tmp"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
+}
+
+#[test]
+#[cfg(feature = "pnpm")]
+fn current_v4_volta_home_is_unchanged() {
+    let s = sandbox().layout_file("v4").build();
+
+    // directories that are already created by the test framework
+    assert!(Sandbox::path_exists(".volta"));
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
+    assert!(Sandbox::path_exists(".volta/cache/node"));
+    assert!(Sandbox::path_exists(".volta/tmp"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
+    assert!(Sandbox::path_exists(".volta/tools/inventory/yarn"));
+
+    // running volta should not create anything else
+    assert_that!(s.volta("--version"), execs().with_status(0));
+
+    // everything should be the same as before running the command
+    assert!(Sandbox::path_exists(".volta"));
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));

--- a/tests/acceptance/volta_install.rs
+++ b/tests/acceptance/volta_install.rs
@@ -7,6 +7,7 @@ use test_support::matchers::execs;
 
 use volta_core::error::ExitCode;
 
+#[cfg(not(feature = "pnpm"))]
 fn platform_with_node(node: &str) -> String {
     format!(
         r#"{{
@@ -20,6 +21,22 @@ fn platform_with_node(node: &str) -> String {
     )
 }
 
+#[cfg(feature = "pnpm")]
+fn platform_with_node(node: &str) -> String {
+    format!(
+        r#"{{
+  "node": {{
+    "runtime": "{}",
+    "npm": null
+  }},
+  "pnpm": null,
+  "yarn": null
+}}"#,
+        node
+    )
+}
+
+#[cfg(not(feature = "pnpm"))]
 fn platform_with_node_npm(node: &str, npm: &str) -> String {
     format!(
         r#"{{
@@ -27,6 +44,21 @@ fn platform_with_node_npm(node: &str, npm: &str) -> String {
     "runtime": "{}",
     "npm": "{}"
   }},
+  "yarn": null
+}}"#,
+        node, npm
+    )
+}
+
+#[cfg(feature = "pnpm")]
+fn platform_with_node_npm(node: &str, npm: &str) -> String {
+    format!(
+        r#"{{
+  "node": {{
+    "runtime": "{}",
+    "npm": "{}"
+  }},
+  "pnpm": null,
   "yarn": null
 }}"#,
         node, npm


### PR DESCRIPTION
Info
-----
* With installing and pinning `pnpm` working, we now need to make sure that the shims are created and will execute correctly.

Changes
-----
* Updated the `run` module to support executing `pnpm` shims specifically, separate from the binary shims.
* Also ensure that `pnpm` and `pnpx` shims are automatically created, in the same manner as `npm` and `yarn` shims.

Notes
-----
* This explicitly does _not_ implement global install interception for `pnpm`, that will be added in a follow-up PR
* This PR builds on #879 and so will remain a draft until that is merged. To see the changes from only this PR, use [this link](https://github.com/volta-cli/volta/pull/880/commits/961a8d9f2b1b07cf9dd98417d23eb6d4f2b967bd)