### PR TITLE
Fix clippy warnings from Rust 1.57.0

### DIFF
--- a/crates/test-support/src/matchers.rs
+++ b/crates/test-support/src/matchers.rs
@@ -11,7 +11,6 @@ use serde_json::{self, Value};
 #[derive(Clone)]
 pub struct Execs {
     expect_stdout: Option<String>,
-    expect_stdin: Option<String>,
     expect_stderr: Option<String>,
     expect_exit_code: Option<i32>,
     expect_stdout_contains: Vec<String>,
@@ -671,7 +670,6 @@ pub fn execs() -> Execs {
     Execs {
         expect_stdout: None,
         expect_stderr: None,
-        expect_stdin: None,
         expect_exit_code: Some(0),
         expect_stdout_contains: Vec::new(),
         expect_stderr_contains: Vec::new(),

--- a/crates/volta-core/src/tool/registry.rs
+++ b/crates/volta-core/src/tool/registry.rs
@@ -56,8 +56,6 @@ pub fn find_unpack_dir(in_dir: &Path) -> Fallible<PathBuf> {
 #[derive(Debug)]
 pub struct PackageDetails {
     pub(crate) version: Version,
-    pub(crate) tarball_url: String,
-    pub(crate) shasum: String,
 }
 
 /// Index of versions of a specific package from the npm Registry
@@ -102,8 +100,6 @@ impl From<RawPackageMetadata> for PackageIndex {
             .into_iter()
             .map(|(_, version_info)| PackageDetails {
                 version: version_info.version,
-                tarball_url: version_info.dist.tarball,
-                shasum: version_info.dist.shasum,
             })
             .collect();
 

--- a/src/command/list/plain.rs
+++ b/src/command/list/plain.rs
@@ -78,7 +78,7 @@ fn describe_package_managers(package_managers: &[PackageManager]) -> Option<Stri
         Some(
             package_managers
                 .iter()
-                .map(|package_manager| display_package_manager(package_manager))
+                .map(display_package_manager)
                 .collect::<Vec<String>>()
                 .join("\n"),
         )


### PR DESCRIPTION
Info
-----
* Seems like I should have waited a couple of days before #1057, as there's a new Rust version with new compiler / clippy warnings

Changes
-----
* Removed some unused struct fields and a redundant closure