### PR TITLE
[Medium] Add support for 'npm unlink' 

### DIFF
--- a/crates/volta-core/src/run/yarn.rs
+++ b/crates/volta-core/src/run/yarn.rs
@@ -22,20 +22,11 @@ pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Exec
     let platform = match env::var_os(RECURSION_ENV_VAR) {
         Some(_) => None,
         None => {
-            match CommandArg::for_yarn(args) {
-                CommandArg::Global(cmd) => {
-                    // For globals, only intercept if the default platform exists
-                    if let Some(default_platform) = session.default_platform()? {
-                        return cmd.executor(default_platform);
-                    }
+            if let CommandArg::Global(cmd) = CommandArg::for_yarn(args) {
+                // For globals, only intercept if the default platform exists
+                if let Some(default_platform) = session.default_platform()? {
+                    return cmd.executor(default_platform);
                 }
-                CommandArg::Intercepted(cmd) => {
-                    // For local commands, only intercept if a platform exists
-                    if let Some(platform) = Platform::current(session)? {
-                        return cmd.executor(platform);
-                    }
-                }
-                _ => {}
             }
 
             Platform::current(session)?


### PR DESCRIPTION
Info
-----
* Follow-up to #888, adding support for the bare `npm unlink` command, which removes the current project from the global links.
* Only when executed with no arguments does `npm unlink` behave like this, all other times it is effectively an alias of `npm uninstall`.

Changes
-----
* Updated the parser to handle `npm unlink` with no package arguments and attempt to uninstall the current project.
* If there is no current project or it can't be determined, this will delegate to the normal `npm` behavior to show any errors.
* However, if we know the project, then this will use Volta's internal logic to handle the uninstall, making sure everything is cleaned up correctly.
* Also removed the `InterceptedCommand` logic from `run/yarn.rs`, since as noted in #888, `yarn link` and `yarn unlink` already work correctly and don't require Interception.

Tested
-----
* Added unit tests to the parser to confirm it handles `npm unlink` correctly both with and without arguments.
* Locally tested that calling `npm unlink` within a linked package correctly uninstalls the package from the globals.

Notes
-----
* This PR builds on #888 and so will remain a draft until that is merged. To see the changes from only this PR, use [this link](https://github.com/volta-cli/volta/pull/889/commits/2c047d211297e5a8efee75a590c34df4ee48d1c7)