### PR TITLE
Replace Platform::from_json with TryFrom trait implementation

### DIFF
--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -1,4 +1,3 @@
-use std::convert::From;
 use std::convert::TryFrom;
 use std::fs::write;
 

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -1,3 +1,5 @@
+use std::convert::From;
+use std::convert::TryFrom;
 use std::fs::write;
 
 use crate::error::{Context, ErrorKind, Fallible};
@@ -48,7 +50,7 @@ impl Toolchain {
                 file: path.to_owned(),
             })?;
 
-        let platform = serial::Platform::from_json(src)?.into_platform();
+        let platform = serial::Platform::try_from(src)?.into_platform();
         if platform.is_some() {
             debug!("Found default configuration at '{}'", path.display());
         }

--- a/crates/volta-migrate/src/v2.rs
+++ b/crates/volta-migrate/src/v2.rs
@@ -105,7 +105,7 @@ fn clear_default_npm(platform_file: &Path) -> Fallible<()> {
             }
         }
     };
-    let mut existing_platform = Platform::from_json(platform_json)?;
+    let mut existing_platform = Platform::try_from(platform_json)?;
 
     if let Some(ref mut node_version) = &mut existing_platform.node {
         if let Some(npm) = &node_version.npm {


### PR DESCRIPTION
Replace `Platform::from_json` with `Platform::try_from`, implement `TryFrom<String>` trait.

This is an attempt at part of https://github.com/volta-cli/volta/issues/489.

I'm aware that this may not be what was intended in #489. I'm prepared to accept that feedback and close if that's the case 🙂 

One drawback is that `try_from` doesn't mention JSON, whereas `from_json` clearly expects a JSON string.