### PR TITLE
Fix clippy warnings, formatting, and M1 build

### DIFF
--- a/ci/build-for-arm.sh
+++ b/ci/build-for-arm.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "Building Volta"
 
-SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=11.0 cargo build --release --target=aarch64-apple-darwin
+SDKROOT=$(xcrun -sdk macosx11.1 --show-sdk-path) MACOSX_DEPLOYMENT_TARGET=11.0 cargo build --release --target=aarch64-apple-darwin
 
 echo "Packaging Binaries"
 

--- a/crates/volta-core/src/tool/node/metadata.rs
+++ b/crates/volta-core/src/tool/node/metadata.rs
@@ -52,6 +52,7 @@ impl From<RawNodeIndex> for NodeIndex {
     }
 }
 
+#[allow(clippy::unnecessary_wraps)] // Needs to match the API expected by Serde
 fn lts_version_serde<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: Deserializer<'de>,

--- a/crates/volta-core/src/tool/serial.rs
+++ b/crates/volta-core/src/tool/serial.rs
@@ -140,9 +140,9 @@ fn is_version_like(value: &str) -> bool {
     matches!(
         value.parse(),
         Ok(VersionSpec::Exact(_))
-        | Ok(VersionSpec::Semver(_))
-        | Ok(VersionSpec::Tag(VersionTag::Latest))
-        | Ok(VersionSpec::Tag(VersionTag::Lts))
+            | Ok(VersionSpec::Semver(_))
+            | Ok(VersionSpec::Tag(VersionTag::Latest))
+            | Ok(VersionSpec::Tag(VersionTag::Lts))
     )
 }
 

--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -93,6 +93,7 @@ impl MigrationState {
         }
     }
 
+    #[allow(clippy::unnecessary_wraps)] // Needs to be Fallible for Unix
     fn detect_legacy_state(home: &Path) -> Fallible<Self> {
         /*
         Triage for determining the legacy layout version:

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -20,6 +20,7 @@ lazy_static! {
             .subsequent_indent(INDENTATION);
 }
 
+#[allow(clippy::unnecessary_wraps)] // Needs to match the API of `plain::format`
 pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
     // Formatting here depends on the toolchain: we do different degrees of
     // indentation


### PR DESCRIPTION
With the release of Rust 1.50, there are a couple of new clippy warnings about functions that are being unnecessarily wrapped in `Result` or `Option`. In each case, it appears that the wrapping is necessary to match the expected API (or to support cross-platform behavior). Added `#[allow(clippy::unnecssary_wraps)]` to each of those with a note about why it's allowed.

Also, there's a small change to formatting with `rustfmt`, so since we build in CI using the latest Rust, we want to fix that.

Finally, @uasi noted in #938 that the ARM build is failing because it's using the wrong version of the Mac OS SDK, so fixed that as well.