### PR TITLE
Clean up warnings in the tests

### DIFF
--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -80,7 +80,7 @@ impl EnvVar {
 }
 
 // used to construct sandboxed files like package.json, platform.json, etc.
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Eq, Clone)]
 pub struct FileBuilder {
     path: PathBuf,
     contents: String,

--- a/tests/smoke/main.rs
+++ b/tests/smoke/main.rs
@@ -18,7 +18,7 @@ cfg_if::cfg_if! {
         mod direct_upgrade;
         mod npm_link;
         mod package_migration;
-        mod support;
+        pub mod support;
         mod volta_fetch;
         mod volta_install;
         mod volta_run;


### PR DESCRIPTION
Info
-----
* There are a couple of warnings still popping up in CI during the tests.
* One of them is another derive of `Eq`
* The other is a dead code warning around the `EnvVar` in smoke tests. While we aren't using this right now, having it around makes sense going forward (rather than adding / removing it as tests are updated to use or not use the API).

Changes
-----
* Added an `Eq` derive to the `FileBuilder` definition.
* Made the `support` module in the smoke tests `pub`, so that dead code warnings won't be generated for types used by the public API.