### PR TITLE
Clean up new clippy warnings (1.49.0)

### DIFF
--- a/crates/volta-core/src/manifest/serial.rs
+++ b/crates/volta-core/src/manifest/serial.rs
@@ -85,7 +85,7 @@ impl From<RawBinManifest> for super::BinManifest {
         if let Some(ref bin) = raw.bin {
             for (name, path) in bin.iter() {
                 // handle case where only the path was given and binary name was unknown
-                if name == "" {
+                if name.is_empty() {
                     // npm uses the package name for the binary in this case
                     map.insert(raw.name.clone().unwrap(), path.clone());
                 } else {

--- a/crates/volta-core/src/tool/node/metadata.rs
+++ b/crates/volta-core/src/tool/node/metadata.rs
@@ -1,5 +1,4 @@
 use std::collections::HashSet;
-use std::iter::FromIterator;
 use std::str::FromStr;
 
 use crate::version::{option_version_serde, version_serde};
@@ -56,7 +55,7 @@ impl From<RawNodeIndex> for NodeIndex {
         for entry in raw.0 {
             if let Some(npm) = entry.npm {
                 let data = NodeDistroFiles {
-                    files: HashSet::from_iter(entry.files.into_iter()),
+                    files: entry.files.into_iter().collect(),
                 };
                 entries.push(NodeEntry {
                     version: entry.version,


### PR DESCRIPTION
A new Rust version comes with a couple of new Clippy warnings to clean up 🎉 