### PR TITLE
[Medium] Add extra directory when linking scoped package

### DIFF
--- a/crates/volta-core/src/run/executor.rs
+++ b/crates/volta-core/src/run/executor.rs
@@ -237,6 +237,23 @@ impl PackageInstallCommand {
         })
     }
 
+    pub fn for_npm_link<A, S>(args: A, platform: Platform, name: String) -> Fallible<Self>
+    where
+        A: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let installer = DirectInstall::with_name(PackageManager::Npm, name)?;
+
+        let mut command = create_command("npm");
+        command.args(args);
+
+        Ok(PackageInstallCommand {
+            command,
+            installer,
+            platform,
+        })
+    }
+
     /// Adds or updates environment variables that the command will use
     pub fn envs<E, K, V>(&mut self, envs: E)
     where

--- a/crates/volta-core/src/run/npm.rs
+++ b/crates/volta-core/src/run/npm.rs
@@ -35,7 +35,7 @@ pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Exec
                 CommandArg::Intercepted(InterceptedCommand::Link(link)) => {
                     // For link commands, only intercept if a platform exists
                     if let Some(platform) = Platform::current(session)? {
-                        return link.executor(platform);
+                        return link.executor(platform, current_project_name(session));
                     }
                 }
                 CommandArg::Intercepted(InterceptedCommand::Unlink) => {

--- a/crates/volta-core/src/run/parser.rs
+++ b/crates/volta-core/src/run/parser.rs
@@ -348,7 +348,8 @@ impl<'a> LinkArgs<'a> {
     pub fn executor(self, platform: Platform, project_name: Option<String>) -> Fallible<Executor> {
         if self.tools.is_empty() {
             // If no tools are specified, then this is a bare link command, linking the current
-            // project as a global package. We treat this exactly like a global install
+            // project as a global package. We treat this like a global install except we look up
+            // the name from the current directory first.
             match project_name {
                 Some(name) => PackageInstallCommand::for_npm_link(self.common_args, platform, name),
                 None => PackageInstallCommand::new(self.common_args, platform, PackageManager::Npm),

--- a/crates/volta-core/src/run/parser.rs
+++ b/crates/volta-core/src/run/parser.rs
@@ -345,12 +345,15 @@ pub struct LinkArgs<'a> {
 }
 
 impl<'a> LinkArgs<'a> {
-    pub fn executor(self, platform: Platform) -> Fallible<Executor> {
+    pub fn executor(self, platform: Platform, project_name: Option<String>) -> Fallible<Executor> {
         if self.tools.is_empty() {
             // If no tools are specified, then this is a bare link command, linking the current
             // project as a global package. We treat this exactly like a global install
-            PackageInstallCommand::new(self.common_args, platform, PackageManager::Npm)
-                .map(Into::into)
+            match project_name {
+                Some(name) => PackageInstallCommand::for_npm_link(self.common_args, platform, name),
+                None => PackageInstallCommand::new(self.common_args, platform, PackageManager::Npm),
+            }
+            .map(Into::into)
         } else {
             // If there are tools specified, then this represents a command to link a global
             // package into the current project. We handle each tool separately to support Volta's


### PR DESCRIPTION
Closes #934 

Info
-----
* With npm 7, when we run `npm link` it uses a relative path to link the local directory to the global directory.
* Since we link into a temp directory and then `rename` to the final `tools/images` directory, we need to make sure that the temp directory has the same level of nesting as the final directory, so that relative symlinks work correctly.
* When linking a package that has a scope, the final directory includes an extra level of nesting, from `@scope/package`, so we need to account for that when creating the temp directory.

Changes
-----
* Updated the install executor and helper struct (`DirectInstall`) to support including the name if available.
* Updated `setup_staging_directory` to handle the case when an extra layer of nesting is required.
* Connected the argument parser to correctly fetch the name and pass it through when `npm link` is run, ensuring that scoped packages are handled correctly.

Tested
-----
* Local testing confirmed that running `npm link` in a scoped package sets up the relative symlink correctly.
* Local testing to ensure that the non-scoped packages are still handled correctly.