### PR TITLE
Cache cargo artifacts to speed up CI runs

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -20,6 +20,8 @@ jobs:
           profile: minimal
           toolchain: 1.63
           override: true
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v2
       - name: Build docs
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
           profile: minimal
           toolchain: 1.63
           override: true
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v2
       - name: Compile and package Volta
         run: ./ci/build-macos-x86_64.sh volta-macos
       - name: Upload release artifact
@@ -59,6 +61,8 @@ jobs:
           toolchain: 1.63
           target: aarch64-apple-darwin
           override: true
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v2
       - name: Compile and package Volta
         run: ./ci/build-macos-arm.sh volta-macos-aarch64
       - name: Upload release artifact
@@ -79,6 +83,8 @@ jobs:
           profile: minimal
           toolchain: 1.63
           override: true
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v2
       - name: Add cargo-wix subcommand
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
           toolchain: 1.63
           override: true
           components: clippy
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v2
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -59,6 +61,8 @@ jobs:
           profile: minimal
           toolchain: 1.63
           override: true
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v2
       - name: Run tests
         uses: actions-rs/cargo@v1
         with:
@@ -89,6 +93,8 @@ jobs:
           toolchain: 1.63
           override: true
           components: rustfmt
+      - name: Cargo Cache
+        uses: Swatinem/rust-cache@v2
       - name: Run check
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
Use https://github.com/Swatinem/rust-cache to cache CI artifacts from cargo and speed things up