### PR TITLE
Update Dockerfile to redirect yum to vault.centos.org

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -1,4 +1,8 @@
-FROM centos:6
+FROM centos:6.10
+
+# CentOS 6 packages are no longer hosted on the main repository, instead they are in the CentOS Vault
+RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Base.repo && \
+    sed -i 's/#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever/baseurl=http:\/\/vault.centos.org\/6.10/g' /etc/yum.repos.d/CentOS-Base.repo
 
 # Set up additional build tools
 RUN yum -y update && yum clean all


### PR DESCRIPTION
Info
-----
* The Dockerfile used to build the Linux versions of Volta is no longer working.
* It appears that the CentOS 6 packages are no longer hosted on `mirror.centos.org` and so must instead be downloaded from `vault.centos.org`

Changes
-----
* Updated the Dockerfile to use a specific version of CentOS 6 (6.10, which is the same that it was using when the tag was just `6`)
* Added commands to modify the repo and point it to `vault.centos.org` instead of using a list of mirrors.

Tested
-----
* Confirmed locally that the docker image builds successfully