### PR TITLE
Add "format" to yarn.index hook

### DIFF
--- a/crates/volta-core/fixtures/hooks/format_github.json
+++ b/crates/volta-core/fixtures/hooks/format_github.json
@@ -1,0 +1,20 @@
+{
+  "node": {
+    "index": {
+      "prefix": "http://localhost/node/index/",
+      "format": "github"
+    }
+  },
+  "npm": {
+    "index": {
+      "prefix": "http://localhost/npm/index/",
+      "format": "github"
+    }
+  },
+  "yarn": {
+    "index": {
+      "prefix": "http://localhost/yarn/index/",
+      "format": "github"
+    }
+  }
+}

--- a/crates/volta-core/fixtures/hooks/format_npm.json
+++ b/crates/volta-core/fixtures/hooks/format_npm.json
@@ -1,0 +1,20 @@
+{
+  "node": {
+    "index": {
+      "prefix": "http://localhost/node/index/",
+      "format": "npm"
+    }
+  },
+  "npm": {
+    "index": {
+      "prefix": "http://localhost/npm/index/",
+      "format": "npm"
+    }
+  },
+  "yarn": {
+    "index": {
+      "prefix": "http://localhost/yarn/index/",
+      "format": "npm"
+    }
+  }
+}

--- a/crates/volta-core/src/error/kind.rs
+++ b/crates/volta-core/src/error/kind.rs
@@ -170,6 +170,11 @@ pub enum ErrorKind {
         version: String,
     },
 
+    /// Thrown when a format other than "npm" or "github" is given for yarn.index in the hooks
+    InvalidRegistryFormat {
+        format: String,
+    },
+
     /// Thrown when a tool name is invalid per npm's rules.
     InvalidToolName {
         name: String,
@@ -811,6 +816,14 @@ To {action} the package '{version}', please use an explicit version such as '{ve
                 write!(f, "{}\n\n{}", error, wrapped_cta)
             }
 
+            ErrorKind::InvalidRegistryFormat { format } => write!(
+                f,
+                "Unrecognized index registry format: '{}'
+
+Please specify either 'npm' or 'github' for the format.",
+format
+            ),
+
             ErrorKind::InvalidToolName { name, errors } => {
                 let indentation = "    ";
                 let wrapped = match text_width() {
@@ -1438,6 +1451,7 @@ impl ErrorKind {
             ErrorKind::InvalidHookOutput { .. } => ExitCode::ExecutionFailure,
             ErrorKind::InvalidInvocation { .. } => ExitCode::InvalidArguments,
             ErrorKind::InvalidInvocationOfBareVersion { .. } => ExitCode::InvalidArguments,
+            ErrorKind::InvalidRegistryFormat { .. } => ExitCode::ConfigurationError,
             ErrorKind::InvalidToolName { .. } => ExitCode::InvalidArguments,
             ErrorKind::LockAcquireError => ExitCode::FileSystemError,
             ErrorKind::NoBundledNpm { .. } => ExitCode::ConfigurationError,

--- a/crates/volta-core/src/tool/npm/resolve.rs
+++ b/crates/volta-core/src/tool/npm/resolve.rs
@@ -1,7 +1,7 @@
 //! Provides resolution of npm Version requirements into specific versions
 
 use super::super::registry::{
-    fetch_public_index, public_registry_index, PackageDetails, PackageIndex,
+    fetch_npm_registry, public_registry_index, PackageDetails, PackageIndex,
 };
 use crate::error::{ErrorKind, Fallible};
 use crate::hook::ToolHooks;
@@ -36,7 +36,7 @@ fn fetch_npm_index(hooks: Option<&ToolHooks<Npm>>) -> Fallible<(String, PackageI
         _ => public_registry_index("npm"),
     };
 
-    fetch_public_index(url, "npm")
+    fetch_npm_registry(url, "npm")
 }
 
 fn resolve_tag(tag: &str, hooks: Option<&ToolHooks<Npm>>) -> Fallible<Version> {

--- a/crates/volta-core/src/tool/registry.rs
+++ b/crates/volta-core/src/tool/registry.rs
@@ -34,8 +34,9 @@ cfg_if! {
     }
 }
 
-pub fn fetch_public_index(url: String, name: &str) -> Fallible<(String, PackageIndex)> {
-    let spinner = progress_spinner(format!("Fetching public registry: {}", url));
+// fetch a registry that returns info in Npm format
+pub fn fetch_npm_registry(url: String, name: &str) -> Fallible<(String, PackageIndex)> {
+    let spinner = progress_spinner(format!("Fetching npm registry: {}", url));
     let metadata: RawPackageMetadata = attohttpc::get(&url)
         .header(ACCEPT, NPM_ABBREVIATED_ACCEPT_HEADER)
         .send()

--- a/crates/volta-core/src/tool/yarn/fetch.rs
+++ b/crates/volta-core/src/tool/yarn/fetch.rs
@@ -10,7 +10,7 @@ use super::super::registry::{
 };
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::fs::{create_staging_dir, create_staging_file, rename, set_executable};
-use crate::hook::ToolHooks;
+use crate::hook::YarnHooks;
 use crate::layout::volta_home;
 use crate::style::{progress_bar, tool_version};
 use crate::tool::{self, Yarn};
@@ -20,7 +20,7 @@ use fs_utils::ensure_containing_dir_exists;
 use log::debug;
 use semver::Version;
 
-pub fn fetch(version: &Version, hooks: Option<&ToolHooks<Yarn>>) -> Fallible<()> {
+pub fn fetch(version: &Version, hooks: Option<&YarnHooks>) -> Fallible<()> {
     let yarn_dir = volta_home()?.yarn_inventory_dir();
     let cache_file = yarn_dir.join(Yarn::archive_filename(&version.to_string()));
 
@@ -117,10 +117,10 @@ fn load_cached_distro(file: &Path) -> Option<Box<dyn Archive>> {
 }
 
 /// Determine the remote URL to download from, using the hooks if available
-fn determine_remote_url(version: &Version, hooks: Option<&ToolHooks<Yarn>>) -> Fallible<String> {
+fn determine_remote_url(version: &Version, hooks: Option<&YarnHooks>) -> Fallible<String> {
     let version_str = version.to_string();
     match hooks {
-        Some(&ToolHooks {
+        Some(&YarnHooks {
             distro: Some(ref hook),
             ..
         }) => {


### PR DESCRIPTION
This adds support for user-specified registry formats.

The `"index"` is the only part of the Yarn hooks that can use either Github (legacy) or Npm registry formats.

In [the RFC](https://github.com/volta-cli/rfcs/pull/48), I left a comment suggesting an optional `"format"` field in the `"yarn"` section of the hooks, but ended up implementing this under '"yarn"."index"`, since that is the only hook that is affected by this configuration.

```json
    "yarn": {
        "index": {
            "template": "http://example.com/yarn/{{os}}/{{arch}}/yarn-{{version}}.tgz",
            "format": "npm"
        },
        "latest": {
            "prefix": "http://example.com/yarnpkg/"
        },
        "distro": {
            "bin": "~/yarn-distro"
        }
    }
```

Closes #1196