### PR TITLE
Don't update the user's shell config files if VOLTA_HOME and PATH already contains what we need.

### DIFF
--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -45,11 +45,14 @@ mod os {
 
         // Don't update the user's shell config files if VOLTA_HOME and PATH already contain what we need.
         let home_in_path = match env::var_os("PATH") {
-            Some(paths) => env::split_paths(&paths).find(|p| p == home.shim_dir()),
-            None => None
+            Some(paths) => env::split_paths(&paths).find(|p| p == home.root()),
+            None => None,
         };
 
         if env::var_os("VOLTA_HOME").is_some() && home_in_path.is_some() {
+            debug!(
+                "{} skipping dot-file modification as VOLTA_HOME is set, and included in the PATH."
+            );
             return Ok(());
         }
 

--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -43,6 +43,16 @@ mod os {
         let home = volta_home()?;
         let formatted_home = format_home(home.root());
 
+        // Don't update the user's shell config files if VOLTA_HOME and PATH already contain what we need.
+        let home_in_path = match env::var_os("PATH") {
+            Some(paths) => env::split_paths(&paths).find(|p| p == home.root()),
+            None => None
+        };
+
+        if env::var_os("VOLTA_HOME").is_some() && home_in_path.is_some() {
+            return Ok(());
+        }
+
         debug!("Searching for profiles to update");
         let profiles = determine_profiles()?;
 

--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -51,7 +51,7 @@ mod os {
 
         if env::var_os("VOLTA_HOME").is_some() && home_in_path.is_some() {
             debug!(
-                "{} skipping dot-file modification as VOLTA_HOME is set, and included in the PATH."
+                "Skipping dot-file modification as VOLTA_HOME is set, and included in the PATH."
             );
             return Ok(());
         }

--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -45,7 +45,7 @@ mod os {
 
         // Don't update the user's shell config files if VOLTA_HOME and PATH already contain what we need.
         let home_in_path = match env::var_os("PATH") {
-            Some(paths) => env::split_paths(&paths).find(|p| p == home.root()),
+            Some(paths) => env::split_paths(&paths).find(|p| p == home.shim_dir()),
             None => None
         };
 

--- a/src/command/setup.rs
+++ b/src/command/setup.rs
@@ -45,7 +45,7 @@ mod os {
 
         // Don't update the user's shell config files if VOLTA_HOME and PATH already contain what we need.
         let home_in_path = match env::var_os("PATH") {
-            Some(paths) => env::split_paths(&paths).find(|p| p == home.root()),
+            Some(paths) => env::split_paths(&paths).find(|p| p == home.shim_dir()),
             None => None,
         };
 


### PR DESCRIPTION
This will prevent changes when these settings are defined in a different, but compatible way to what volta does.