### PR TITLE
[Large] Add support for 'npm link'

### DIFF
--- a/crates/volta-core/src/error/kind.rs
+++ b/crates/volta-core/src/error/kind.rs
@@ -222,6 +222,16 @@ pub enum ErrorKind {
     /// Thrown when default Yarn is not set
     NoDefaultYarn,
 
+    /// Thrown when `npm link` is called with a package that isn't available
+    NpmLinkMissingPackage {
+        package: String,
+    },
+
+    /// Thrown when `npm link` is called with a package that was not installed / linked with npm
+    NpmLinkWrongManager {
+        package: String,
+    },
+
     /// Thrown when there is no npm version matching the requested Semver/Tag
     NpmVersionNotFound {
         matching: String,
@@ -862,6 +872,20 @@ Use `volta install` to select a default version of a tool."
 
 Use `volta install yarn` to select a default version (see `volta help install` for more info)."
             ),
+            ErrorKind::NpmLinkMissingPackage { package } => write!(
+                f,
+                "Could not locate the package '{}'
+
+Please ensure it is available by running `npm link` in its source directory.",
+                package
+            ),
+            ErrorKind::NpmLinkWrongManager { package } => write!(
+                f,
+                "The package '{}' was not installed using npm and cannot be linked with `npm link`
+
+Please ensure it is linked with `npm link` or installed with `npm i -g {0}`.",
+                package
+            ),
             ErrorKind::NpmVersionNotFound { matching } => write!(
                 f,
                 r#"Could not find Node version matching "{}" in the version registry.
@@ -1338,6 +1362,8 @@ impl ErrorKind {
             ErrorKind::NoShellProfile { .. } => ExitCode::EnvironmentError,
             ErrorKind::NotInPackage => ExitCode::ConfigurationError,
             ErrorKind::NoDefaultYarn => ExitCode::ConfigurationError,
+            ErrorKind::NpmLinkMissingPackage { .. } => ExitCode::ConfigurationError,
+            ErrorKind::NpmLinkWrongManager { .. } => ExitCode::ConfigurationError,
             ErrorKind::NpmVersionNotFound { .. } => ExitCode::NoVersionMatch,
             ErrorKind::NpxNotAvailable { .. } => ExitCode::ExecutableNotFound,
             ErrorKind::PackageInstallFailed { .. } => ExitCode::UnknownError,

--- a/crates/volta-core/src/run/parser.rs
+++ b/crates/volta-core/src/run/parser.rs
@@ -2,7 +2,9 @@ use std::env;
 use std::ffi::OsStr;
 use std::iter::once;
 
-use super::executor::{Executor, InternalInstallCommand, PackageInstallCommand, UninstallCommand};
+use super::executor::{
+    Executor, InternalInstallCommand, PackageInstallCommand, PackageLinkCommand, UninstallCommand,
+};
 use crate::error::Fallible;
 use crate::platform::{Platform, PlatformSpec};
 use crate::tool::package::PackageManager;
@@ -261,7 +263,24 @@ impl<'a> LinkArgs<'a> {
             // If there are tools specified, then this represents a command to link a global
             // package into the current project. We handle each tool separately to support Volta's
             // package sandboxing.
-            todo!();
+            let common_args = self.common_args;
+            let manager = self.manager;
+
+            Ok(self
+                .tools
+                .into_iter()
+                .map(|tool| {
+                    let args = common_args.iter().chain(once(&tool));
+                    PackageLinkCommand::new(
+                        args,
+                        platform.clone(),
+                        manager,
+                        tool.to_string_lossy().to_string(),
+                    )
+                    .into()
+                })
+                .collect::<Vec<_>>()
+                .into())
         }
     }
 }

--- a/crates/volta-core/src/run/parser.rs
+++ b/crates/volta-core/src/run/parser.rs
@@ -139,17 +139,6 @@ impl<'a> CommandArg<'a> {
                     CommandArg::Global(GlobalCommand::Uninstall(UninstallArgs { tools }))
                 }
             }
