### PR TITLE
Clean up warnings from clippy

### DIFF
--- a/crates/volta-core/src/tool/node/resolve.rs
+++ b/crates/volta-core/src/tool/node/resolve.rs
@@ -215,8 +215,8 @@ fn read_cached_opt(url: &str) -> Fallible<Option<RawNodeIndex>> {
                 })?;
 
             if let Some(content) = cached {
-                if content.starts_with(url) {
-                    return serde_json::de::from_str(&content[url.len()..])
+                if let Some(json) = content.strip_prefix(url) {
+                    return serde_json::de::from_str(json)
                         .with_context(|| ErrorKind::ParseNodeIndexCacheError);
                 }
             }

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -139,7 +139,7 @@ impl DirectInstall {
         let name = self
             .manager
             .get_installed_package(self.staging.path().to_owned())
-            .ok_or_else(|| ErrorKind::InstalledPackageNameError)?;
+            .ok_or(ErrorKind::InstalledPackageNameError)?;
         let manifest =
             configure::parse_manifest(&name, self.staging.path().to_owned(), self.manager)?;
 

--- a/crates/volta-core/src/version/mod.rs
+++ b/crates/volta-core/src/version/mod.rs
@@ -109,10 +109,9 @@ pub fn parse_version(s: impl AsRef<str>) -> Fallible<Version> {
 // remove the leading 'v' from the version string, if present
 fn trim_version(s: &str) -> &str {
     let s = s.trim();
-    if s.starts_with('v') {
-        s[1..].trim()
-    } else {
-        s
+    match s.strip_prefix('v') {
+        Some(stripped) => stripped,
+        None => s,
     }
 }
 


### PR DESCRIPTION
Info
-----
* The latest clippy is showing a few new warnings to clean up in the code

Changes
-----
* Updated code to conform to clippy's suggested style

Tested
-----
* All tests continue to pass
* Manually verified that the Node index cache still respects the `url` and that the `version_serde` deserializer still strips a single preceding `v` character.