### PR TITLE
Don't intercept npm commands with prefix flag

### DIFF
--- a/crates/volta-core/src/run/parser.rs
+++ b/crates/volta-core/src/run/parser.rs
@@ -11,6 +11,7 @@ use crate::inventory::package_configs;
 use crate::platform::{Platform, PlatformSpec};
 use crate::tool::package::PackageManager;
 use crate::tool::Spec;
+use log::debug;
 
 const UNSAFE_GLOBAL: &str = "VOLTA_UNSAFE_GLOBAL";
 /// Aliases that npm supports for the 'install' command
@@ -396,6 +397,10 @@ where
             _ => (global, prefix),
         }
     });
+
+    if has_global && has_prefix {
+        debug!("Skipping global interception due to prefix argument");
+    }
 
     has_global && !has_prefix
 }


### PR DESCRIPTION
Closes #1166 

Info
-----
* Our interception of `npm install --global` (and other global npm commands) relies on us setting the `prefix` configuration via an environment variable.
* However, if a user (or script) explicitly provides a prefix at the command line via `--prefix`, that will override our environment variable.
* In those cases, our intercepted install will fail since the install will go to a different location than we expect.
* At the same time, explicitly providing a prefix is an advanced option that likely means the user is doing something intentional and not trying to do a "standard" global install.
* We shouldn't try to be smarter than the user, in these cases we should skip interception entirely to prevent unexpected errors.

Changes
-----
* Updated the `has_global_flag` helper to `has_global_without_prefix` to check for both the _presence_ of `--global` and the _absence_ of `--prefix`

Tested
-----
* Added a unit test that covers each of the global commands and confirms that the parser disables global interception when an explicit prefix is added.