### PR TITLE
[Small] Better handling for global commands without arguments

### DIFF
--- a/tests/acceptance/direct_install.rs
+++ b/tests/acceptance/direct_install.rs
@@ -317,6 +317,23 @@ fn npm_global_install_supports_multiples() {
 }
 
 #[test]
+fn npm_global_install_without_packages_is_treated_as_not_global() {
+    let s = sandbox()
+        .platform(&platform_with_node("10.99.1040"))
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.npm("i --global"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_does_not_contain("[..]Volta is processing each package separately")
+    );
+}
+
+#[test]
 fn yarn_global_add_supports_multiples() {
     let s = sandbox()
         .platform(&platform_with_node("10.99.1040"))
@@ -338,6 +355,25 @@ fn yarn_global_add_supports_multiples() {
             .with_stdout_contains("[..]installed and set npm@8.1.5 as default")
             .with_stdout_contains("[..]using Volta to install Yarn")
             .with_stdout_contains("[..]installed and set yarn@1.12.99 as default")
+    );
+}
+
+#[test]
+fn yarn_global_add_without_packages_is_treated_as_not_global() {
+    let s = sandbox()
+        .platform(&platform_with_node_yarn("10.99.1040", "1.2.42"))
+        .node_available_versions(NODE_VERSION_INFO)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .yarn_available_versions(YARN_VERSION_INFO)
+        .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "info")
+        .build();
+
+    assert_that!(
+        s.yarn("global add"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stdout_does_not_contain("[..]Volta is processing each package separately")
     );
 }
 


### PR DESCRIPTION
Info
-----
* Currently, if a user runs a global install or uninstall without any package arguments (e.g. `npm i -g` or `yarn global remove`), we show:
```
note: Volta is processing each package separately
```
* However, since there are no arguments, we then effectively no-op by iterating over an empty list.
* This leads to a confusing situation where there's no feedback about success or failure to the user (and the return code is 0, indicating success).
* Since, in these situations, there aren't any tools for Volta to handle, we should treat it like a non-global situation and allow the underlying package manager to show whatever error it normally would when the user forgets the arguments.

Changes
-----
* Updated the parser for both npm and Yarn to handle the case of no package arguments and treat it like a non-global command.

Tested
-----
* Added new tests to cover this use case, confirming that the `note` text is _not_ shown.