### PR TITLE
Fix clippy warnings

### DIFF
--- a/crates/validate-npm-package-name/src/lib.rs
+++ b/crates/validate-npm-package-name/src/lib.rs
@@ -69,7 +69,7 @@ lazy_static! {
     ];
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Validity {
     /// Valid for new and old packages
     Valid,

--- a/crates/volta-core/src/error/kind.rs
+++ b/crates/volta-core/src/error/kind.rs
@@ -15,7 +15,7 @@ https://github.com/volta-cli/volta/issues with the details!";
 const PERMISSIONS_CTA: &str = "Please ensure you have correct permissions to the Volta directory.";
 
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum ErrorKind {
     /// Thrown when package tries to install a binary that is already installed.
     BinaryAlreadyInstalled {

--- a/crates/volta-core/src/event.rs
+++ b/crates/volta-core/src/event.rs
@@ -18,7 +18,7 @@ pub struct Event {
     pub event: EventKind,
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
 pub struct ErrorEnv {
     argv: String,
     exec_path: String,
@@ -27,7 +27,7 @@ pub struct ErrorEnv {
     platform_version: String,
 }
 
-#[derive(Deserialize, Serialize, PartialEq, Debug)]
+#[derive(Deserialize, Serialize, PartialEq, Eq, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum EventKind {
     Start,

--- a/crates/volta-core/src/hook/mod.rs
+++ b/crates/volta-core/src/hook/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod serial;
 pub mod tool;
 
 /// A hook for publishing Volta events.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Publish {
     /// Reports an event by sending a POST request to a URL.
     Url(String),
@@ -221,7 +221,7 @@ impl HookConfig {
 }
 
 /// Format of the registry used for Yarn (Npm or Github)
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum RegistryFormat {
     Npm,
     Github,

--- a/crates/volta-core/src/hook/tool.rs
+++ b/crates/volta-core/src/hook/tool.rs
@@ -26,7 +26,7 @@ lazy_static! {
 }
 
 /// A hook for resolving the distro URL for a given tool version
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum DistroHook {
     Prefix(String),
     Template(String),
@@ -79,7 +79,7 @@ fn calculate_extension(filename: &str) -> Option<&str> {
 }
 
 /// A hook for resolving the URL for metadata about a tool
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum MetadataHook {
     Prefix(String),
     Template(String),
@@ -101,7 +101,7 @@ impl MetadataHook {
 }
 
 /// A hook for resolving the URL for the Yarn index
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct YarnIndexHook {
     pub format: RegistryFormat,
     pub metadata: MetadataHook,

--- a/crates/volta-core/src/shim.rs
+++ b/crates/volta-core/src/shim.rs
@@ -57,7 +57,7 @@ fn entry_to_shim_name((entry, metadata): (DirEntry, Metadata)) -> Option<String>
     }
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum ShimResult {
     Created,
     AlreadyExists,

--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -63,7 +63,7 @@ pub trait Tool: Display {
 
 /// Specification for a tool and its associated version.
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum Spec {
     Node(VersionSpec),
     Npm(VersionSpec),

--- a/crates/volta-core/src/toolchain/serial.rs
+++ b/crates/volta-core/src/toolchain/serial.rs
@@ -5,7 +5,7 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct NodeVersion {
     #[serde(with = "version_serde")]
     pub runtime: Version,
@@ -13,7 +13,7 @@ pub struct NodeVersion {
     pub npm: Option<Version>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub struct Platform {
     #[serde(default)]
     pub node: Option<NodeVersion>,

--- a/crates/volta-core/src/version/mod.rs
+++ b/crates/volta-core/src/version/mod.rs
@@ -7,7 +7,7 @@ use semver::{Version, VersionReq};
 mod serial;
 
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum VersionSpec {
     /// No version specified (default)
     None,
@@ -23,7 +23,7 @@ pub enum VersionSpec {
 }
 
 #[derive(Debug)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum VersionTag {
     /// The 'latest' tag, a special case that exists for all packages
     Latest,


### PR DESCRIPTION
A new Rust version, new clippy warnings :smile: This time all related to deriving `PartialEq` without also deriving `Eq`.