### PR TITLE
Replace `double-checked-cell` with `once_cell`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -497,16 +497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "double-checked-cell"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ecdac508e0a96c2cc6328363eab7937290bfbd397cb360c35786feaed0b06a"
-dependencies = [
- "unreachable",
- "void",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1142,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "opaque-debug"
@@ -1874,15 +1864,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "url"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1927,12 +1908,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "volta"
 version = "1.0.8"
 dependencies = [
@@ -1974,7 +1949,6 @@ dependencies = [
  "ctrlc",
  "detect-indent",
  "dirs",
- "double-checked-cell",
  "dunce",
  "envoy",
  "fs-utils",
@@ -1987,6 +1961,7 @@ dependencies = [
  "lazycell",
  "log",
  "mockito",
+ "once_cell",
  "os_info",
  "readext",
  "regex",

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -44,7 +44,7 @@ log = { version = "0.4", features = ["std"] }
 ctrlc = "3.2.2"
 walkdir = "2.3.2"
 volta-layout = { path = "../volta-layout" }
-double-checked-cell = "2.1.0"
+once_cell = "1.14.0"
 dunce = "1.0.2"
 ci_info = "0.14.6"
 hyperx = "1.4.0"

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -3,9 +3,9 @@ use std::path::PathBuf;
 
 use crate::error::{Context, ErrorKind, Fallible};
 use cfg_if::cfg_if;
-use double_checked_cell::DoubleCheckedCell;
 use dunce::canonicalize;
 use lazy_static::lazy_static;
+use once_cell::sync::OnceCell;
 use volta_layout::v3::{VoltaHome, VoltaInstall};
 
 cfg_if! {
@@ -19,8 +19,8 @@ cfg_if! {
 }
 
 lazy_static! {
-    static ref VOLTA_HOME: DoubleCheckedCell<VoltaHome> = DoubleCheckedCell::new();
-    static ref VOLTA_INSTALL: DoubleCheckedCell<VoltaInstall> = DoubleCheckedCell::new();
+    static ref VOLTA_HOME: OnceCell<VoltaHome> = OnceCell::new();
+    static ref VOLTA_INSTALL: OnceCell<VoltaInstall> = OnceCell::new();
 }
 
 pub fn volta_home<'a>() -> Fallible<&'a VoltaHome> {


### PR DESCRIPTION
Closes #1074.

We can also consider removing `once_cell` crate once it's included in the standard library.