### PR TITLE
Bump textwrap to 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,6 +1761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,9 +1858,9 @@ checksum = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.5"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
@@ -1987,7 +1998,7 @@ dependencies = [
  "sha-1 0.10.0",
  "tempfile",
  "term_size",
- "textwrap 0.14.2",
+ "textwrap 0.15.1",
  "validate-npm-package-name",
  "volta-layout",
  "walkdir",

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -38,7 +38,7 @@ sha-1 = "0.10.0"
 hex = "0.4.3"
 chrono = "0.4.22"
 validate-npm-package-name = { path = "../validate-npm-package-name" }
-textwrap = "0.14.2"
+textwrap = "0.15.1"
 atty = "0.2"
 log = { version = "0.4", features = ["std"] }
 ctrlc = "3.2.2"

--- a/crates/volta-core/src/log.rs
+++ b/crates/volta-core/src/log.rs
@@ -4,8 +4,7 @@ use console::style;
 use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use std::env;
 use std::fmt::Display;
-use textwrap::word_splitters::NoHyphenation;
-use textwrap::{fill, Options};
+use textwrap::{fill, Options, WordSplitter};
 
 use crate::style::text_width;
 
@@ -127,7 +126,7 @@ where
     match text_width() {
         Some(width) => {
             let options = Options::new(width)
-                .word_splitter(NoHyphenation)
+                .word_splitter(WordSplitter::NoHyphenation)
                 .subsequent_indent(WRAP_INDENT)
                 .break_words(false);
 


### PR DESCRIPTION
This upgrade was attempted by dependabot, but the API had shifted slightly so it needed to be updated manually.