### PR TITLE
Pin Rust to 1.63 to maintain compatibility with old CentOS versions

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.63
           override: true
       - name: Build docs
         uses: actions-rs/cargo@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.63
           override: true
       - name: Compile and package Volta
         run: ./ci/build-macos-x86_64.sh volta-macos
@@ -56,7 +56,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.63
           target: aarch64-apple-darwin
           override: true
       - name: Compile and package Volta
@@ -77,7 +77,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.63
           override: true
       - name: Add cargo-wix subcommand
         uses: actions-rs/cargo@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.63
           override: true
           components: clippy
       - name: Run tests
@@ -57,7 +57,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.63
           override: true
       - name: Run tests
         uses: actions-rs/cargo@v1
@@ -86,7 +86,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.63
           override: true
           components: rustfmt
       - name: Run check

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -12,5 +12,5 @@ RUN wget -O /etc/yum.repos.d/slc6-devtoolset.repo http://linuxsoft.cern.ch/cern/
 RUN yum -y install devtoolset-2-gcc devtoolset-2-binutils
 
 # Install Rust toolchain
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.63
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.63"
+profile = "minimal"


### PR DESCRIPTION
Info
-----
* As noted in the [release announcement](https://blog.rust-lang.org/2022/09/22/Rust-1.64.0.html#compatibility-notes), Rust now requires a minimum of glibc 2.17
* This is higher than Volta's current minimum glibc requirement of 2.12
* We have committed to maintaining that backwards compatibility at least until we release Volta 2.0 at some point in the future.
* As a result, we need to pin our builds to use Rust 1.63 and no longer always use the latest.

Changes
-----
* Updated all CI scripts and the Linux build Dockerfile to pin to Rust 1.63
* Added a `rust-toolchain.toml` file so that developers running `cargo` locally will use the appropriate version as well (making sure we don't accidentally try to use features released after 1.63)

Tested
-----
* CI builds are currently failing for Linux, so the core test is the CI run
* Confirmed locally that running `cargo` within the Volta directory gets Rust 1.63