### PR TITLE
feat: arm64 linux build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,20 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Set up docker image
-        run: docker build -t volta .
-        working-directory: ./ci/docker
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: .
+          file: ./ci/docker/Dockerfile.centos6
+          load: true
+          push: false
+          tags: volta
+          target: base
       - name: Compile and package Volta
         run: docker run --volume ${PWD}:/root/workspace --workdir /root/workspace --rm --init --tty volta /root/workspace/ci/build-and-package.sh volta-centos
       - name: Confirm correct OpenSSL Version
@@ -33,34 +44,86 @@ jobs:
   linux:
     strategy:
       matrix:
-        openssl:
-          - 1_1_0
-          - 1_0_1
-    name: Build - OpenSSL ${{ matrix.openssl }}
+        arch: [x86_64, arm64]
+        openssl: [1_0_1, 1_1_1]
+        os: [linux]
+        include:
+        - arch: x86_64
+          dockerfile: Dockerfile.centos6
+          # Docker's BuildX platform for x86_64 is `amd64`. But `uname -m` on linux returns x86_64.
+          # So we'll officially designate this binary as `x86_64` but map it here to `amd64` so that
+          # we build it on the correct docker arch
+          dockerArch: amd64
+        - arch: arm64
+          dockerfile: Dockerfile.centos8
+          dockerArch: arm64
+
+    name: Build - OpenSSL ${{ matrix.openssl }} - Arch ${{ matrix.arch }}
     runs-on: ubuntu-latest
     steps:
+      
       - name: Check out code
         uses: actions/checkout@v2
-      - name: Check out OpenSSL
-        uses: actions/checkout@v2
+
+      # Not stricly speaking necessary for x86 builds, but the QEMU arm64 builds take hours
+      - name: Rust build cache
+        id: cache-openssl
+        uses: actions/cache@v2
         with:
-          repository: openssl/openssl
-          ref: OpenSSL_${{ matrix.openssl }}-stable
-          path: openssl
-      - name: Set up docker image
-        run: docker build -t volta .
-        working-directory: ./ci/docker
+          path: |
+            .cargo/registry
+            .cargo/git
+            target/
+          key: ${{ runner.os }}-${{ matrix.openssl }}-${{ matrix.arch }}-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.openssl }}-${{ matrix.arch }}-target-
+
+      - name: Clean .git
+        run: |
+          rm -rf ./openssl/.git
+
+      - name: Debug
+        run: |
+          echo $(ls -la)
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          build-args: |
+            OPENSSL_VERSION=${{ matrix.openssl }}
+          cache-from: type=gha,scope=${{ matrix.openssl }}-${{ matrix.arch }}
+          cache-to: type=gha,scope=${{ matrix.openssl }}-${{ matrix.arch }},mode=max
+          context: .
+          file: ./ci/docker/${{ matrix.dockerfile }}
+          load: true
+          platforms: linux/${{ matrix.dockerArch }}
+          push: false
+          tags: volta-${{ matrix.openssl }}-${{ matrix.arch }}
+          target: openssl-${{ matrix.openssl }}
+
       - name: Compile and package OpenSSL & Volta
-        run: docker run --volume ${PWD}:/root/workspace --workdir /root/workspace --rm --init --tty volta /root/workspace/ci/build-with-openssl.sh volta-openssl-${{ matrix.openssl }}
+        run: docker run --volume ${PWD}:/root/workspace --platform linux/${{ matrix.dockerArch }} --workdir /root/workspace --rm --init --tty volta-${{ matrix.openssl }}-${{ matrix.arch }} /root/workspace/ci/build-with-openssl.sh volta-openssl-${{ matrix.openssl }}-${{ matrix.arch }}
+      
+      - name: Set .cargo/ ownership to current user
+        run: sudo chown -R $(id -u):$(id -g) .cargo/
+
       - name: Confirm OpenSSL Version
         run: |
           objdump -p target/release/volta
           readelf -d target/release/volta
+
       - name: Upload release artifact
         uses: actions/upload-artifact@v2
         with:
           name: linux-openssl-${{ matrix.openssl }}
