### PR TITLE
Bump retry to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "retry"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac95c60a949a63fd2822f4964939662d8f2c16c4fa0624fd954bc6e703b9a3f6"
+checksum = "9166d72162de3575f950507683fac47e30f6f2c3836b71b7fbc61aa517c9c5f4"
 dependencies = [
  "rand",
 ]

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -48,7 +48,7 @@ hyperx = "1.4.0"
 attohttpc = { version = "0.22.0", default-features = false, features = ["json", "compress", "tls-rustls"] }
 chain-map = "0.1.0"
 indexmap = "1.9.1"
-retry = "1.3.1"
+retry = "2"
 fs2 = "0.4.3"
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/volta-core/src/fs.rs
+++ b/crates/volta-core/src/fs.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::layout::volta_home;
 use retry::delay::Fibonacci;
-use retry::{retry, Error as RetryError, OperationResult};
+use retry::{retry, OperationResult};
 use tempfile::{tempdir_in, NamedTempFile, TempDir};
 
 /// Opens a file, creating it if it doesn't exist
@@ -190,8 +190,5 @@ where
             },
         }
     })
-    .map_err(|e| match e {
-        RetryError::Operation { error, .. } => error,
-        RetryError::Internal(message) => io::Error::new(io::ErrorKind::Other, message),
-    })
+    .map_err(|e| e.error)
 }


### PR DESCRIPTION
This was attempted by dependabot, but ran into issues with a change to the `Error` API. Bumping manually and resolving the `Error` issue.