### PR TITLE
Bump cmdline_words_parser and use the new API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,7 +45,7 @@ checksum = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
 name = "archive"
 version = "0.1.0"
 dependencies = [
- "attohttpc",
+ "attohttpc 0.18.0",
  "cfg-if 1.0.0",
  "flate2",
  "fs-utils",
@@ -101,7 +101,24 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "wildmatch",
+ "wildmatch 1.0.11",
+]
+
+[[package]]
+name = "attohttpc"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e69e13a99a7e6e070bb114f7ff381e58c7ccc188630121fc4c2fe4bcf24cd072"
+dependencies = [
+ "flate2",
+ "http",
+ "log",
+ "native-tls",
+ "openssl",
+ "serde",
+ "serde_json",
+ "url",
+ "wildmatch 2.1.0",
 ]
 
 [[package]]
@@ -205,7 +222,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.0",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -354,9 +380,9 @@ dependencies = [
 
 [[package]]
 name = "cmdline_words_parser"
-version = "0.0.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346b10598869bcdcd53cd166ecfb04ff8a4d5d7bb33e4ef4acbdb2a447ac3c73"
+checksum = "75d8078f03daf673d8bd34a1ef48c680ea4a895204882ce5f0ccfb2487b2bd29"
 
 [[package]]
 name = "colored"
@@ -426,6 +452,15 @@ name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc"
@@ -507,7 +542,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.0",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -517,7 +561,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.3.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users 0.4.0",
  "winapi 0.3.9",
 ]
 
@@ -607,7 +671,7 @@ checksum = "450537dc346f0c4d738dda31e790da1da5d4bd12145aad4da0d03d713cb3794f"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.54",
  "winapi 0.3.9",
 ]
 
@@ -687,6 +751,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1163,6 +1237,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,7 +1343,7 @@ checksum = "f249ea6de7c7b7aba92b4ff4376a994c6dbd98fd2166c89d5c4947397ecb574d"
 dependencies = [
  "maplit",
  "pest",
- "sha-1",
+ "sha-1 0.8.1",
 ]
 
 [[package]]
@@ -1592,6 +1672,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,7 +1689,17 @@ dependencies = [
  "argon2rs",
  "failure",
  "rand_os",
- "redox_syscall",
+ "redox_syscall 0.1.54",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.3",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -1799,10 +1898,23 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.0",
  "fake-simd",
- "opaque-debug",
+ "opaque-debug 0.2.2",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1902,7 +2014,7 @@ checksum = "b3196bfbffbba3e57481b6ea32249fbaf590396a52505a2615adbb79d9d826d3"
 dependencies = [
  "filetime",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.54",
  "xattr",
 ]
 
@@ -1921,7 +2033,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "rand 0.6.5",
- "redox_syscall",
+ "redox_syscall 0.1.54",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
@@ -2020,15 +2132,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 dependencies = [
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.54",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.10.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
+checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
 name = "ucd-trie"
@@ -2175,7 +2287,7 @@ dependencies = [
  "atty",
  "cfg-if 1.0.0",
  "ci_info",
- "dirs",
+ "dirs 1.0.5",
  "envoy",
  "hamcrest2",
  "hyperx",
@@ -2199,7 +2311,7 @@ name = "volta-core"
 version = "0.1.0"
 dependencies = [
  "archive",
- "attohttpc",
+ "attohttpc 0.16.0",
  "atty",
  "cfg-if 1.0.0",
  "chain-map",
@@ -2209,7 +2321,7 @@ dependencies = [
  "console",
  "ctrlc",
  "detect-indent",
- "dirs",
+ "dirs 4.0.0",
  "double-checked-cell",
  "dunce",
  "envoy",
@@ -2230,7 +2342,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha-1",
+ "sha-1 0.9.8",
  "tempfile",
  "term_size",
  "textwrap",
@@ -2310,6 +2422,12 @@ name = "wildmatch"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae79c150cec3fd46326dfb57f358b1f8f75223869555c5cb6c896a393ee4615c"
+
+[[package]]
+name = "wildmatch"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6c48bd20df7e4ced539c12f570f937c6b4884928a87fee70a479d72f031d4e0"
 
 [[package]]
 name = "winapi"

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -23,7 +23,7 @@ archive = { path = "../archive" }
 lazycell = "1.2.0"
 lazy_static = "1.3.0"
 semver = { git = "https://github.com/mikrostew/semver", branch = "new-parser" }
-cmdline_words_parser = "0.0.2"
+cmdline_words_parser = "0.2.1"
 fs-utils = { path = "../fs-utils" }
 cfg-if = "1.0"
 winfolder = "0.1"

--- a/crates/volta-core/src/hook/tool.rs
+++ b/crates/volta-core/src/hook/tool.rs
@@ -7,7 +7,7 @@ use std::process::Stdio;
 use crate::command::create_command;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::tool::{NODE_DISTRO_ARCH, NODE_DISTRO_OS};
-use cmdline_words_parser::StrExt;
+use cmdline_words_parser::parse_posix;
 use dunce::canonicalize;
 use lazy_static::lazy_static;
 use log::debug;
@@ -102,7 +102,7 @@ impl MetadataHook {
 /// Execute a shell command and return the trimmed stdout from that command
 fn execute_binary(bin: &str, base_path: &Path, extra_arg: Option<String>) -> Fallible<String> {
     let mut trimmed = bin.trim().to_string();
-    let mut words = trimmed.parse_cmdline_words();
+    let mut words = parse_posix(&mut trimmed);
     let cmd = match words.next() {
         Some(word) => {
             // Treat any path that starts with a './' or '../' as a relative path (using OS separator)


### PR DESCRIPTION
Info
-----
* The dependabot update to `cmdline_words_parser` in #1065  is failing to build, because the API has changed from an extension trait to a bare function.

Changes
-----
* Bumped `cmdline_words_parser` version
* Switched to calling `posix_parse` instead of `StrExt::parse_cmdline_words`

Tested
-----
* All tests pass.