### PR TITLE
Filter out invalid bins when loading package manifest

### DIFF
--- a/crates/volta-core/src/tool/package/metadata.rs
+++ b/crates/volta-core/src/tool/package/metadata.rs
@@ -261,7 +261,12 @@ mod serde_bins {
         {
             let mut bins = Vec::new();
             while let Some((name, _)) = access.next_entry::<String, String>()? {
-                bins.push(name);
+                // Bin names that include path separators are invalid, as they would then point to
+                // other locations on the filesystem. To match the behavior of npm & Yarn, we
+                // filter those values out of the list of bins.
+                if !name.contains(&['/', '\\'][..]) {
+                    bins.push(name);
+                }
             }
             Ok(bins)
         }


### PR DESCRIPTION
Info
-----
* Reported in Discord: https://discord.com/channels/413753499835301908/413753499835301917/845139760993402891
* If a package has an invalid name in the `bin` hash in `package.json`, both npm and Yarn handle it by skipping over that entry, but Volta tries to create shims and then fails with an error.
* We should match the behavior of the package managers and skip over invalid entries (ones that contain path separators).

Changes
-----
* Updated the logic for parsing the `bin` hash to exclude any names that contain path separators (`/` and `\`).

Tested
-----
* Installed the example from Discord (`@ethersphere/swarm-cli`) and confirmed that it failed before the change and succeeded afterwards.
    * Note: npm version 6 and lower appear to do some normalization of the `package.json` during a global install, so I was only able to reproduce the failure using npm 7.