-          path: target/release/volta-openssl-${{ matrix.openssl }}.tar.gz
+          path: target/release/volta-openssl-${{ matrix.openssl }}-${{ matrix.arch }}.tar.gz
 
   macos:
     name: Build - MacOS
@@ -180,15 +243,25 @@ jobs:
         with:
           name: linux-centos
           path: release
-      - name: Fetch OpenSSL 1.0.* artifact
+      - name: Fetch OpenSSL 1.0.*-x86_64 artifact
         uses: actions/download-artifact@v2
         with:
-          name: linux-openssl-1_0_1
+          name: linux-openssl-1_0_1-x86_64
           path: release
-      - name: Fetch OpenSSL 1.1.* artifact
+      - name: Fetch OpenSSL 1.0.*-arm64 artifact
         uses: actions/download-artifact@v2
         with:
-          name: linux-openssl-1_1_0
+          name: linux-openssl-1_0_1-arm64
+          path: release
+      - name: Fetch OpenSSL 1.1.*-x86_64 artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-openssl-1_1_0-x86_64
+          path: release
+      - name: Fetch OpenSSL 1.1.*-arm64 artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: linux-openssl-1_1_0-arm64
           path: release
       - name: Fetch MacOS artifact
         uses: actions/download-artifact@v2
@@ -230,24 +303,42 @@ jobs:
           asset_path: ./release/volta-centos.tar.gz
           asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-rhel.tar.gz
           asset_content_type: applictaion/gzip
-      - name: Upload OpenSSL 1.0.* artifact
+      - name: Upload OpenSSL 1.0.*-amd64 artifact
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./release/volta-openssl-1_0_1.tar.gz
-          asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-1.0.tar.gz
+          asset_path: ./release/volta-openssl-1_0_1-amd64.tar.gz
+          asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-1.0-amd64.tar.gz
           asset_content_type: applictaion/gzip
-      - name: Upload OpenSSL 1.1.* artifact
+      - name: Upload OpenSSL 1.0.*-arm64 artifact
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./release/volta-openssl-1_1_0.tar.gz
-          asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-1.1.tar.gz
+          asset_path: ./release/volta-openssl-1_0_1-arm64.tar.gz
+          asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-1.0-arm64.tar.gz
           asset_content_type: applictaion/gzip
+      - name: Upload OpenSSL 1.1.*-amd64 artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/volta-openssl-1_1_0-amd64.tar.gz
+          asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-1.1-amd64.tar.gz
+          asset_content_type: applictaion/gzip
+      - name: Upload OpenSSL 1.1.*-arm64 artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release/volta-openssl-1_1_0-arm64.tar.gz
+          asset_name: volta-${{ steps.release_info.outputs.version }}-linux-openssl-1.1-arm64.tar.gz
+          asset_content_type: applictaion/gzip 
       - name: Upload MacOS artifact
         uses: actions/upload-release-asset@v1
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ crashlytics-build.properties
 fabric.properties
 
 # End of https://www.gitignore.io/api/intellij
+
+openssl/

--- a/ci/build-openssl.sh
+++ b/ci/build-openssl.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+echo "Checking out OpenSSL $1"
+git clone --branch OpenSSL_"$1"-stable https://github.com/openssl/openssl
+
+echo "Building OpenSSL"
+cd openssl
+./config shared --prefix=/app/src/openssl-dist
+make
+make install_sw
+cd -

--- a/ci/build-with-openssl.sh
+++ b/ci/build-with-openssl.sh
@@ -2,11 +2,4 @@
 
 set -e
 
-echo "Building OpenSSL"
-cd openssl
-./config shared --prefix=/root/workspace/openssl-dist
-make
-make install_sw
-cd -
-
-OPENSSL_DIR=/root/workspace/openssl-dist ./ci/build-and-package.sh "$1"
+OPENSSL_DIR=/app/src/openssl-dist ./ci/build-and-package.sh "$1"

--- a/ci/docker/Dockerfile.centos6
+++ b/ci/docker/Dockerfile.centos6
@@ -1,4 +1,4 @@
-FROM centos:6.10
+FROM centos:6.10 as base
 
 # CentOS 6 packages are no longer hosted on the main repository, instead they are in the CentOS Vault
 RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Base.repo && \
