### PR TITLE
Avoid using curl write-out variable that isn't always supported

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -23,7 +23,7 @@ download_release_from_repo() {
   local download_file="$tmpdir/$filename"
   local archive_url="$(release_url)/download/v$version/$filename"
 
-  curl --progress-bar --show-error --location --fail "$archive_url" --output "$download_file" --write-out '%{filename_effective}'
+  curl --progress-bar --show-error --location --fail "$archive_url" --output "$download_file" --write-out "$download_file"
 }
 
 usage() {


### PR DESCRIPTION
Info
-----
* In #687, we improved the reliability of the install by having cURL write out the filename directly (rather than following it with an `echo` and running into issues of extra output).
* However, some older versions of cURL (including those available by default on older systems that we nominally support) don't understand the `filename_effective` variable.
* This causes the installer to abort early with an error, despite the fact that it successfully downloaded the binary.
* From [the docs](https://everything.curl.dev/usingcurl/verbose/writeout), using `filename_effective` is mostly to handle the case where there is a `--output` set and so the file name is changed. However, in our case we're explicitly setting `--output` and _know_ what the filename is going to be.

Changes
-----
* Updated the `curl` command to use `--write-out` with the actual value of the filename that we are also passing to `--output`, which is exactly what we want.

Tested
-----
* Ran the updated installer locally on a machine that had an old version of cURL and verified that the install completed successfully where it was previously erroring.
* Ran the installer on a machine that had an up-to-date cURL to confirm that it continued to complete successfully.