### PR TITLE
Replace Platform::into_platform with Into implementation

### DIFF
--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -1,4 +1,3 @@
-use std::convert::Into;
 use std::convert::TryFrom;
 use std::fs::write;
 

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -1,3 +1,4 @@
+use std::convert::Into;
 use std::convert::TryFrom;
 use std::fs::write;
 
@@ -49,7 +50,7 @@ impl Toolchain {
                 file: path.to_owned(),
             })?;
 
-        let platform = serial::Platform::try_from(src)?.into_platform();
+        let platform: Option<PlatformSpec> = serial::Platform::try_from(src)?.into();
         if platform.is_some() {
             debug!("Found default configuration at '{}'", path.display());
         }

--- a/crates/volta-core/src/toolchain/serial.rs
+++ b/crates/volta-core/src/toolchain/serial.rs
@@ -54,10 +54,10 @@ impl TryFrom<String> for Platform {
     }
 }
 
-impl Into<Option<PlatformSpec>> for Platform {
-    fn into(self) -> Option<PlatformSpec> {
-        let yarn = self.yarn;
-        self.node.map(|node_version| PlatformSpec {
+impl From<Platform> for Option<PlatformSpec> {
+    fn from(platform: Platform) -> Option<PlatformSpec> {
+        let yarn = platform.yarn;
+        platform.node.map(|node_version| PlatformSpec {
             node: node_version.runtime,
             npm: node_version.npm,
             yarn,

--- a/crates/volta-core/src/toolchain/serial.rs
+++ b/crates/volta-core/src/toolchain/serial.rs
@@ -1,6 +1,4 @@
 use crate::error::{Context, ErrorKind, Fallible, VoltaError};
-use std::convert::Into;
-
 use crate::platform::PlatformSpec;
 use crate::version::{option_version_serde, version_serde};
 use semver::Version;

--- a/crates/volta-core/src/toolchain/serial.rs
+++ b/crates/volta-core/src/toolchain/serial.rs
@@ -1,4 +1,6 @@
 use crate::error::{Context, ErrorKind, Fallible, VoltaError};
+use std::convert::Into;
+
 use crate::platform::PlatformSpec;
 use crate::version::{option_version_serde, version_serde};
 use semver::Version;
@@ -33,15 +35,6 @@ impl Platform {
         }
     }
 
-    pub fn into_platform(self) -> Option<PlatformSpec> {
-        let yarn = self.yarn;
-        self.node.map(|node_version| PlatformSpec {
-            node: node_version.runtime,
-            npm: node_version.npm,
-            yarn,
-        })
-    }
-
     /// Serialize the Platform to a JSON String
     pub fn into_json(self) -> Fallible<String> {
         serde_json::to_string_pretty(&self).with_context(|| ErrorKind::StringifyPlatformError)
@@ -58,6 +51,17 @@ impl TryFrom<String> for Platform {
         };
 
         result.with_context(|| ErrorKind::ParsePlatformError)
+    }
+}
+
+impl Into<Option<PlatformSpec>> for Platform {
+    fn into(self) -> Option<PlatformSpec> {
+        let yarn = self.yarn;
+        self.node.map(|node_version| PlatformSpec {
+            node: node_version.runtime,
+            npm: node_version.npm,
+            yarn,
+        })
     }
 }
 


### PR DESCRIPTION
Part of https://github.com/volta-cli/volta/issues/489

Replace into_platform with TryInto implementation. 

The first commit, 39e6d3a, includes a very simple change that implements `Into<Option<PlatformSpec>>`.

The second commit goes further and implements `TryInto<PlatformSpec>` that may result in a `VoltaError` of kind `ErrorKind::NoPlatform`. Implementing `TryInto` seems more idiomatic than implementing `into` to return an `Option`. I am very new to this codebase and a Rust novice, this may be going too far and the first commit may be sufficient.