@@ -6,8 +6,21 @@ RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Base.repo && \
 
 # Set up additional build tools
 RUN yum -y update && yum clean all
-RUN yum -y install gcc curl openssl openssl-devel ca-certificates tar perl perl-Module-Load-Conditional && yum clean all
+RUN yum -y install gcc git curl openssl openssl-devel ca-certificates tar perl perl-Module-Load-Conditional && yum clean all
 
 # Install Rust
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
-ENV PATH="/root/.cargo/bin:${PATH}"
+
+ENV CARGO_HOME=/root/workspace/.cargo \
+    PATH="/root/.cargo/bin:${PATH}"
+
+FROM base as openssl
+
+WORKDIR /app/src
+COPY ./ci ./ci
+
+FROM openssl AS openssl-1_0_1
+RUN ./ci/build-openssl.sh 1_0_1
+
+FROM openssl AS openssl-1_1_1
+RUN ./ci/build-openssl.sh 1_1_1

--- a/ci/docker/Dockerfile.centos8
+++ b/ci/docker/Dockerfile.centos8
@@ -1,0 +1,26 @@
+FROM centos:8 as base
+
+# CentOS 6 packages are no longer hosted on the main repository, instead they are in the CentOS Vault
+# RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Base.repo && \
+#     sed -i 's/#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever/baseurl=http:\/\/vault.centos.org\/6.10/g' /etc/yum.repos.d/CentOS-Base.repo
+
+# Set up additional build tools
+RUN yum -y update && yum clean all
+RUN yum -y install gcc git curl openssl openssl-devel ca-certificates tar perl perl-Module-Load-Conditional && yum clean all
+
+# Install Rust
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+
+ENV CARGO_HOME=/root/workspace/.cargo \
+    PATH="/root/.cargo/bin:${PATH}"
+
+FROM base as openssl
+
+WORKDIR /app/src
+COPY ./ci ./ci
+
+FROM openssl AS openssl-1_0_1
+RUN ./ci/build-openssl.sh 1_0_1
+
+FROM openssl AS openssl-1_1_1
+RUN ./ci/build-openssl.sh 1_1_1

--- a/dev/unix/tests/install-script.bats
+++ b/dev/unix/tests/install-script.bats
@@ -42,19 +42,35 @@ END_CARGO_TOML
 
 
 # macos
