### PR TITLE
[Small] Check Node OS & Arch availability and support M1 native builds

### DIFF
--- a/crates/volta-core/src/tool/node/metadata.rs
+++ b/crates/volta-core/src/tool/node/metadata.rs
@@ -1,37 +1,19 @@
 use std::collections::HashSet;
-use std::str::FromStr;
 
+use super::NODE_DISTRO_IDENTIFIER;
 use crate::version::{option_version_serde, version_serde};
 use semver::Version;
 use serde::{Deserialize, Deserializer};
-use serde_json::Error;
 
 /// The index of the public Node server.
 pub struct NodeIndex {
     pub(super) entries: Vec<NodeEntry>,
 }
 
-impl FromStr for NodeIndex {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let raw: RawNodeIndex = serde_json::de::from_str(s)?;
-        Ok(raw.into())
-    }
-}
-
 #[derive(Debug)]
 pub struct NodeEntry {
     pub version: Version,
-    pub npm: Version,
-    pub files: NodeDistroFiles,
     pub lts: bool,
-}
-
-/// The set of available files on the public Node server for a given Node version.
-#[derive(Debug)]
-pub struct NodeDistroFiles {
-    pub files: HashSet<String>,
 }
 
 #[derive(Deserialize)]
@@ -44,27 +26,28 @@ pub struct RawNodeEntry {
     #[serde(default)] // handles Option
     #[serde(with = "option_version_serde")]
     npm: Option<Version>,
-    files: Vec<String>,
+    files: HashSet<String>,
     #[serde(deserialize_with = "lts_version_serde")]
     lts: bool,
 }
 
 impl From<RawNodeIndex> for NodeIndex {
     fn from(raw: RawNodeIndex) -> NodeIndex {
-        let mut entries = Vec::new();
-        for entry in raw.0 {
-            if let Some(npm) = entry.npm {
-                let data = NodeDistroFiles {
-                    files: entry.files.into_iter().collect(),
-                };
-                entries.push(NodeEntry {
-                    version: entry.version,
-                    npm,
-                    files: data,
-                    lts: entry.lts,
-                });
-            }
-        }
+        let entries = raw
+            .0
+            .into_iter()
+            .filter_map(|entry| {
+                if entry.npm.is_some() && entry.files.contains(NODE_DISTRO_IDENTIFIER) {
+                    Some(NodeEntry {
+                        version: entry.version,
+                        lts: entry.lts,
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect();
+
         NodeIndex { entries }
     }
 }

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -21,45 +21,67 @@ pub use fetch::load_default_npm_version;
 pub use resolve::resolve;
 
 cfg_if! {
-    if #[cfg(target_os = "windows")] {
-        /// The OS component of a Node distro's filename.
+    if #[cfg(all(target_os = "windows", target_arch = "x86"))] {
+        /// The OS component of a Node distro filename
         pub const NODE_DISTRO_OS: &str = "win";
-    } else if #[cfg(target_os = "macos")] {
-        /// The OS component of a Node distro's filename.
-        pub const NODE_DISTRO_OS: &str = "darwin";
-    } else if #[cfg(target_os = "linux")] {
-        /// The OS component of a Node distro's filename.
-        pub const NODE_DISTRO_OS: &str = "linux";
-    } else {
-        compile_error!("Unsupported operating system (expected Windows, macOS, or Linux).");
-    }
-}
-
-cfg_if! {
-    if #[cfg(target_arch = "x86")] {
-        /// The system architecture component of a Node distro's name.
+        /// The architecture component of a Node distro filename
         pub const NODE_DISTRO_ARCH: &str = "x86";
-    } else if #[cfg(target_arch = "x86_64")] {
-        /// The system architecture component of a Node distro's name.
-        pub const NODE_DISTRO_ARCH: &str = "x64";
-    } else if #[cfg(target_arch = "aarch64")] {
-        /// The system architecture component of a Node distro's name.
-        pub const NODE_DISTRO_ARCH: &str = "arm64";
-    } else if #[cfg(target_arch = "arm")] {
-        /// The system architecture component of a Node distro's name.
-        pub const NODE_DISTRO_ARCH: &str = "armv7l";
-    } else {
-        compile_error!("Unsupported target_arch variant (expected 'x86', 'x64', or 'aarch64').");
-    }
-}
-
-cfg_if! {
-    if #[cfg(target_os = "windows")] {
-        /// Filename extension for Node distro files.
+        /// The extension for Node distro files
         pub const NODE_DISTRO_EXTENSION: &str = "zip";
-    } else {
-        /// Filename extension for Node distro files.
+        /// The file identifier in the Node index `files` array
+        pub const NODE_DISTRO_IDENTIFIER: &str = "win-x86-zip";
+    } else if #[cfg(all(target_os = "windows", target_arch = "x86_64"))] {
+        /// The OS component of a Node distro filename
+        pub const NODE_DISTRO_OS: &str = "win";
+        /// The architecture component of a Node distro filename
+        pub const NODE_DISTRO_ARCH: &str = "x64";
+        /// The extension for Node distro files
+        pub const NODE_DISTRO_EXTENSION: &str = "zip";
+        /// The file identifier in the Node index `files` array
+        pub const NODE_DISTRO_IDENTIFIER: &str = "win-x64-zip";
+    } else if #[cfg(all(target_os = "macos", any(target_arch = "x86_64", target_arch = "aarch64")))] {
+        // NOTE: Currently, Node does not provide prebuilt binaries for Apple M1 machines, so we
+        // fall back to using the x64 binaries through Rosetta 2. When Node starts shipping M1
+        // binaries, then we will need to adjust our logic to search for those first and only fall
+        // back if they aren't found
+
+        /// The OS component of a Node distro filename
+        pub const NODE_DISTRO_OS: &str = "darwin";
+        /// The architecture component of a Node distro filename
+        pub const NODE_DISTRO_ARCH: &str = "x64";
+        /// The extension for Node distro files
         pub const NODE_DISTRO_EXTENSION: &str = "tar.gz";
