### PR TITLE
Only show stdout and stderr of spawned process in dev mode

### DIFF
--- a/crates/volta-core/src/monitor.rs
+++ b/crates/volta-core/src/monitor.rs
@@ -46,8 +46,8 @@ fn spawn_process(command: &str) -> Option<Child> {
         child.args(command.split(' ').skip(1));
         child.stdin(Stdio::piped());
 
-        #[cfg(debug_assertions)]
-        // Only show stdout and stderr of spawned process in dev mode
+        #[cfg(not(debug_assertions))]
+        // Hide stdout and stderr of spawned process in release mode
         child.stdout(Stdio::null()).stderr(Stdio::null());
 
         match child.spawn() {


### PR DESCRIPTION
- Use `cfg!(debug_assertions)` to check if it's a dev build or release build.
- For dev build, pipe `stdout` and `stderr` of the `command` in `spawn_process`, so it's easier to debug.
- For release build, pipe `stdout` and `stderr` to "nowhere", so the spawn_process won't mess up with `stdout` of `volta` if there is any thing from `stdout` or `stderr`