-            (Some(link), maybe_tool) if link == "link" => {
-                let mut common_args = vec![link];
-                common_args.extend(args.iter().filter(is_flag).map(AsRef::as_ref));
-                let tools = maybe_tool.into_iter().chain(positionals).collect();
-
-                CommandArg::Intercepted(InterceptedCommand::Link(LinkArgs {
-                    manager: PackageManager::Yarn,
-                    common_args,
-                    tools,
-                }))
-            }
             _ => CommandArg::Standard,
         }
     }

--- a/crates/volta-core/src/run/yarn.rs
+++ b/crates/volta-core/src/run/yarn.rs
@@ -22,10 +22,20 @@ pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Exec
     let platform = match env::var_os(RECURSION_ENV_VAR) {
         Some(_) => None,
         None => {
-            if let CommandArg::Global(cmd) = CommandArg::for_yarn(args) {
-                if let Some(default_platform) = session.default_platform()? {
-                    return cmd.executor(default_platform);
+            match CommandArg::for_yarn(args) {
+                CommandArg::Global(cmd) => {
+                    // For globals, only intercept if the default platform exists
+                    if let Some(default_platform) = session.default_platform()? {
+                        return cmd.executor(default_platform);
+                    }
                 }
+                CommandArg::Intercepted(cmd) => {
+                    // For local commands, only intercept if a platform exists
+                    if let Some(platform) = Platform::current(session)? {
+                        return cmd.executor(platform);
+                    }
+                }
+                _ => {}
             }
 
             Platform::current(session)?

--- a/crates/volta-core/src/tool/package/manager.rs
+++ b/crates/volta-core/src/tool/package/manager.rs
@@ -81,7 +81,7 @@ impl PackageManager {
     }
 
     /// Modify a given `Command` to be set up for global installs, given the package root
-    pub(super) fn setup_global_command(self, command: &mut Command, package_root: PathBuf) {
+    pub fn setup_global_command(self, command: &mut Command, package_root: PathBuf) {
         command.env("npm_config_prefix", &package_root);
 
         if let PackageManager::Yarn = self {


### PR DESCRIPTION
Info
-----
* One of the main outstanding features prior to 1.0 release: Support for `npm link`, both to link the current project as a global _and_ to pull a global in as a link into the current project.
* The bare command (`npm link`) works similarly to a global install, except that internally npm create a symlink instead of copying the files into the global directory.
    * Notably, it _does_ hook up any bins of the current project as global binaries.
* The command with package arguments (`npm link my_package`) will install the global `my_package` into the current project as a symlink.

Changes
-----
* Updated the command interception parser to handle `npm link` both with and without additional arguments.
    * In the case that there are _no_ additional arguments, we can re-use the `PackageInstallCommand` executor, since an `npm link` is functionally the same as an `npm install --global`, except for the symlink behavior.
    * In the case that there _are_ arguments, we split the calls out and run them sequentially, similar to how we handle `npm i -g` with multiple arguments. This allows us to set the appropriate environment variables so that `npm link my_package` works as expected and can find the appropriate global package.
* Added a `PackageLinkCommand` executor which handles the second case above.
    * Using the name of an individual tool, we can set the `prefix` option so that `npm` will correctly locate the global link.
    * Also added some checks to confirm that the command will work and provide useful error messages / warnings for when things may go wrong.

Tested
-----
* Added unit tests to cover the parsing logic
* Acceptance tests will be added in a follow-up PR
* Local testing confirms that a local package can be linked to global and then linked into a separate package.

Notes
-----
* There is no support here for `yarn link`: `yarn link` has different semantics than `npm link`, as it uses a different store location that doesn't overlap with the global installs. Yarn also already uses a directory _outside_ of where it's installed to hold the links, so `yarn link` already works exactly as it was designed and doesn't need additional support from Volta.
* Support for `npm unlink` will be added in a follow-up PR