### PR TITLE
[Large] Implement global upgrade interception

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: Production
 jobs:
   centos:
     name: Build - CentOS / RHEL
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
           - 1_1_0
           - 1_0_1
     name: Build - OpenSSL ${{ matrix.openssl }}
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/crates/volta-core/src/tool/package/mod.rs
+++ b/crates/volta-core/src/tool/package/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 use std::fs::create_dir_all;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use super::Tool;
@@ -119,6 +119,10 @@ impl Display for Package {
     }
 }
 
+/// Helper struct for direct installs through `npm i -g` or `yarn global add`
+///
+/// Provides methods to simplify installing into a staging directory and then moving that install
+/// into the proper location after it is complete.
 pub struct DirectInstall {
     staging: TempDir,
     manager: PackageManager,
@@ -146,9 +150,40 @@ impl DirectInstall {
 
         persist_install(&name, &manifest.version, self.staging.path())?;
         link_package_to_shared_dir(&name, self.manager)?;
-        configure::write_config_and_shims(&name, &manifest, image, self.manager)?;
+        configure::write_config_and_shims(&name, &manifest, image, self.manager)
+    }
+}
 
-        Ok(())
+/// Helper struct for direct in-place upgrades using `npm update -g` or `yarn global upgrade`
+///
+/// Upgrades the requested package directly in the image directory
+pub struct InPlaceUpgrade {
+    package: String,
+    directory: PathBuf,
+    manager: PackageManager,
+}
+
+impl InPlaceUpgrade {
+    pub fn new(package: String, manager: PackageManager) -> Fallible<Self> {
+        let directory = volta_home()?.package_image_dir(&package);
+
+        Ok(Self {
+            package,
+            directory,
+            manager,
+        })
+    }
+
+    pub fn setup_command(&self, command: &mut Command) {
+        self.manager
+            .setup_global_command(command, self.directory.clone());
+    }
+
+    pub fn complete_upgrade(self, image: &Image) -> Fallible<()> {
+        let manifest = configure::parse_manifest(&self.package, self.directory, self.manager)?;
+
+        link_package_to_shared_dir(&self.package, self.manager)?;
+        configure::write_config_and_shims(&self.package, &manifest, image, self.manager)
     }
 }
 

--- a/tests/smoke/direct_upgrade.rs
+++ b/tests/smoke/direct_upgrade.rs
@@ -1,0 +1,94 @@
+use crate::support::temp_project::temp_project;
+use hamcrest2::assert_that;
+use hamcrest2::prelude::*;
+use test_support::matchers::execs;
+use volta_core::error::ExitCode;
+
+#[test]
+fn npm_global_update() {
+    let p = temp_project().build();
+
+    // Install Node and typescript
+    assert_that!(
+        p.volta("install node@14.10.1 typescript@2.8.4"),
+        execs().with_status(0)
+    );
+    // Confirm correct version of typescript installed
+    assert_that!(
+        p.exec_shim("tsc", "--version"),
+        execs().with_status(0).with_stdout_contains("Version 2.8.4")
+    );
+
+    // Update typescript
+    assert_that!(p.npm("update --global typescript"), execs().with_status(0));
+    // Confirm update completed successfully
+    assert_that!(
+        p.exec_shim("tsc", "--version"),
+        execs().with_status(0).with_stdout_contains("Version 2.9.2")
+    );
+
+    // Revert typescript update
+    assert_that!(p.npm("i -g typescript@2.8.4"), execs().with_status(0));
+    // Update all packages (should include typescript)
+    assert_that!(p.npm("update --global"), execs().with_status(0));
+    // Confirm update
+    assert_that!(
+        p.exec_shim("tsc", "--version"),
+        execs().with_status(0).with_stdout_contains("Version 2.9.2")
+    );
+
+    // Confirm that attempting to upgrade using `yarn` fails
+    assert_that!(
+        p.yarn("global upgrade typescript"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]The package 'typescript' was installed using npm.")
+    );
+}
+
+#[test]
+fn yarn_global_update() {
+    let p = temp_project().build();
+
+    // Install Node and Yarn
+    assert_that!(
+        p.volta("install node@14.10.1 yarn@1.22.5"),
+        execs().with_status(0)
+    );
+    // Install typescript
+    assert_that!(
+        p.yarn("global add typescript@2.8.4"),
+        execs().with_status(0)
+    );
+    // Confirm correct version of typescript installed
+    assert_that!(
+        p.exec_shim("tsc", "--version"),
+        execs().with_status(0).with_stdout_contains("Version 2.8.4")
+    );
+
+    // Upgrade typescript
+    assert_that!(
+        p.yarn("global upgrade typescript@2.9"),
+        execs().with_status(0)
+    );
+    // Confirm upgrade completed successfully
+    assert_that!(
+        p.exec_shim("tsc", "--version"),
+        execs().with_status(0).with_stdout_contains("Version 2.9.2")
+    );
+
+    // Note: Since Yarn always installs the latest version that matches your requirements and
+    // 'upgrade' also gets the latest version that matches (which can change over time), an
+    // immediate call to 'yarn upgrade' without packages won't result in any change.
+
+    // This is in contrast to npm, which treats your installed version as a caret specifier when
+    // runnin `npm update`
+
+    // Confirm that attempting to upgrade using `npm` fails
+    assert_that!(
+        p.npm("update -g typescript"),
+        execs()
+            .with_status(ExitCode::ExecutionFailure as i32)
+            .with_stderr_contains("[..]The package 'typescript' was installed using Yarn.")
+    );
+}

--- a/tests/smoke/main.rs
+++ b/tests/smoke/main.rs
@@ -15,6 +15,7 @@ cfg_if::cfg_if! {
     if #[cfg(all(unix, feature = "smoke-tests"))] {
         mod autodownload;
         mod direct_install;
+        mod direct_upgrade;
         mod npm_link;
         mod package_migration;
         mod support;


### PR DESCRIPTION
Closes #850

Info
-----
* The last piece of global install interception is allowing users to upgrade their versions using the built-in commands from the package manager: `npm update --global` and `yarn global upgrade`.
* Due to Volta's package sandboxing, we need to intercept this command and set things up so that the package managers can correctly locate the packages to upgrade.
* Since the directory layout is different between the package managers, we also need to make sure that we only upgrade packages installed by the package manager being invoked.
* Finally, running `npm update -g` or `yarn global upgrade` without any package arguments attempts to upgrade _all_ installed global packages, so we need to provide support for that behavior.


Changes
-----
* Added interception for the global upgrade commands in both Node and Yarn.
* Added support for upgrading the appropriate packages directly in the Volta directory (since the package manager needs to know what's already installed there to figure out what to upgrade).
* When run without arguments, pull the packages to upgrade from Volta's inventory of installed packages, choosing only those that were installed with the same package manager.
* Provide a nice error / CTA when a package either couldn't be found or was installed with a different package manager.

Tested
-----
* Local testing to confirm the package managers can locate packages to upgrade both when provided arguments or without.
* Local testing to make sure errors are shown when attempting to upgrade a package with the wrong package manager.
* Added smoke tests to verify the basic upgrade behavior.

Notes
-----
* This PR builds on #891 and so will remain a draft until that is merged. To see the changes from only this PR, use [this link](https://github.com/volta-cli/volta/pull/895/files/2b3279ffeed66d75c21f74ed7b04e47fcc9e6c5e..10d36b47c3fcdea2c9d249c25ace92f7db352359)