### PR TITLE
Swap to the archive.kernel.org mirror of the CentOS vault

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:6.10
 
 # CentOS 6 packages are no longer hosted on the main repository, instead they are in the CentOS Vault
 RUN sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Base.repo && \
-    sed -i 's/#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever/baseurl=http:\/\/vault.centos.org\/6.10/g' /etc/yum.repos.d/CentOS-Base.repo
+    sed -i 's/#baseurl=http:\/\/mirror.centos.org\/centos\/$releasever/baseurl=http:\/\/archive.kernel.org\/centos-vault\/6.10/g' /etc/yum.repos.d/CentOS-Base.repo
 
 # Set up additional build tools
 RUN yum -y update && yum clean all


### PR DESCRIPTION
Info
-----
* The default CentOS vault seems to be very spotty and regularly disconnecting, trying to switch to the mirror hosted on `archive.kernel.org`