### PR TITLE
fix: renames `release.sh` to `dev/unix/release.sh`

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -343,7 +343,7 @@ compile_and_package() {
 
   # call the release script to create the packaged archive file
   # '2> >(tee /dev/stderr)' copies stderr to stdout, to collect it and parse the filename
-  release_output="$( "$DIR/release.sh" "--$dev_or_release" 2> >(tee /dev/stderr) )"
+  release_output="$( "$DIR/dev/unix/release.sh" "--$dev_or_release" 2> >(tee /dev/stderr) )"
   [ "$?" != 0 ] && return 1
 
   # parse the release filename and return that


### PR DESCRIPTION
when you pass `--release` or `--dev` to the installer provided at `get.volta.sh`, you get the following error:

```console
$ curl -sSL https://get.volta.sh | bash -s -- --release
Installing Volta locally after compiling with '--release'
    Checking for existing Volta installation
main: line 346: /home/a/work/volta/release.sh: No such file or directory
```

i _believe_ that this PR will fix this by pointing to the correct `release.sh` path, but i'm not entirely sure!