### PR TITLE
Bump 'percent_encoding' version and create appropriate escape set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,7 +713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -891,7 +891,7 @@ dependencies = [
  "language-tags",
  "log",
  "mime",
- "percent-encoding 2.1.0",
+ "percent-encoding",
  "time",
  "unicase",
 ]
@@ -1289,12 +1289,6 @@ dependencies = [
  "serde",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -2202,7 +2196,7 @@ checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
 dependencies = [
  "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -2216,7 +2210,7 @@ name = "validate-npm-package-name"
 version = "0.1.0"
 dependencies = [
  "lazy_static",
- "percent-encoding 1.0.1",
+ "percent-encoding",
  "regex 1.5.4",
 ]
 

--- a/crates/validate-npm-package-name/Cargo.toml
+++ b/crates/validate-npm-package-name/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2018"
 
 [dependencies]
 lazy_static = "1.3.0"
-percent-encoding = "1.0.1"
+percent-encoding = "2.1.0"
 regex = "1.1.6"


### PR DESCRIPTION
Info
-----
* The dependabot update to `percent-encoding` in #1063 is failing to build, because predefined escape sets were removed in 2.1.0.

Changes
-----
* Bumped `percent-encoding` version
* Switched to using `utf8_percent_encode`, which takes an `&str` instead of an `&[u8]`.
* Created a custom `AsciiSet` based on the definition of [`encodeURIComponent`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#description)

Tested
-----
* All tests for `validate-npm-package-name` pass.