### PR TITLE
Clean up clippy warnings with newest Rust version

### DIFF
--- a/crates/test-support/src/matchers.rs
+++ b/crates/test-support/src/matchers.rs
@@ -196,7 +196,7 @@ impl Execs {
         }
         for &(ref expect, number) in self.expect_stdout_contains_n.iter() {
             self.match_std(
-                Some(&expect),
+                Some(expect),
                 &actual.stdout,
                 "stdout",
                 &actual.stderr,
@@ -483,7 +483,7 @@ impl Execs {
             .enumerate()
             .filter_map(|(i, (a, e))| match (a, e) {
                 (Some(a), Some(e)) => {
-                    if lines_match(&e, &a) {
+                    if lines_match(e, a) {
                         None
                     } else {
                         Some(format!("{:3} - |{}|\n    + |{}|\n", i, e, a))
@@ -577,7 +577,7 @@ fn find_mismatch<'a>(expected: &'a Value, actual: &'a Value) -> Option<(&'a Valu
 
             if !l.is_empty() {
                 assert!(!r.is_empty());
-                Some((&l[0], &r[0]))
+                Some((l[0], r[0]))
             } else {
                 assert_eq!(r.len(), 0);
                 None

--- a/crates/volta-core/src/run/binary.rs
+++ b/crates/volta-core/src/run/binary.rs
@@ -134,7 +134,7 @@ impl DefaultBinary {
             Some(yarn) => Some(yarn),
             None => session
                 .default_platform()?
-                .and_then(|ref plat| plat.yarn.clone()),
+                .and_then(|plat| plat.yarn.clone()),
         };
         let platform = Platform {
             node: Sourced::with_binary(bin_config.platform.node),

--- a/crates/volta-core/src/session.rs
+++ b/crates/volta-core/src/session.rs
@@ -110,7 +110,7 @@ impl Session {
 
     /// Returns the current project's pinned platform image, if any.
     pub fn project_platform(&self) -> Fallible<Option<&PlatformSpec>> {
-        if let Some(ref project) = self.project()? {
+        if let Some(project) = self.project()? {
             return Ok(project.platform());
         }
         Ok(None)
@@ -191,7 +191,7 @@ pub mod tests {
         let pinned_platform = pinned_session
             .project_platform()
             .expect("Couldn't create Project");
-        assert_eq!(pinned_platform.is_some(), true);
+        assert!(pinned_platform.is_some());
 
         let project_unpinned = fixture_path("no_toolchain");
         env::set_current_dir(&project_unpinned).expect("Could not set current directory");
@@ -199,6 +199,6 @@ pub mod tests {
         let unpinned_platform = unpinned_session
             .project_platform()
             .expect("Couldn't create Project");
-        assert_eq!(unpinned_platform.is_none(), true);
+        assert!(unpinned_platform.is_none());
     }
 }

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -123,7 +123,7 @@ impl Spec {
             Spec::Node(_) => "Node",
             Spec::Npm(_) => "npm",
             Spec::Yarn(_) => "Yarn",
-            Spec::Package(name, _) => &name,
+            Spec::Package(name, _) => name,
         }
     }
 }

--- a/crates/volta-core/src/tool/node/fetch.rs
+++ b/crates/volta-core/src/tool/node/fetch.rs
@@ -59,8 +59,8 @@ pub fn fetch(version: &Version, hooks: Option<&ToolHooks<Node>>) -> Fallible<Nod
         }
         None => {
             let staging = create_staging_file()?;
-            let remote_url = determine_remote_url(&version, hooks)?;
-            let archive = fetch_remote_distro(&version, &remote_url, staging.path())?;
+            let remote_url = determine_remote_url(version, hooks)?;
+            let archive = fetch_remote_distro(version, &remote_url, staging.path())?;
             (archive, Some(staging))
         }
     };
@@ -109,7 +109,7 @@ fn unpack_archive(archive: Box<dyn Archive>, version: &Version) -> Fallible<Node
     // Save the npm version number in the npm version file for this distro
     let npm_package_json = temp.path().join(npm_manifest_path(version));
     let npm = Manifest::version(&npm_package_json)?;
-    save_default_npm_version(&version, &npm)?;
+    save_default_npm_version(version, &npm)?;
 
     let dest = volta_home()?.node_image_dir(&version_string);
     ensure_containing_dir_exists(&dest)
@@ -156,7 +156,7 @@ fn determine_remote_url(version: &Version, hooks: Option<&ToolHooks<Node>>) -> F
             ..
         }) => {
             debug!("Using node.distro hook to determine download URL");
-            hook.resolve(&version, &distro_file_name)
+            hook.resolve(version, &distro_file_name)
         }
         _ => Ok(format!(
             "{}/v{}/{}",

--- a/crates/volta-core/src/tool/npm/fetch.rs
+++ b/crates/volta-core/src/tool/npm/fetch.rs
@@ -32,8 +32,8 @@ pub fn fetch(version: &Version, hooks: Option<&ToolHooks<Npm>>) -> Fallible<()> 
         }
         None => {
             let staging = create_staging_file()?;
-            let remote_url = determine_remote_url(&version, hooks)?;
-            let archive = fetch_remote_distro(&version, &remote_url, staging.path())?;
+            let remote_url = determine_remote_url(version, hooks)?;
+            let archive = fetch_remote_distro(version, &remote_url, staging.path())?;
             (archive, Some(staging))
         }
     };
@@ -127,7 +127,7 @@ fn determine_remote_url(version: &Version, hooks: Option<&ToolHooks<Npm>>) -> Fa
         }) => {
             debug!("Using npm.distro hook to determine download URL");
             let distro_file_name = Npm::archive_filename(&version_str);
-            hook.resolve(&version, &distro_file_name)
+            hook.resolve(version, &distro_file_name)
         }
         _ => Ok(public_registry_package("npm", &version_str)),
     }

--- a/crates/volta-core/src/tool/npm/resolve.rs
+++ b/crates/volta-core/src/tool/npm/resolve.rs
@@ -74,7 +74,7 @@ fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Npm>>) -> Falli
     let details_opt = index
         .entries
         .into_iter()
-        .find(|PackageDetails { version, .. }| matching.matches(&version));
+        .find(|PackageDetails { version, .. }| matching.matches(version));
 
     match details_opt {
         Some(details) => {

--- a/crates/volta-core/src/tool/package/configure.rs
+++ b/crates/volta-core/src/tool/package/configure.rs
@@ -36,7 +36,7 @@ pub(super) fn write_config_and_shims(
 
     // Generate the shims and bin configs for each bin provided by the package
     for bin_name in &manifest.bin {
-        shim::create(&bin_name)?;
+        shim::create(bin_name)?;
 
         BinConfig {
             name: bin_name.clone(),
@@ -68,7 +68,7 @@ fn validate_bins(package_name: &str, manifest: &PackageManifest) -> Fallible<()>
     for bin_name in &manifest.bin {
         // Check for name conflicts with already-installed bins
         // Some packages may install bins with the same name
-        if let Ok(config) = BinConfig::from_file(home.default_tool_bin_config(&bin_name)) {
+        if let Ok(config) = BinConfig::from_file(home.default_tool_bin_config(bin_name)) {
             // The file exists, so there is a bin with this name
             // That is okay iff it came from the package that is currently being installed
             if package_name != config.package {

--- a/crates/volta-core/src/tool/package/uninstall.rs
+++ b/crates/volta-core/src/tool/package/uninstall.rs
@@ -79,7 +79,7 @@ fn remove_config_and_shim(bin_name: &str, pkg_name: &str) -> Fallible<()> {
 fn binaries_from_package(package: &str) -> Fallible<Vec<String>> {
     let bin_config_dir = volta_home()?.default_bin_dir();
 
-    dir_entry_match(&bin_config_dir, |entry| {
+    dir_entry_match(bin_config_dir, |entry| {
         let path = entry.path();
         if let Ok(config) = BinConfig::from_file(path) {
             if config.package == package {

--- a/crates/volta-core/src/tool/yarn/fetch.rs
+++ b/crates/volta-core/src/tool/yarn/fetch.rs
@@ -32,8 +32,8 @@ pub fn fetch(version: &Version, hooks: Option<&ToolHooks<Yarn>>) -> Fallible<()>
         }
         None => {
             let staging = create_staging_file()?;
-            let remote_url = determine_remote_url(&version, hooks)?;
-            let archive = fetch_remote_distro(&version, &remote_url, staging.path())?;
+            let remote_url = determine_remote_url(version, hooks)?;
+            let archive = fetch_remote_distro(version, &remote_url, staging.path())?;
             (archive, Some(staging))
         }
     };
@@ -120,7 +120,7 @@ fn determine_remote_url(version: &Version, hooks: Option<&ToolHooks<Yarn>>) -> F
         }) => {
             debug!("Using yarn.distro hook to determine download URL");
             let distro_file_name = Yarn::archive_filename(&version_str);
-            hook.resolve(&version, &distro_file_name)
+            hook.resolve(version, &distro_file_name)
         }
         _ => Ok(public_registry_package("yarn", &version_str)),
     }

--- a/crates/volta-core/src/tool/yarn/resolve.rs
+++ b/crates/volta-core/src/tool/yarn/resolve.rs
@@ -114,7 +114,7 @@ fn resolve_semver_from_registry(matching: VersionReq) -> Fallible<Version> {
     let details_opt = index
         .entries
         .into_iter()
-        .find(|PackageDetails { version, .. }| matching.matches(&version));
+        .find(|PackageDetails { version, .. }| matching.matches(version));
 
     match details_opt {
         Some(details) => {

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -43,7 +43,7 @@ pub struct Toolchain {
 impl Toolchain {
     fn current() -> Fallible<Toolchain> {
         let path = volta_home()?.default_platform_file();
-        let src = touch(&path)
+        let src = touch(path)
             .and_then(|mut file| file.read_into_string())
             .with_context(|| ErrorKind::ReadPlatformError {
                 file: path.to_owned(),

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -25,7 +25,7 @@ pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
     // Formatting here depends on the toolchain: we do different degrees of
     // indentation
     Some(match toolchain {
-        Toolchain::Node(runtimes) => display_node(&runtimes),
+        Toolchain::Node(runtimes) => display_node(runtimes),
         Toolchain::Active {
             runtime,
             package_managers,
@@ -121,7 +121,7 @@ fn display_node(runtimes: &[Node]) -> String {
     } else {
         format!(
             "⚡️ Node runtimes in your toolchain:\n\n{}",
-            format_runtime_list(&runtimes)
+            format_runtime_list(runtimes)
         )
     }
 }

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -129,7 +129,7 @@ impl Package {
                 .iter()
                 .map(|config| {
                     let source = Self::source(&config.name, project);
-                    Package::new(&config, &source)
+                    Package::new(config, &source)
                 })
                 .collect()
         })

--- a/src/command/list/plain.rs
+++ b/src/command/list/plain.rs
@@ -8,11 +8,11 @@ use super::{Node, Package, PackageManager, Source, Toolchain};
 
 pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
     let (runtimes, package_managers, packages) = match toolchain {
-        Toolchain::Node(runtimes) => (describe_runtimes(&runtimes), None, None),
+        Toolchain::Node(runtimes) => (describe_runtimes(runtimes), None, None),
         Toolchain::PackageManagers { managers, .. } => {
             (None, describe_package_managers(managers), None)
         }
-        Toolchain::Packages(packages) => (None, None, describe_packages(&packages)),
+        Toolchain::Packages(packages) => (None, None, describe_packages(packages)),
         Toolchain::Tool {
             name,
             host_packages,
@@ -25,17 +25,17 @@ pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
             runtime
                 .as_ref()
                 .and_then(|r| describe_runtimes(&[(**r).clone()])),
-            describe_package_managers(&package_managers),
-            describe_packages(&packages),
+            describe_package_managers(package_managers),
+            describe_packages(packages),
         ),
         Toolchain::All {
             runtimes,
             package_managers,
             packages,
         } => (
-            describe_runtimes(&runtimes),
-            describe_package_managers(&package_managers),
-            describe_packages(&packages),
+            describe_runtimes(runtimes),
+            describe_package_managers(package_managers),
+            describe_packages(packages),
         ),
     };
 
@@ -78,7 +78,7 @@ fn describe_package_managers(package_managers: &[PackageManager]) -> Option<Stri
         Some(
             package_managers
                 .iter()
-                .map(|package_manager| display_package_manager(&package_manager))
+                .map(|package_manager| display_package_manager(package_manager))
                 .collect::<Vec<String>>()
                 .join("\n"),
         )
@@ -148,7 +148,7 @@ fn display_package(package: &Package) -> String {
                 // Should be updated when we support installing with custom package_managers,
                 // whether Yarn or non-built-in versions of npm
                 "npm@built-in",
-                package_source(&package)
+                package_source(package)
             )
         }
         Package::Project { name, tools, .. } => {
@@ -163,7 +163,7 @@ fn display_package(package: &Package) -> String {
                 tools,
                 "node@project",
                 "npm@project",
-                package_source(&package)
+                package_source(package)
             )
         }
         Package::Fetched(details) => format!(
@@ -181,7 +181,7 @@ fn display_tool(name: &str, host: &Package) -> Option<String> {
             tool_version(&details.name, &details.version),
             tool_version("node", &node),
             "npm@built-in",
-            package_source(&host)
+            package_source(host)
         )),
         Package::Project {
             name: host_name, ..
@@ -191,7 +191,7 @@ fn display_tool(name: &str, host: &Package) -> Option<String> {
             tool_version(&host_name, "project"),
             "node@project",
             "npm@project",
-            package_source(&host)
+            package_source(host)
         )),
         Package::Fetched(..) => None,
     }

--- a/src/command/list/toolchain.rs
+++ b/src/command/list/toolchain.rs
@@ -335,7 +335,7 @@ impl Toolchain {
                 let packages = packages_and_tools
                     .into_iter()
                     .filter_map(|(kind, config, source)| match kind {
-                        Kind::Package => Some(Package::new(&config, &source)),
+                        Kind::Package => Some(Package::new(config, &source)),
                         Kind::Tool => None,
                     })
                     .collect();
@@ -348,7 +348,7 @@ impl Toolchain {
                 let host_packages = packages_and_tools
                     .into_iter()
                     .filter_map(|(kind, config, source)| match kind {
-                        Kind::Tool => Some(Package::new(&config, &source)),
+                        Kind::Tool => Some(Package::new(config, &source)),
                         Kind::Package => None, // should be none of these!
                     })
                     .collect();

--- a/tests/smoke/support/temp_project.rs
+++ b/tests/smoke/support/temp_project.rs
@@ -55,7 +55,7 @@ impl TempProjectBuilder {
     pub fn new(root: PathBuf) -> TempProjectBuilder {
         TempProjectBuilder {
             root: TempProject {
-                root: root.clone(),
+                root,
                 path: OsString::new(),
             },
             files: vec![],
@@ -341,7 +341,7 @@ impl TempProject {
     }
 
     /// Verify that the input Node version has been installed.
-    pub fn assert_node_version_is_installed(&self, version: &str) -> () {
+    pub fn assert_node_version_is_installed(&self, version: &str) {
         let default_platform = default_platform_file(self.root());
         let platform_contents = read_file_to_string(default_platform);
         let json_contents: serde_json::Value =
@@ -363,7 +363,7 @@ impl TempProject {
     }
 
     /// Verify that the input Yarn version has been installed.
-    pub fn assert_yarn_version_is_installed(&self, version: &str) -> () {
+    pub fn assert_yarn_version_is_installed(&self, version: &str) {
         let default_platform = default_platform_file(self.root());
         let platform_contents = read_file_to_string(default_platform);
         let json_contents: serde_json::Value =
@@ -384,7 +384,7 @@ impl TempProject {
     }
 
     /// Verify that the input Npm version has been installed.
-    pub fn assert_npm_version_is_installed(&self, version: &str) -> () {
+    pub fn assert_npm_version_is_installed(&self, version: &str) {
         let default_platform = default_platform_file(self.root());
         let platform_contents = read_file_to_string(default_platform);
         let json_contents: serde_json::Value =

--- a/tests/smoke/volta_install.rs
+++ b/tests/smoke/volta_install.rs
@@ -146,7 +146,7 @@ fn install_npm_concurrent() {
     assert!(concurrent_thread.join().is_ok());
 }
 
-const COWSAY_HELLO: &'static str = r#" _______
+const COWSAY_HELLO: &str = r#" _______
 < hello >
  -------
         \   ^__^


### PR DESCRIPTION
Info
-----
* With the latest stable Rust release, there are a number of warnings from clippy about a few issues, mostly unnecessary borrows.

Changes
-----
* Resolved clippy issues