### PR TITLE
Fix Windows Builds and Clippy Warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1193,18 +1193,18 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c725b36c99df7af7bf9324e9c999b9e37d92c8f8caf106d82e1d7953218d2d8"
+checksum = "d7f95648580798cc44ff8efb9bb0d7ee5205ea32e087b31b0732f3e8c2648ee2"
 dependencies = [
  "proc-macro-hack-impl",
 ]
 
 [[package]]
 name = "proc-macro-hack-impl"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b753ad9ed99dd8efeaa7d2fb8453c8f6bc3e54b97966d35f1bc77ca6865254a"
+checksum = "7be55bf0ae1635f4d7c7ddd6efc05c631e98a82104a73d35550bbc52db960027"
 
 [[package]]
 name = "proc-macro2"

--- a/crates/volta-core/src/platform/tests.rs
+++ b/crates/volta-core/src/platform/tests.rs
@@ -91,11 +91,12 @@ fn test_image_path() {
 
 #[cfg(windows)]
 fn test_image_path() {
-    let mut pathbufs: Vec<PathBuf> = Vec::new();
-    pathbufs.push(volta_home().unwrap().shim_dir().to_owned());
-    pathbufs.push(PathBuf::from("C:\\\\somebin"));
-    pathbufs.push(volta_install().unwrap().root().to_owned());
-    pathbufs.push(PathBuf::from("D:\\\\ProbramFlies"));
+    let pathbufs = vec![
+        volta_home().unwrap().shim_dir().to_owned(),
+        PathBuf::from("C:\\\\somebin"),
+        volta_install().unwrap().root().to_owned(),
+        PathBuf::from("D:\\\\ProbramFlies"),
+    ];
 
     let path_with_shims = std::env::join_paths(pathbufs.iter())
         .unwrap()
@@ -191,11 +192,12 @@ fn test_system_path() {
 
 #[cfg(windows)]
 fn test_system_path() {
-    let mut pathbufs: Vec<PathBuf> = Vec::new();
-    pathbufs.push(volta_home().unwrap().shim_dir().to_owned());
-    pathbufs.push(PathBuf::from("C:\\\\somebin"));
-    pathbufs.push(volta_install().unwrap().root().to_owned());
-    pathbufs.push(PathBuf::from("D:\\\\ProbramFlies"));
+    let pathbufs = vec![
+        volta_home().unwrap().shim_dir().to_owned(),
+        PathBuf::from("C:\\\\somebin"),
+        volta_install().unwrap().root().to_owned(),
+        PathBuf::from("D:\\\\ProbramFlies"),
+    ];
 
     let path_with_shims = std::env::join_paths(pathbufs.iter())
         .unwrap()

--- a/crates/volta-core/src/project/mod.rs
+++ b/crates/volta-core/src/project/mod.rs
@@ -114,8 +114,8 @@ impl Project {
 
         Ok(Project {
             manifest_file,
-            dependencies,
             workspace_manifests,
+            dependencies,
             platform,
         })
     }


### PR DESCRIPTION
Info
-----
* As of the latest Rust release, Windows builds are failing to compile due to an issue with `proc-macro-hack`, which is a transitive dependency on Windows.
* The upstream `proc-macro-hack` released a new version `0.4.3` that resolves the compiler failure.
* Additionally, there are some warnings from Clippy on Windows that should be resolved.

Changes
-----
* Used `cargo update` to bump the version of `proc-macro-hack` in `Cargo.lock`
* Fixed the clippy warnings.

Tested
-----
* Compiles on a Windows machine completely.
* `cargo clippy` Shows no warnings.