### PR TITLE
Fix pinning of npm@bundled

### DIFF
--- a/tests/acceptance/merged_platform.rs
+++ b/tests/acceptance/merged_platform.rs
@@ -1,9 +1,24 @@
-use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, YarnFixture};
+use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, NpmFixture, YarnFixture};
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
 use test_support::matchers::execs;
 
 use volta_core::error::ExitCode;
+
+const PACKAGE_JSON_NODE_ONLY: &str = r#"{
+    "name": "node-only",
+    "volta": {
+        "node": "10.99.1040"
+    }
+}"#;
+
+const PACKAGE_JSON_WITH_NPM: &str = r#"{
+    "name": "with-npm",
+    "volta": {
+        "node": "10.99.1040",
+        "npm": "4.5.6"
+    }
+}"#;
 
 const PACKAGE_JSON_WITH_YARN: &str = r#"{
     "name": "with-yarn",
@@ -13,10 +28,17 @@ const PACKAGE_JSON_WITH_YARN: &str = r#"{
     }
 }"#;
 
-const PACKAGE_JSON_NO_YARN: &str = r#"{
-    "name": "without-yarn",
-    "volta": {
-        "node": "10.99.1040"
+const PLATFORM_NODE_ONLY: &str = r#"{
+    "node":{
+        "runtime":"9.27.6",
+        "npm":null
+    }
+}"#;
+
+const PLATFORM_WITH_NPM: &str = r#"{
+    "node":{
+        "runtime":"9.27.6",
+        "npm":"1.2.3"
     }
 }"#;
 
@@ -26,13 +48,6 @@ const PLATFORM_WITH_YARN: &str = r#"{
         "npm":null
     },
     "yarn": "1.7.71"
-}"#;
-
-const PLATFORM_NO_YARN: &str = r#"{
-    "node":{
-        "runtime":"9.27.6",
-        "npm":null
-    }
 }"#;
 
 cfg_if::cfg_if! {
@@ -80,6 +95,19 @@ cfg_if::cfg_if! {
     }
 }
 
+const NPM_VERSION_FIXTURES: [DistroMetadata; 2] = [
+    DistroMetadata {
+        version: "1.2.3",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+    DistroMetadata {
+        version: "4.5.6",
+        compressed_size: 239,
+        uncompressed_size: Some(0x0028_0000),
+    },
+];
+
 const YARN_VERSION_FIXTURES: [DistroMetadata; 2] = [
     DistroMetadata {
         version: "1.12.99",
@@ -92,6 +120,80 @@ const YARN_VERSION_FIXTURES: [DistroMetadata; 2] = [
         uncompressed_size: Some(0x0028_0000),
     },
 ];
+
+#[test]
+fn uses_project_npm_if_available() {
+    let s = sandbox()
+        .platform(PLATFORM_WITH_NPM)
+        .package_json(PACKAGE_JSON_WITH_NPM)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "debug")
+        .build();
+
+    assert_that!(
+        s.npm("--version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]Node: 10.99.1040 from project configuration")
+            .with_stderr_contains("[..]npm: 4.5.6 from project configuration")
+    );
+}
+
+#[test]
+fn uses_bundled_npm_in_project_without_npm() {
+    let s = sandbox()
+        .platform(PLATFORM_WITH_NPM)
+        .package_json(PACKAGE_JSON_NODE_ONLY)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "debug")
+        .build();
+
+    assert_that!(
+        s.npm("--version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]Node: 10.99.1040 from project configuration")
+            .with_stderr_contains("[..]npm: 6.2.26 from project configuration")
+    );
+}
+
+#[test]
+fn uses_default_npm_outside_project() {
+    let s = sandbox()
+        .platform(PLATFORM_WITH_NPM)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "debug")
+        .build();
+
+    assert_that!(
+        s.npm("--version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]Node: 9.27.6 from default configuration")
+            .with_stderr_contains("[..]npm: 1.2.3 from default configuration")
+    );
+}
+
+#[test]
+fn uses_bundled_npm_outside_project() {
+    let s = sandbox()
+        .platform(PLATFORM_NODE_ONLY)
+        .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
+        .distro_mocks::<NpmFixture>(&NPM_VERSION_FIXTURES)
+        .env("VOLTA_LOGLEVEL", "debug")
+        .build();
+
+    assert_that!(
+        s.npm("--version"),
+        execs()
+            .with_status(ExitCode::Success as i32)
+            .with_stderr_contains("[..]Node: 9.27.6 from default configuration")
+            .with_stderr_contains("[..]npm: 5.6.17 from default configuration")
+    );
+}
 
 #[test]
 fn uses_project_yarn_if_available() {
@@ -117,7 +219,7 @@ fn uses_project_yarn_if_available() {
 fn uses_default_yarn_in_project_without_yarn() {
     let s = sandbox()
         .platform(PLATFORM_WITH_YARN)
-        .package_json(PACKAGE_JSON_NO_YARN)
+        .package_json(PACKAGE_JSON_NODE_ONLY)
         .distro_mocks::<NodeFixture>(&NODE_VERSION_FIXTURES)
         .distro_mocks::<YarnFixture>(&YARN_VERSION_FIXTURES)
         .env("VOLTA_LOGLEVEL", "debug")
@@ -155,8 +257,8 @@ fn uses_default_yarn_outside_project() {
 #[test]
 fn throws_project_error_in_project() {
     let s = sandbox()
-        .platform(PLATFORM_NO_YARN)
-        .package_json(PACKAGE_JSON_NO_YARN)
+        .platform(PLATFORM_NODE_ONLY)
+        .package_json(PACKAGE_JSON_NODE_ONLY)
         .build();
 
     assert_that!(
@@ -169,7 +271,7 @@ fn throws_project_error_in_project() {
 
 #[test]
 fn throws_default_error_outside_project() {
-    let s = sandbox().platform(PLATFORM_NO_YARN).build();
+    let s = sandbox().platform(PLATFORM_NODE_ONLY).build();
 
     assert_that!(
         s.yarn("--version"),


### PR DESCRIPTION
When node is pinned in a project, and `volta pin npm@bundled` is run, nothing is added to `package.json`, that is, `npm@bundled` is pinned by default. However, when actually running npm in a project like this, Volta didn't behave correctly, and used the global default npm.

It would be nice to write a test case for the fixed behavior, and I tried, but I don't understand correctly the Sandbox thing, or how I should go about doing it.

After fixing this, I noticed that the `volta list` output is wrong as well in this case, showing the default npm version instead of the bundled one. Could be fixed in a follow-up commit, will need some advice on how to do that.

Fixes #953