### PR TITLE
[Small] Remove now-unused 'LtsRequirement' tag

### DIFF
--- a/crates/volta-core/src/tool/node/resolve.rs
+++ b/crates/volta-core/src/tool/node/resolve.rs
@@ -44,7 +44,6 @@ pub fn resolve(matching: VersionSpec, session: &mut Session) -> Fallible<Version
         VersionSpec::Exact(version) => Ok(version),
         VersionSpec::None | VersionSpec::Tag(VersionTag::Lts) => resolve_lts(hooks),
         VersionSpec::Tag(VersionTag::Latest) => resolve_latest(hooks),
-        VersionSpec::Tag(VersionTag::LtsRequirement(req)) => resolve_lts_semver(req, hooks),
         // Node doesn't have "tagged" versions (apart from 'latest' and 'lts'), so custom tags will always be an error
         VersionSpec::Tag(VersionTag::Custom(tag)) => {
             Err(ErrorKind::NodeVersionNotFound { matching: tag }.into())
@@ -124,55 +123,6 @@ fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Node>>) -> Fall
         Some(version) => {
             debug!(
                 "Found node@{} matching requirement '{}' from {}",
-                version, matching, url
-            );
-            Ok(version)
-        }
-        None => Err(ErrorKind::NodeVersionNotFound {
-            matching: matching.to_string(),
-        }
-        .into()),
-    }
-}
-
-fn resolve_lts_semver(matching: VersionReq, hooks: Option<&ToolHooks<Node>>) -> Fallible<Version> {
-    // ISSUE #34: also make sure this OS is available for this version
-    let url = match hooks {
-        Some(&ToolHooks {
-            index: Some(ref hook),
-            ..
-        }) => {
-            debug!("Using node.index hook to determine node index URL");
-            hook.resolve("index.json")?
-        }
-        _ => public_node_version_index(),
-    };
-
-    let first_pass = match_node_version(
-        &url,
-        |&NodeEntry {
-             ref version, lts, ..
-         }| { lts && matching.matches(version) },
-    )?;
-
-    match first_pass {
-        Some(version) => {
-            debug!(
-                "Found LTS node@{} matching requirement '{}' from {}",
-                version, matching, url
-            );
-            return Ok(version);
-        }
-        None => debug!(
-            "No LTS version found matching requirement '{}', checking for non-LTS",
-            matching
-        ),
-    };
-
-    match match_node_version(&url, |NodeEntry { version, .. }| matching.matches(version))? {
-        Some(version) => {
-            debug!(
-                "Found non-LTS node@{} matching requirement '{}' from {}",
                 version, matching, url
             );
             Ok(version)

--- a/crates/volta-core/src/version/mod.rs
+++ b/crates/volta-core/src/version/mod.rs
@@ -33,9 +33,6 @@ pub enum VersionTag {
 
     /// An arbitrary tag version
     Custom(String),
-
-    /// An internal tag that represents the latest LTS version which matches a set of requirements
-    LtsRequirement(VersionReq),
 }
 
 impl fmt::Display for VersionSpec {
@@ -55,7 +52,6 @@ impl fmt::Display for VersionTag {
             VersionTag::Latest => write!(f, "latest"),
             VersionTag::Lts => write!(f, "lts"),
             VersionTag::Custom(s) => s.fmt(f),
-            VersionTag::LtsRequirement(req) => req.fmt(f),
         }
     }
 }


### PR DESCRIPTION
Info
-----
* With the previous package installation logic, we relied on finding a Node version that matched `engines` to determine which Node version to use when installing a global package.
* To better match user expectations, we added an internal-only `LtsRequirement` tag, which represented finding the latest LTS version that matched a requirement (if possible), falling back to the latest version overall.
* Now that we match `npm i -g` more closely and use the current default Node version for global installs, that internal tag is no longer needed.

Changes
-----
* Removed the `LtsRequirement` variant from the `VersionTag` enum.
* Removed the `resolve_lts_semver` function which was used only with that variant.