### PR TITLE
v0.9.99

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2040,7 +2040,7 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "volta"
-version = "0.9.3"
+version = "0.9.99"
 dependencies = [
  "atty",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volta"
-version = "0.9.3"
+version = "0.9.99"
 authors = ["David Herman <david.herman@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/volta-cli/volta"


### PR DESCRIPTION
This is the release candidate for v1.0.0. Due to limitation of the Windows installer and our existing install script, tagging it as `0.9.99` instead of `1.0.0-rc1`. It will also be marked as a "Pre-release" version in the releases list.