-@test "parse_os_info - macos" {
+@test "parse_os_info - macos intel" {
   expected_output="macos"
 
-  run parse_os_info "Darwin" "this is ignored"
+  run parse_os_info "Darwin" "arch is ignored" "openssl is ignored"
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+@test "parse_os_info - macos m1" {
+  expected_output="macos-aarch64"
+
+  run parse_os_info "Darwin" "arm64" "openssl is ignored"
   [ "$status" -eq 0 ]
   diff <(echo "$output") <(echo "$expected_output")
 }
 
 # linux - supported OpenSSL
-@test "parse_os_info - linux with supported OpenSSL" {
-  expected_output="linux-openssl-1.2"
+@test "parse_os_info - linux-x86_64 with supported OpenSSL" {
+  expected_output="linux-openssl-1.2-x86_64"
 
-  run parse_os_info "Linux" "OpenSSL 1.2.3a whatever else"
+  run parse_os_info "Linux" "x86_64" "OpenSSL 1.2.3a whatever else"
+  [ "$status" -eq 0 ]
+  diff <(echo "$output") <(echo "$expected_output")
+}
+
+@test "parse_os_info - linux-arm64 with supported OpenSSL" {
+  expected_output="linux-openssl-1.2-arm64"
+
+  run parse_os_info "Linux" "arm64" "OpenSSL 1.2.3a whatever else"
   [ "$status" -eq 0 ]
   diff <(echo "$output") <(echo "$expected_output")
 }
@@ -63,7 +79,7 @@ END_CARGO_TOML
 @test "parse_os_info - linux with unsupported OpenSSL" {
   expected_output=$(echo -e "\033[1;31mError\033[0m: Releases for 'SomeSSL' not currently supported. Supported libraries are: OpenSSL.")
 
-  run parse_os_info "Linux" "SomeSSL 1.2.3a whatever else"
+  run parse_os_info "Linux" "x86_64" "SomeSSL 1.2.3a whatever else"
   [ "$status" -eq 1 ]
   diff <(echo "$output") <(echo "$expected_output")
 }
@@ -72,7 +88,7 @@ END_CARGO_TOML
 @test "parse_os_info - linux with unexpected OpenSSL format" {
   expected_output=$(echo -e "\033[1;31mError\033[0m: Could not determine OpenSSL version for 'Some SSL 1.2.4'.")
 
-  run parse_os_info "Linux" "Some SSL 1.2.4"
+  run parse_os_info "Linux" "x86_64" "Some SSL 1.2.4"
   [ "$status" -eq 1 ]
   diff <(echo "$output") <(echo "$expected_output")
 }

--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -124,7 +124,8 @@ upgrade_is_ok() {
 # including the openssl info if necessary
 parse_os_info() {
   local uname_str="$1"
-  local openssl_version="$2"
+  local arch_str="$2"
+  local openssl_version="$3"
 
   case "$uname_str" in
     Linux)
@@ -133,11 +134,10 @@ parse_os_info() {
       if [ "$exit_code" != 0 ]; then
         return "$exit_code"
       fi
-
-      echo "linux-openssl-$parsed_version"
+      echo "linux-openssl-$parsed_version-$arch_str"
       ;;
     Darwin)
-      if [ "$(uname -m)" == "arm64" ]; then
+      if [ "$arch_str" == "arm64" ]; then
         echo "macos-aarch64"
       else
         echo "macos"
@@ -359,9 +359,10 @@ download_release() {
   local version="$1"
 
   local uname_str="$(uname -s)"
+  local arch_str="$(uname -m)"
   local openssl_version="$(openssl version)"
   local os_info
-  os_info="$(parse_os_info "$uname_str" "$openssl_version")"
+  os_info="$(parse_os_info "$uname_str" "arch_str" "$openssl_version")"
   if [ "$?" != 0 ]; then
     error "The current operating system ($uname_str) does not appear to be supported by Volta."
     return 1


### PR DESCRIPTION
I've been poking on this on and off since early November and didn't realize that in the meantime someone else had opened https://github.com/volta-cli/volta/pull/1052

I've taken a look at that approach and personally prefer the approach I've taken (we build our internal CI arm64 docker images this way at my day job), and I have working builds already that you can pull to your own machine to test and play with. I haven't exhaustively tested the binary yet as my primary focus was on reducing the time it takes to build the binary, but it should work well enough at the moment for testing. I'll do a full pass in the coming days.

#### Why do this at all?
I'm on an M1 MBP. It's a lovely machine. But at my day job we use volta inside debian docker images. Because volta only supports x86_amd64 on Linux I have to run an x86 Docker container locally. It's painfully slow virtualizing a Docker image this way. Native arm64 builds of volta would allow us to build both arm64 and x86 versions of our docker images for local development.

On to the good bits: I've updated the existing linux flow with an additional matrix dimension for architecture. The benefit here is keeping a consistent build process for every linux release. We can leverage Docker's `buildx` and `qemu` actions to build both `x86` and `arm64` binaries in parallel. I needed to bump to CentOS 8 for this to work as 6 does not have an arm64 linux image available. The big caveat: building arm64 binaries on a qemu layer is _very very_ slow. Without any caching enhancements it takes over 2 hours to build. 🤯.

On that note I've refactored how OpenSSL builds work. Rather than build them on every single build I've elected to move the build process inside the docker image, and then cache that docker image. On repeated builds the image is downloaded from the cache, restored into the docker runtime on the GHA node, and you only need to spend the time to build volta itself without spending CPU cycles rebuilding OpenSSL every time.

Additionally I'm caching the rust `target` directory between builds so we can reduce the amount of time spent on building dependencies. That was another source that took exponentially longer on arm64 VMs.

Related https://github.com/volta-cli/volta/issues/1006