### PR TITLE
[Medium] Fetch Native Apple Silicon Node builds for Node 16+

### DIFF
--- a/crates/volta-core/src/tool/node/metadata.rs
+++ b/crates/volta-core/src/tool/node/metadata.rs
@@ -1,6 +1,8 @@
 use std::collections::HashSet;
 
 use super::NODE_DISTRO_IDENTIFIER;
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+use super::NODE_DISTRO_IDENTIFIER_FALLBACK;
 use crate::version::{option_version_serde, version_serde};
 use semver::Version;
 use serde::{Deserialize, Deserializer};
@@ -37,7 +39,21 @@ impl From<RawNodeIndex> for NodeIndex {
             .0
             .into_iter()
             .filter_map(|entry| {
+                #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
                 if entry.npm.is_some() && entry.files.contains(NODE_DISTRO_IDENTIFIER) {
+                    Some(NodeEntry {
+                        version: entry.version,
+                        lts: entry.lts,
+                    })
+                } else {
+                    None
+                }
+
+                #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+                if entry.npm.is_some()
+                    && (entry.files.contains(NODE_DISTRO_IDENTIFIER)
+                        || entry.files.contains(NODE_DISTRO_IDENTIFIER_FALLBACK))
+                {
                     Some(NodeEntry {
                         version: entry.version,
                         lts: entry.lts,

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -129,8 +129,25 @@ impl Node {
         Node { version }
     }
 
+    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
     pub fn archive_basename(version: &Version) -> String {
         format!("node-v{}-{}-{}", version, NODE_DISTRO_OS, NODE_DISTRO_ARCH)
+    }
+
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    pub fn archive_basename(version: &Version) -> String {
+        // Note: Node began shipping pre-built binaries for Apple Silicon with Major version 16
+        // Prior to that, we need to fall back on the x64 binaries
+        format!(
+            "node-v{}-{}-{}",
+            version,
+            NODE_DISTRO_OS,
+            if version.major >= 16 {
+                NODE_DISTRO_ARCH
+            } else {
+                NODE_DISTRO_ARCH_FALLBACK
+            }
+        )
     }
 
     pub fn archive_filename(version: &Version) -> String {

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -39,12 +39,7 @@ cfg_if! {
         pub const NODE_DISTRO_EXTENSION: &str = "zip";
         /// The file identifier in the Node index `files` array
         pub const NODE_DISTRO_IDENTIFIER: &str = "win-x64-zip";
-    } else if #[cfg(all(target_os = "macos", any(target_arch = "x86_64", target_arch = "aarch64")))] {
-        // NOTE: Currently, Node does not provide prebuilt binaries for Apple M1 machines, so we
-        // fall back to using the x64 binaries through Rosetta 2. When Node starts shipping M1
-        // binaries, then we will need to adjust our logic to search for those first and only fall
-        // back if they aren't found
-
+    } else if #[cfg(all(target_os = "macos", target_arch = "x86_64"))] {
         /// The OS component of a Node distro filename
         pub const NODE_DISTRO_OS: &str = "darwin";
         /// The architecture component of a Node distro filename
@@ -53,6 +48,23 @@ cfg_if! {
         pub const NODE_DISTRO_EXTENSION: &str = "tar.gz";
         /// The file identifier in the Node index `files` array
         pub const NODE_DISTRO_IDENTIFIER: &str = "osx-x64-tar";
+    } else if #[cfg(all(target_os = "macos", target_arch = "aarch64"))] {
+        /// The OS component of a Node distro filename
+        pub const NODE_DISTRO_OS: &str = "darwin";
+        /// The architecture component of a Node distro filename
+        pub const NODE_DISTRO_ARCH: &str = "arm64";
+        /// The extension for Node distro files
+        pub const NODE_DISTRO_EXTENSION: &str = "tar.gz";
+        /// The file identifier in the Node index `files` array
+        pub const NODE_DISTRO_IDENTIFIER: &str = "osx-arm64-tar";
+
+        // NOTE: Node support for pre-built Apple Silicon binaries was added in major version 16
+        // For versions prior to that, we need to fall back on the x64 binaries via Rosetta 2
+
+        /// The fallback architecture component of a Node distro filename
+        pub const NODE_DISTRO_ARCH_FALLBACK: &str = "x64";
+        /// The fallback file identifier in the Node index `files` array
+        pub const NODE_DISTRO_IDENTIFIER_FALLBACK: &str = "osx-x64-tar";
     } else if #[cfg(all(target_os = "linux", target_arch = "x86_64"))] {
         /// The OS component of a Node distro filename
         pub const NODE_DISTRO_OS: &str = "linux";

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -129,11 +129,11 @@ impl Node {
         Node { version }
     }
 
-    pub fn archive_basename(version: &str) -> String {
+    pub fn archive_basename(version: &Version) -> String {
         format!("node-v{}-{}-{}", version, NODE_DISTRO_OS, NODE_DISTRO_ARCH)
     }
 
-    pub fn archive_filename(version: &str) -> String {
+    pub fn archive_filename(version: &Version) -> String {
         format!(
             "{}.{}",
             Node::archive_basename(version),
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn test_node_archive_basename() {
         assert_eq!(
-            Node::archive_basename("1.2.3"),
+            Node::archive_basename(&Version::new(1, 2, 3)),
             format!("node-v1.2.3-{}-{}", NODE_DISTRO_OS, NODE_DISTRO_ARCH)
         );
     }
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn test_node_archive_filename() {
         assert_eq!(
-            Node::archive_filename("1.2.3"),
+            Node::archive_filename(&Version::new(1, 2, 3)),
             format!(
                 "node-v1.2.3-{}-{}.{}",
                 NODE_DISTRO_OS, NODE_DISTRO_ARCH, NODE_DISTRO_EXTENSION

--- a/tests/acceptance/corrupted_download.rs
+++ b/tests/acceptance/corrupted_download.rs
@@ -1,6 +1,7 @@
 use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, YarnFixture};
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
+use semver::Version;
 use test_support::matchers::execs;
 
 use volta_core::error::ExitCode;
@@ -58,7 +59,7 @@ fn install_corrupted_node_leaves_inventory_unchanged() {
         execs().with_status(ExitCode::UnknownError as i32)
     );
 
-    assert!(!s.node_inventory_archive_exists("0.0.1"));
+    assert!(!s.node_inventory_archive_exists(&Version::new(0, 0, 1)));
 }
 
 #[test]
@@ -73,7 +74,7 @@ fn install_valid_node_saves_to_inventory() {
         execs().with_status(ExitCode::Success as i32)
     );
 
-    assert!(s.node_inventory_archive_exists("10.99.1040"));
+    assert!(s.node_inventory_archive_exists(&Version::new(10, 99, 1040)));
 }
 
 #[test]

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -7,6 +7,7 @@ use std::time::{Duration, SystemTime};
 
 use hyperx::header::HttpDate;
 use mockito::{self, mock, Matcher};
+use semver::Version;
 use test_support::{self, ok_or_panic, paths, paths::PathExt, process::ProcessBuilder};
 use volta_core::fs::symlink_file;
 use volta_core::tool::{Node, Yarn, NODE_DISTRO_ARCH, NODE_DISTRO_EXTENSION, NODE_DISTRO_OS};
@@ -631,7 +632,7 @@ impl Sandbox {
 
     // check that files in the sandbox exist
 
-    pub fn node_inventory_archive_exists(&self, version: &str) -> bool {
+    pub fn node_inventory_archive_exists(&self, version: &Version) -> bool {
         node_inventory_dir()
             .join(Node::archive_filename(version))
             .exists()


### PR DESCRIPTION
Closes #919 

Info
-----
* With the release of Node v16, there are now pre-built binaries available for Apple Silicon devices.
* Where possible, we should fetch and use those binaries, so that users get the best possible experience.
* However, for older versions of Node, we will need to continue to fetch the x64 binaries and rely on Rosetta.

Changes
-----
* Updated the constants section in `tool/node/mod.rs` to include the constant values for Apple Silicon architecture
* Ensured that the parsing of the `files` metadata in the Node index will check for both the native and x64 versions of Node.
* Customized `archive_filename` on Apple Silicon builds to check the Node major version and fetch either a native or x64 build of Node depending on whether it is greater than or equal to 16.

Tested
-----
* Our test suite currently doesn't execute on an Apple Silicon machine, so we don't have a way to automatically test these changes (opened #973 to track that issue separately, currently blocked on GitHub Actions support).
* Could someone with access to an M1 machine (cc @chriskrycho ?) run a test to confirm this properly fetches Node 16+ and 15-?

Notes
-----
* Per [this comment](https://github.com/nodejs/build/issues/2474#issuecomment-820312698), Node does not support Apple Silicon (even when building from source) prior to Node 15, and only provides pre-built binaries as of Node 16. So there shouldn't be any LTS releases of Node that have pre-built binaries but a major version less than 16.