### PR TITLE
Add detailed activity kind to event for node/yarn/npm/npx

### DIFF
--- a/crates/volta-core/src/run/node.rs
+++ b/crates/volta-core/src/run/node.rs
@@ -5,10 +5,11 @@ use super::executor::{Executor, ToolCommand, ToolKind};
 use super::{debug_active_image, debug_no_platform, RECURSION_ENV_VAR};
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{Platform, System};
-use crate::session::Session;
+use crate::session::{ActivityKind, Session};
 
 /// Build a `ToolCommand` for Node
 pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
+    session.add_event_start(ActivityKind::Node);
     // Don't re-evaluate the platform if this is a recursive call
     let platform = match env::var_os(RECURSION_ENV_VAR) {
         Some(_) => None,

--- a/crates/volta-core/src/run/npm.rs
+++ b/crates/volta-core/src/run/npm.rs
@@ -6,7 +6,7 @@ use super::parser::CommandArg;
 use super::{debug_active_image, debug_no_platform, RECURSION_ENV_VAR};
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{Platform, System};
-use crate::session::Session;
+use crate::session::{ActivityKind, Session};
 
 /// Build an `Executor` for npm
 ///
@@ -17,6 +17,7 @@ use crate::session::Session;
 /// If the command is _not_ a global install / uninstall or we don't have a default platform, then
 /// we will allow npm to execute the command as usual.
 pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
+    session.add_event_start(ActivityKind::Npm);
     // Don't re-evaluate the context or global install interception if this is a recursive call
     let platform = match env::var_os(RECURSION_ENV_VAR) {
         Some(_) => None,

--- a/crates/volta-core/src/run/npx.rs
+++ b/crates/volta-core/src/run/npx.rs
@@ -5,7 +5,7 @@ use super::executor::{Executor, ToolCommand, ToolKind};
 use super::{debug_active_image, debug_no_platform, RECURSION_ENV_VAR};
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{Platform, System};
-use crate::session::Session;
+use crate::session::{ActivityKind, Session};
 use lazy_static::lazy_static;
 use semver::Version;
 
@@ -16,6 +16,7 @@ lazy_static! {
 
 /// Build a `ToolCommand` for npx
 pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
+    session.add_event_start(ActivityKind::Npx);
     // Don't re-evaluate the context if this is a recursive call
     let platform = match env::var_os(RECURSION_ENV_VAR) {
         Some(_) => None,

--- a/crates/volta-core/src/run/yarn.rs
+++ b/crates/volta-core/src/run/yarn.rs
@@ -6,7 +6,7 @@ use super::parser::CommandArg;
 use super::{debug_active_image, debug_no_platform, RECURSION_ENV_VAR};
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{Platform, Source, System};
-use crate::session::Session;
+use crate::session::{ActivityKind, Session};
 
 /// Build an `Executor` for Yarn
 ///
@@ -17,6 +17,7 @@ use crate::session::Session;
 /// If the command is _not_ a global add / remove or we don't have a default platform, then
 /// we will allow Yarn to execute the command as usual.
 pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
+    session.add_event_start(ActivityKind::Yarn);
     // Don't re-evaluate the context or global install interception if this is a recursive call
     let platform = match env::var_os(RECURSION_ENV_VAR) {
         Some(_) => None,


### PR DESCRIPTION
Adding `ActivityKind::Node/Npm/Npx/Yarn` into the event list under `ActivityKind::Tool`

Example when run `node -v`:

```
[
    {"timestamp":1607565565134,"name":"tool","event":"start"}, 
    {"timestamp":1607565565134,"name":"node","event":"start"},
    {"timestamp":1607565565147,"name":"tool","event":{"end":{"exit_code":0}}}
]
```