### PR TITLE
Fix dependabot config: specify the bare minimum

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,69 +3,39 @@ updates:
   - directory: /
     open-pull-requests-limit: 5
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC
 
   - directory: /crates/archive
     open-pull-requests-limit: 3
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC
 
   - directory: /crates/fs-utils
     open-pull-requests-limit: 3
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC
 
   - directory: /crates/progress-read
     open-pull-requests-limit: 3
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC
 
   - directory: /crates/test-support
     open-pull-requests-limit: 3
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC
 
   - directory: /crates/validate-npm-package-name
     open-pull-requests-limit: 3
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC
 
   - directory: /crates/volta-core
     open-pull-requests-limit: 3
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC
 
   - directory: /crates/volta-layout
     open-pull-requests-limit: 3
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC
 
   - directory: /crates/volta-layout-macro
     open-pull-requests-limit: 3
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC
 
   - directory: /crates/volta-migrate
     open-pull-requests-limit: 3
     package-ecosystem: "cargo"
-    rebase-strategy: auto
-    schedule:
-      timezone: 05:00 UTC


### PR DESCRIPTION
The previous implementation overspecified this, and that ended up not even being correct (despite coming from GitHub's docs!), so the easiest solution is simply to remove things which the defaults cover for us: scheduling and rebasing.