### PR TITLE
[Small] Add smoke tests for `npm link` interception & behavior.

### DIFF
--- a/tests/smoke/main.rs
+++ b/tests/smoke/main.rs
@@ -15,6 +15,7 @@ cfg_if::cfg_if! {
     if #[cfg(all(unix, feature = "smoke-tests"))] {
         mod autodownload;
         mod direct_install;
+        mod npm_link;
         mod package_migration;
         mod support;
         mod volta_fetch;

--- a/tests/smoke/npm_link.rs
+++ b/tests/smoke/npm_link.rs
@@ -1,0 +1,61 @@
+use crate::support::temp_project::temp_project;
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+
+const PACKAGE_JSON: &str = r#"
+{
+    "name": "my-library",
+    "version": "1.0.0",
+    "bin": {
+        "mylibrary": "./index.js"
+    }
+}"#;
+
+const INDEX_JS: &str = r#"#!/usr/bin/env node
+
+console.log('VOLTA TEST');
+"#;
+
+#[test]
+fn link_unlink_local_project() {
+    let p = temp_project()
+        .package_json(PACKAGE_JSON)
+        .project_file("index.js", INDEX_JS)
+        .build();
+
+    // Install node to ensure npm is available
+    assert_that!(p.volta("install node@14.15.1"), execs().with_status(0));
+
+    // Link the current project as a global
+    assert_that!(p.npm("link"), execs().with_status(0));
+    // Executable should be available
+    assert!(p.shim_exists("mylibrary"));
+    assert!(p.package_is_installed("my-library"));
+    assert_that!(
+        p.exec_shim("mylibrary", ""),
+        execs().with_status(0).with_stdout_contains("VOLTA TEST")
+    );
+
+    // Unlink the current project
+    assert_that!(p.npm("unlink"), execs().with_status(0));
+    // Executable should no longer be available
+    assert!(!p.shim_exists("mylibrary"));
+    assert!(!p.package_is_installed("my-library"));
+}
+
+#[test]
+fn link_global_into_current_project() {
+    let p = temp_project().package_json(PACKAGE_JSON).build();
+
+    assert_that!(
+        p.volta("install node@12.19.1 typescript@4.1.2"),
+        execs().with_status(0)
+    );
+
+    // Link typescript into the current project
+    assert_that!(p.npm("link typescript"), execs().with_status(0));
+    // Typescript should now be available inside the node_modules directory
+    assert!(p.project_path_exists("node_modules/typescript"));
+    assert!(p.project_path_exists("node_modules/typescript/package.json"));
+}

--- a/tests/smoke/support/temp_project.rs
+++ b/tests/smoke/support/temp_project.rs
@@ -69,6 +69,13 @@ impl TempProjectBuilder {
         self
     }
 
+    /// Create a file in the project directory (chainable)
+    pub fn project_file(mut self, path: &str, contents: &str) -> Self {
+        let path = self.root().join(path);
+        self.files.push(FileBuilder::new(path, contents));
+        self
+    }
+
     /// Create a file in the `volta_home` directory (chainable)
     pub fn volta_home_file(mut self, path: &str, contents: &str) -> Self {
         let path = volta_home(self.root()).join(path);
@@ -394,6 +401,11 @@ impl TempProject {
     /// Verify that the input package version has been fetched.
     pub fn shim_exists(&self, name: &str) -> bool {
         shim_file(name, self.root()).exists()
+    }
+
+    /// Verify that a given path in the project directory exists
+    pub fn project_path_exists(&self, path: &str) -> bool {
+        self.root().join(path).exists()
     }
 }
 


### PR DESCRIPTION
Info
-----
* With `npm link` and `npm unlink` set up to work correctly, we want to make sure that behavior is covered by our test suite.
* Since the actual results depend on running `npm`, we need to use the smoke tests.

Changes
-----
* Added test for linking / unlinking the local project into a global, confirming that Volta correctly picks up the changes and makes them available.
* Added test for linking a globally installed package into the local project, confirming that Volta sets the environment up for the link to work correctly.

Notes
-----
* This PR builds on #889 and so will remain a draft until that is merged. To see only the changes from this PR, use [this link](https://github.com/volta-cli/volta/pull/891/commits/2b3279ffeed66d75c21f74ed7b04e47fcc9e6c5e)