### PR TITLE
Make volta-migrate regenerate shims and add --no-create option to it

### DIFF
--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -27,6 +27,7 @@ use volta_core::error::Fallible;
 use volta_core::layout::volta_home;
 #[cfg(unix)]
 use volta_core::layout::volta_install;
+use volta_core::shim::regenerate_shims_for_dir;
 use volta_core::sync::VoltaLock;
 
 /// Represents the state of the Volta directory at every point in the migration process
@@ -168,6 +169,8 @@ fn detect_and_migrate() -> Fallible<()> {
             }
         };
     }
+
+    regenerate_shims_for_dir(volta_home()?.shim_dir())?;
 
     Ok(())
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,7 +2,6 @@ use std::process::{Command, ExitStatus};
 
 use volta_core::error::{Context, ErrorKind, VoltaError};
 use volta_core::layout::{volta_home, volta_install};
-use volta_core::shim::regenerate_shims_for_dir;
 
 pub enum Error {
     Volta(VoltaError),
@@ -19,7 +18,6 @@ pub fn ensure_layout() -> Result<(), Error> {
             .status()
             .with_context(|| ErrorKind::CouldNotStartMigration)
             .into_result()?;
-        regenerate_shims_for_dir(home.shim_dir()).map_err(Error::Volta)?;
     }
 
     Ok(())

--- a/src/volta-migrate.rs
+++ b/src/volta-migrate.rs
@@ -1,10 +1,41 @@
+use structopt::StructOpt;
+
 use volta_core::error::{report_error, ExitCode};
+use volta_core::layout::volta_home;
 use volta_core::log::{LogContext, LogVerbosity, Logger};
 use volta_migrate::run_migration;
 
+#[derive(StructOpt)]
+#[structopt(
+    name = "volta-migrate",
+    about = "Migrates the Volta directory to the latest version",
+    raw(global_setting = "structopt::clap::AppSettings::ColoredHelp"),
+    raw(global_setting = "structopt::clap::AppSettings::ColorAuto"),
+    raw(global_setting = "structopt::clap::AppSettings::DeriveDisplayOrder"),
+    raw(global_setting = "structopt::clap::AppSettings::DisableVersion")
+)]
+struct VoltaMigrate {
+    #[structopt(
+        long = "no-create",
+        help = "Runs migration only if the Volta directory already exists",
+        global = true
+    )]
+    pub(crate) no_create: bool,
+}
+
 pub fn main() {
+    let volta_migrate = VoltaMigrate::from_args();
+
     Logger::init(LogContext::Migration, LogVerbosity::Default)
         .expect("Only a single Logger should be initialized");
+
+    if volta_migrate.no_create
+        && !volta_home()
+            .map(|home| home.root().exists())
+            .unwrap_or(false)
+    {
+        ExitCode::Success.exit();
+    }
 
     let exit_code = match run_migration() {
         Ok(()) => ExitCode::Success,

--- a/src/volta-migrate.rs
+++ b/src/volta-migrate.rs
@@ -29,11 +29,7 @@ pub fn main() {
     Logger::init(LogContext::Migration, LogVerbosity::Default)
         .expect("Only a single Logger should be initialized");
 
-    if volta_migrate.no_create
-        && !volta_home()
-            .map(|home| home.root().exists())
-            .unwrap_or(false)
-    {
+    if volta_migrate.no_create && !volta_home().map_or(false, |home| home.root().exists()) {
         ExitCode::Success.exit();
     }
 


### PR DESCRIPTION
Addresses https://github.com/volta-cli/volta/issues/927

## Background

Shims are symbolic links to `/path/to/volta-shim`. If a package manager installs a new version of Volta to a different location and removes the current version, shims will be broken.

## Changes

- Make `volta-migrate` regenerate shims even if the layout is up-to-date.
- Add `--no-create` option to `volta-migrate`. When specified, `volta-migrate` runs migration only if the Volta directory already exists.