### PR TITLE
[Tiny] Update installer to fetch native M1 Volta binary

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -137,7 +137,11 @@ parse_os_info() {
       echo "linux-openssl-$parsed_version"
       ;;
     Darwin)
-      echo "macos"
+      if [ "$(uname -m)" == "arm64" ]; then
+        echo "macos-aarch64"
+      else
+        echo "macos"
+      fi
       ;;
     *)
       return 1


### PR DESCRIPTION
Update the installer script to fetch the M1 Native build instead of the standard x64 build.

* DO NOT MERGE Until after version 1.0.1 has been released and https://volta.sh/latest-version updated