### PR TITLE
Resolve new clippy warnings

### DIFF
--- a/crates/volta-core/src/project/tests.rs
+++ b/crates/volta-core/src/project/tests.rs
@@ -225,20 +225,20 @@ mod plug_n_play {
     fn project_is_not_pnp() {
         let project_path = fixture_path(&["basic"]);
         let test_project = Project::for_dir(project_path).unwrap().unwrap();
-        assert_eq!(test_project.is_yarn_pnp(), false);
+        assert!(!test_project.is_yarn_pnp());
     }
 
     #[test]
     fn project_has_pnp_js() {
         let project_path = fixture_path(&["plug-n-play", "pnp-js"]);
         let test_project = Project::for_dir(project_path).unwrap().unwrap();
-        assert_eq!(test_project.is_yarn_pnp(), true);
+        assert!(test_project.is_yarn_pnp());
     }
 
     #[test]
     fn project_has_pnp_cjs() {
         let project_path = fixture_path(&["plug-n-play", "pnp-cjs"]);
         let test_project = Project::for_dir(project_path).unwrap().unwrap();
-        assert_eq!(test_project.is_yarn_pnp(), true);
+        assert!(test_project.is_yarn_pnp());
     }
 }


### PR DESCRIPTION
Info
-----
* Another new Rust version, more useful clippy warnings.

Changes
-----
* Updated `assert_eq!` with a literal boolean to use `assert!` directly instead.

Tested
-----
* All tests pass.
* Clippy does not show any warnings or errors.