### PR TITLE
Clean up unnecessary to_string calls

### DIFF
--- a/crates/volta-core/src/hook/tool.rs
+++ b/crates/volta-core/src/hook/tool.rs
@@ -186,9 +186,7 @@ pub mod tests {
         // tar.gz format has extra handling, to support a multi-part extension
         let expected = format!(
             "http://localhost/node/{}/{}/{}/tar.gz/node-v1.0.0.tar.gz",
-            NODE_DISTRO_OS,
-            NODE_DISTRO_ARCH,
-            version.to_string()
+            NODE_DISTRO_OS, NODE_DISTRO_ARCH, version
         );
         assert_eq!(
             hook.resolve(&version, "node-v1.0.0.tar.gz")
@@ -199,9 +197,7 @@ pub mod tests {
         // zip is a standard extension
         let expected = format!(
             "http://localhost/node/{}/{}/{}/zip/node-v1.0.0.zip",
-            NODE_DISTRO_OS,
-            NODE_DISTRO_ARCH,
-            version.to_string()
+            NODE_DISTRO_OS, NODE_DISTRO_ARCH, version
         );
         assert_eq!(
             hook.resolve(&version, "node-v1.0.0.zip")

--- a/crates/volta-layout-macro/src/ir.rs
+++ b/crates/volta-layout-macro/src/ir.rs
@@ -91,7 +91,7 @@ impl Ir {
 
         let methods = self.field_names().map(|field_name| {
             // Markdown-formatted field name for the doc comment.
-            let markdown_field_name = format!("`{}`", field_name.to_string());
+            let markdown_field_name = format!("`{}`", field_name);
             let markdown_field_name = LitStr::new(&markdown_field_name, field_name.span());
 
             // Use the field name's span for good duplicate-method-name error messages.
@@ -129,7 +129,7 @@ impl Ir {
         let all_names = dir_names.chain(file_names).chain(exe_names);
         let all_inits = dir_inits.chain(file_inits).chain(exe_inits);
 
-        let markdown_struct_name = format!("`{}`", name.to_string());
+        let markdown_struct_name = format!("`{}`", name);
         let markdown_struct_name = LitStr::new(&markdown_struct_name, name.span());
 
         quote! {


### PR DESCRIPTION
Info
-----
* Another new Rust release comes with new clippy lints! This time, clippy found a few places where we were unnecessarily calling `to_string` inside of a `format!` macro 🤯 

Changes
-----
* Removed the redundant `to_string` calls.