### PR TITLE
Sign Windows Installer after creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,24 @@ jobs:
         with:
           command: wix
           args: --nocapture --output target\wix\volta-windows.msi
+      - name: Load Certificate File
+        id: certificate_file
+        if: github.event_name == 'push'
+        uses: timheuer/base64-to-file@v1
+        with:
+          fileName: 'volta-certificate.pfx'
+          encodedString: ${{ secrets.INSTALLER_CERTIFICATE }}
+      - name: Sign Installer
+        if: github.event_name == 'push'
+        env:
+          CERTIFICATE_FILE: ${{ steps.certificate_file.outputs.filePath }}
+          CERTIFICATE_PASSWORD: ${{ secrets.INSTALLER_CERTIFICATE_PASSWORD }}
+        run: |
+          & "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool.exe" sign /fd sha256 /f "$env:CERTIFICATE_FILE" /p "$env:CERTIFICATE_PASSWORD" /tr http://ts.ssl.com /td sha256 /d "Volta: Start Your Engines" /du "https://volta.sh" "target\wix\volta-windows.msi"
+      - name: Verify Signature
+        if: github.event_name == 'push'
+        run: |
+          & "C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool.exe" verify /pa "target\wix\volta-windows.msi"
       - name: Create zip of binaries
         run: powershell Compress-Archive volta*.exe volta-windows.zip
         working-directory: ./target/release


### PR DESCRIPTION
Info
-----
* As part of the run-up to the 1.0 release, we want to digitally sign the Windows installer so that it can gain reputation and eventually prevent the SmartScreen errors.
* Since the build artifacts are created during CI runs, we need the signature to happen there too.

Changes
-----
* Added the certificate and password to the repo's secrets.
* Updated CI to fetch the certificate and sign the `.msi` installer file during a release build (this has to be triggered by pushing a tag, it won't happen in PR builds, which don't have access to the secrets).

Tested
-----
* Confirmed that the built artifact is correctly signed.

Notes
-----
* Due to how Microsoft SmartScreen works, even though the installer is signed, it will require an unknown number of actual installs to establish reputation and bypass the SmartScreen warning.