### PR TITLE
[Tiny] Make tool name case-insensitive on Windows

### DIFF
--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -107,7 +107,7 @@ fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
     // On Windows PowerShell, the file name includes the .exe suffix
     // We need to remove that to get the raw tool name
     match file_name.to_str() {
-        Some(file) => OsString::from(file.trim_end_matches(".exe")),
+        Some(file) => OsString::from(file.to_ascii_lowercase().trim_end_matches(".exe")),
         None => OsString::from(file_name),
     }
 }

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -104,7 +104,8 @@ fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
 
 #[cfg(windows)]
 fn tool_name_from_file_name(file_name: &OsStr) -> OsString {
-    // On Windows PowerShell, the file name includes the .exe suffix
+    // On Windows PowerShell, the file name includes the .exe suffix,
+    // and the Windows file system is case-insensitive
     // We need to remove that to get the raw tool name
     match file_name.to_str() {
         Some(file) => OsString::from(file.to_ascii_lowercase().trim_end_matches(".exe")),


### PR DESCRIPTION
Closes #939 

Info
-----
* Our logic for detecting the tool name on Windows was assuming that the command would always be called as e.g. `node` or `node.exe`, fully lowercase.
* On Windows, the file system is case-insensitive, so it's possible to call the tool as `NODE.EXE` or even `nOdE.eXe` or any capitalization.
* We should detect those situations and treat them appropriately.

Changes
-----
* Updated the Windows implementation of getting the tool name from the file name to convert the tool to lowercase before removing the `.exe` and trying to match the command name.

Tested
-----
* Confirmed that running `node.exe --version`,  `NODE.EXE --version`, and `nOdE.eXe --version` all work correctly.

Notes
-----
* The detection of binaries is based on locating the configuration on disk, so lowercasing the tool name should still work correctly, as the configuration file will be case-insensitive as well, meaning it will be correctly found.