### PR TITLE
Bump indicatif to latest and update API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.12.0"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d596a9576eaa1446996092642d72bfef35cf47243129b7ab883baf5faec31e"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
 dependencies = [
  "console",
  "lazy_static",
@@ -1214,9 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "number_prefix"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "ole32-sys"

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -14,7 +14,7 @@ cross-platform-docs = []
 
 [dependencies]
 term_size = "0.3.0"
-indicatif = "0.12.0"
+indicatif = "0.16.2"
 console = ">=0.11.3, <1.0.0"
 readext = "0.1.0"
 serde_json = { version = "1.0.37", features = ["preserve_order"] }

--- a/crates/volta-core/src/style.rs
+++ b/crates/volta-core/src/style.rs
@@ -1,4 +1,5 @@
 //! The view layer of Volta, with utilities for styling command-line output.
+use std::borrow::Cow;
 use std::error::Error;
 
 use archive::Origin;
@@ -69,7 +70,7 @@ pub fn progress_bar(origin: Origin, details: &str, len: u64) -> ProgressBar {
 
     let progress = ProgressBar::new(len);
 
-    progress.set_message(&format!(
+    progress.set_message(format!(
         "{: >width$} {}",
         style(action).green().bold(),
         details,
@@ -91,7 +92,10 @@ cfg_if! {
     if #[cfg(windows)] {
         /// Constructs a command-line progress spinner with the specified "message"
         /// string. The spinner is ticked by default every 100ms.
-        pub fn progress_spinner(message: &str) -> ProgressBar {
+        pub fn progress_spinner<S>(message: S) -> ProgressBar
+        where
+            S: Into<Cow<'static, str>>,
+        {
             let spinner = ProgressBar::new_spinner();
             // Windows CMD prompt doesn't support Unicode characters, so use a simplified spinner
             let style = ProgressStyle::default_spinner().tick_chars(r#"-\|/-"#);
@@ -105,7 +109,10 @@ cfg_if! {
     } else {
         /// Constructs a command-line progress spinner with the specified "message"
         /// string. The spinner is ticked by default every 50ms.
-        pub fn progress_spinner(message: &str) -> ProgressBar {
+        pub fn progress_spinner<S>(message: S) -> ProgressBar
+        where
+            S: Into<Cow<'static, str>>,
+        {
             // ⠋ Fetching public registry: https://nodejs.org/dist/index.json
             let spinner = ProgressBar::new_spinner();
 

--- a/crates/volta-core/src/tool/node/resolve.rs
+++ b/crates/volta-core/src/tool/node/resolve.rs
@@ -197,7 +197,7 @@ fn resolve_node_versions(url: &str) -> Fallible<RawNodeIndex> {
         }
         None => {
             debug!("Node index cache was not found or was invalid");
-            let spinner = progress_spinner(&format!("Fetching public registry: {}", url));
+            let spinner = progress_spinner(format!("Fetching public registry: {}", url));
 
             let (_, headers, response) = attohttpc::get(url)
                 .send()

--- a/crates/volta-core/src/tool/npm/resolve.rs
+++ b/crates/volta-core/src/tool/npm/resolve.rs
@@ -41,7 +41,7 @@ fn fetch_npm_index(hooks: Option<&ToolHooks<Npm>>) -> Fallible<(String, PackageI
         _ => public_registry_index("npm"),
     };
 
-    let spinner = progress_spinner(&format!("Fetching public registry: {}", url));
+    let spinner = progress_spinner(format!("Fetching public registry: {}", url));
     let metadata: RawPackageMetadata = attohttpc::get(&url)
         .header(ACCEPT, NPM_ABBREVIATED_ACCEPT_HEADER)
         .send()

--- a/crates/volta-core/src/tool/package/install.rs
+++ b/crates/volta-core/src/tool/package/install.rs
@@ -30,7 +30,7 @@ pub(super) fn run_global_install(
     PackageManager::Npm.setup_global_command(&mut command, staging_dir);
 
     debug!("Installing {} with command: {:?}", package, command);
-    let spinner = progress_spinner(&format!("Installing {}", package));
+    let spinner = progress_spinner(format!("Installing {}", package));
     let output_result = command
         .output()
         .with_context(|| ErrorKind::PackageInstallFailed {

--- a/crates/volta-core/src/tool/yarn/resolve.rs
+++ b/crates/volta-core/src/tool/yarn/resolve.rs
@@ -71,7 +71,7 @@ fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Yarn>>) -> Fall
 
 fn fetch_yarn_index() -> Fallible<(String, PackageIndex)> {
     let url = public_registry_index("yarn");
-    let spinner = progress_spinner(&format!("Fetching public registry: {}", url));
+    let spinner = progress_spinner(format!("Fetching public registry: {}", url));
     let metadata: RawPackageMetadata = attohttpc::get(&url)
         .header(ACCEPT, NPM_ABBREVIATED_ACCEPT_HEADER)
         .send()
@@ -132,7 +132,7 @@ fn resolve_semver_from_registry(matching: VersionReq) -> Fallible<Version> {
 }
 
 fn resolve_semver_legacy(matching: VersionReq, url: String) -> Fallible<Version> {
-    let spinner = progress_spinner(&format!("Fetching public registry: {}", url));
+    let spinner = progress_spinner(format!("Fetching public registry: {}", url));
     let releases: RawYarnIndex = attohttpc::get(&url)
         .send()
         .and_then(Response::error_for_status)


### PR DESCRIPTION
Info
-----
* The dependabot update to `indicatif` in #1094 is failing because the API has changed slightly between versions.

Changes
-----
* Bumped `indicatif` to the latest version.
* Updated `progress_spinner` to accept the message as a `Cow<'static, str>` to match `indicatif`. This allows it to accept either a string literal or an owned string, which matches our usage.
* Removed the now-incorrect borrows of the results of `format!` when calling `progress_spinner`

Tested
-----
* All tests pass
* Manual testing confirms the spinner is still shown as expected.