### PR TITLE
[Small] Build Apple Silicon Native build in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,27 @@ jobs:
           name: macos
           path: target/release/volta-macos.tar.gz
 
+  macos-aarch64:
+    name: Build - MacOS (ARM)
+    runs-on: macos-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up cargo
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: aarch64-apple-darwin
+          override: true
+      - name: Compile and package Volta
+        run: ./ci/build-for-arm.sh volta-macos-aarch64
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: macos-aarch64
+          path: target/aarch64-apple-darwin/release/volta-macos-aarch64.tar.gz
+
   windows:
     name: Build - Windows
     runs-on: windows-latest
@@ -143,6 +164,7 @@ jobs:
       - centos
       - linux
       - macos
+      - macos-aarch64
       - windows
     if: github.event_name == 'push'
     steps:
@@ -172,6 +194,11 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: macos
+          path: release
+      - name: Fetch MacOS (ARM) artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: macos-aarch64
           path: release
       - name: Fetch Windows installer
         uses: actions/download-artifact@v2
@@ -230,6 +257,15 @@ jobs:
           asset_path: ./release/volta-macos.tar.gz
           asset_name: volta-${{ steps.release_info.outputs.version }}-macos.tar.gz
           asset_content_type: applictaion/gzip
+      - name: Upload MacOS (ARM) artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/volta-macos-aarch64.tar.gz
+          asset_name: volta-${{ steps.release_info.outputs.version }}-macos-aarch64.tar.gz
+          asset_content_type: application/gzip
       - name: Upload Windows installer
         uses: actions/upload-release-asset@v1
         env:

--- a/ci/build-for-arm.sh
+++ b/ci/build-for-arm.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+echo "Building Volta"
+
+SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=11.0 cargo build --release --target=aarch64-apple-darwin
+
+echo "Packaging Binaries"
+
+cd target/aarch64-apple-darwin/release
+tar -zcvf "$1.tar.gz" volta volta-shim volta-migrate


### PR DESCRIPTION
Info
-----
* With #915, we can now create native M1 MacOS binaries.
* We should create them in CI so they are included in future releases.

Changes
-----
* Updated the CI scripts to build both Intel and ARM Mac builds (the latter being named `volta-{version}-macos-aarch64.tar.gz`
* Updated the release job to also include the native build in the release artifacts.