+        /// The file identifier in the Node index `files` array
+        pub const NODE_DISTRO_IDENTIFIER: &str = "osx-x64-tar";
+    } else if #[cfg(all(target_os = "linux", target_arch = "x86_64"))] {
+        /// The OS component of a Node distro filename
+        pub const NODE_DISTRO_OS: &str = "linux";
+        /// The architecture component of a Node distro filename
+        pub const NODE_DISTRO_ARCH: &str = "x64";
+        /// The extension for Node distro files
+        pub const NODE_DISTRO_EXTENSION: &str = "tar.gz";
+        /// The file identifier in the Node index `files` array
+        pub const NODE_DISTRO_IDENTIFIER: &str = "linux-x64";
+    } else if #[cfg(all(target_os = "linux", target_arch = "aarch64"))] {
+        /// The OS component of a Node distro filename
+        pub const NODE_DISTRO_OS: &str = "linux";
+        /// The architecture component of a Node distro filename
+        pub const NODE_DISTRO_ARCH: &str = "arm64";
+        /// The extension for Node distro files
+        pub const NODE_DISTRO_EXTENSION: &str = "tar.gz";
+        /// The file identifier in the Node index `files` array
+        pub const NODE_DISTRO_IDENTIFIER: &str = "linux-arm64";
+    } else if #[cfg(all(target_os = "linux", target_arch = "arm"))] {
+        /// The OS component of a Node distro filename
+        pub const NODE_DISTRO_OS: &str = "linux";
+        /// The architecture component of a Node distro filename
+        pub const NODE_DISTRO_ARCH: &str = "armv7l";
+        /// The extension for Node distro files
+        pub const NODE_DISTRO_EXTENSION: &str = "tar.gz";
+        /// The file identifier in the Node index `files` array
+        pub const NODE_DISTRO_IDENTIFIER: &str = "linux-armv7l";
+    } else {
+        compile_error!("Unsuppored operating system + architecture combination");
     }
 }
 

--- a/crates/volta-core/src/tool/node/resolve.rs
+++ b/crates/volta-core/src/tool/node/resolve.rs
@@ -106,7 +106,6 @@ fn resolve_lts(hooks: Option<&ToolHooks<Node>>) -> Fallible<Version> {
 }
 
 fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Node>>) -> Fallible<Version> {
-    // ISSUE #34: also make sure this OS is available for this version
     let url = match hooks {
         Some(&ToolHooks {
             index: Some(ref hook),


### PR DESCRIPTION
Closes #34 

Info
-----
* Now that Rust 1.49 is out and has stable [Tier 2 support for Apple M1 chips](https://blog.rust-lang.org/2020/12/31/Rust-1.49.0.html#64-bit-arm-macos-and-windows-reach-tier-2), we can create an M1 native build of Volta.
* Currently, Node doesn't provide pre-built binaries for M1 chips, so we still need to fetch the x64 version of Node and run it through Rosetta 2.
* At the same time, we should also confirm when resolving a Node version that it is available for the current OS & Architecture.

Changes
-----
* Updated the `NODE_DISTRO_*` constants to also include `NODE_DISTRO_IDENTIFIER`, representing the identifier used in the Node index `files` property.
    * Currently this uses the `osx-x64-tar` identifier on M1 MacOS, since Node doesn't provide pre-built M1 binaries and hasn't yet indicated what the identifier will be).
* Updated the parsing of the Node index to exclude any versions that aren't available for the current OS / Architecture.
* Removed some unused properties and traits.