### PR TITLE
add rustls-native-certs to support MITM enterprise proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,14 +39,12 @@ dependencies = [
 name = "archive"
 version = "0.1.0"
 dependencies = [
- "attohttpc",
  "cfg-if 1.0.0",
+ "fetch",
  "flate2",
  "fs-utils",
  "hyperx",
  "progress-read",
- "rustls",
- "rustls-native-certs",
  "tar",
  "tee",
  "thiserror",
@@ -395,6 +393,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "fetch"
+version = "0.1.0"
+dependencies = [
+ "attohttpc",
+ "rustls",
+ "rustls-native-certs",
 ]
 
 [[package]]
@@ -1579,7 +1586,6 @@ name = "volta-core"
 version = "0.1.0"
 dependencies = [
  "archive",
- "attohttpc",
  "atty",
  "cfg-if 1.0.0",
  "chain-map",
@@ -1592,6 +1598,7 @@ dependencies = [
  "dirs",
  "dunce",
  "envoy",
+ "fetch",
  "fs-utils",
  "fs2",
  "hyperx",
@@ -1606,8 +1613,6 @@ dependencies = [
  "readext",
  "regex",
  "retry",
- "rustls",
- "rustls-native-certs",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 name = "archive"
 version = "0.1.0"
 dependencies = [
- "attohttpc 0.23.1",
+ "attohttpc",
  "cfg-if 1.0.0",
  "flate2",
  "fs-utils",
@@ -62,23 +62,6 @@ checksum = "50f1c3703dd33532d7f0ca049168930e9099ecac238e23cf932f3a69c42f06da"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "attohttpc"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
-dependencies = [
- "flate2",
- "http",
- "log",
- "rustls",
- "serde",
- "serde_json",
- "url",
- "webpki",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1596,7 +1579,7 @@ name = "volta-core"
 version = "0.1.0"
 dependencies = [
  "archive",
- "attohttpc 0.22.0",
+ "attohttpc",
  "atty",
  "cfg-if 1.0.0",
  "chain-map",
@@ -1623,6 +1606,8 @@ dependencies = [
  "readext",
  "regex",
  "retry",
+ "rustls",
+ "rustls-native-certs",
  "semver",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,10 @@
 version = 3
 
 [[package]]
-name = "adler32"
-version = "1.0.3"
+name = "adler"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
@@ -39,12 +39,14 @@ dependencies = [
 name = "archive"
 version = "0.1.0"
 dependencies = [
- "attohttpc",
+ "attohttpc 0.23.1",
  "cfg-if 1.0.0",
  "flate2",
  "fs-utils",
  "hyperx",
  "progress-read",
+ "rustls",
+ "rustls-native-certs",
  "tar",
  "tee",
  "thiserror",
@@ -67,6 +69,23 @@ name = "attohttpc"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
+dependencies = [
+ "flate2",
+ "http",
+ "log",
+ "rustls",
+ "serde",
+ "serde_json",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
+name = "attohttpc"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12489f6c5525b06c7e5d689f0efeeae5b9efc38824478e854da9f4f33f040cf5"
 dependencies = [
  "flate2",
  "http",
@@ -104,12 +123,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "base64"
-version = "0.10.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
-dependencies = [
- "byteorder",
-]
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -137,12 +153,6 @@ checksum = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "build_const"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 
 [[package]]
 name = "bumpalo"
@@ -283,19 +293,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "crc"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-dependencies = [
- "build_const",
-]
 
 [[package]]
 name = "crc32fast"
@@ -417,14 +428,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.8"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "246b6f24d8e616b0c176a8143486ddc8bb0bac2f30f0a0d3efbcf1e0d47cb7e5"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
- "libc",
- "miniz-sys",
- "miniz_oxide_c_api",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -522,13 +531,13 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.5"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
+checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
 dependencies = [
  "bytes",
  "fnv",
- "itoa 0.4.4",
+ "itoa 1.0.1",
 ]
 
 [[package]]
@@ -701,34 +710,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz-sys"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "miniz_oxide"
-version = "0.2.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c468f2369f07d651a5d0bb2c9079f8488a66d5466efe42d0c5c6466edcb7f71e"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
 dependencies = [
- "adler32",
-]
-
-[[package]]
-name = "miniz_oxide_c_api"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7fe927a42e3807ef71defb191dc87d4e24479b221e67015fe38ae2b7b447bab"
-dependencies = [
- "cc",
- "crc",
- "libc",
- "miniz_oxide",
+ "adler",
 ]
 
 [[package]]
@@ -864,6 +851,12 @@ name = "opaque-debug"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "os_info"
@@ -1094,14 +1087,35 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.4"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbfeb8d0ddb84706bc597a5574ab8912817c52a397f819e5b614e2265206921"
+checksum = "539a2bfe908f471bfa933876bd1eb6a19cf2176d375f82ef7f99530a40e48c2c"
 dependencies = [
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -1120,6 +1134,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2"
+dependencies = [
+ "lazy_static",
+ "windows-sys",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1127,6 +1151,29 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1482,12 +1529,12 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
 dependencies = [
+ "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
@@ -1549,7 +1596,7 @@ name = "volta-core"
 version = "0.1.0"
 dependencies = [
  "archive",
- "attohttpc",
+ "attohttpc 0.22.0",
  "atty",
  "cfg-if 1.0.0",
  "chain-map",
@@ -1759,6 +1806,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -15,4 +15,6 @@ verbatim = "0.1"
 cfg-if = "1.0"
 hyperx = "1.0.0"
 thiserror = "1.0.16"
-attohttpc = { version = "0.22.0", default-features = false, features = ["json", "compress", "tls-rustls"] }
+attohttpc = { version = "0.23.1", default-features = false, features = ["json", "compress", "tls-rustls"] }
+rustls-native-certs = "0.6.2"
+rustls = "0.20.7"

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -15,6 +15,4 @@ verbatim = "0.1"
 cfg-if = "1.0"
 hyperx = "1.0.0"
 thiserror = "1.0.16"
-attohttpc = { version = "0.23.1", default-features = false, features = ["json", "compress", "tls-rustls"] }
-rustls-native-certs = "0.6.2"
-rustls = "0.20.7"
+fetch = { path = "../fetch" }

--- a/crates/archive/src/lib.rs
+++ b/crates/archive/src/lib.rs
@@ -3,6 +3,8 @@
 use std::fs::File;
 use std::path::Path;
 
+use fetch::attohttpc;
+
 use thiserror::Error;
 
 mod tarball;

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -5,6 +5,8 @@ use std::fs::{create_dir_all, File};
 use std::io::copy;
 use std::path::Path;
 
+use rustls;
+
 use crate::ArchiveError;
 use progress_read::ProgressRead;
 use verbatim::PathExt;
@@ -34,7 +36,14 @@ impl Zip {
     /// Initiate fetching of a Node zip archive from the given URL, returning
     /// a `Remote` data source.
     pub fn fetch(url: &str, cache_file: &Path) -> Result<Box<dyn Archive>, ArchiveError> {
-        let (status, _, mut response) = attohttpc::get(url).send()?.split();
+        let mut request = attohttpc::get(url);
+
+        for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs")
+        {
+            request = request.add_root_certificate(rustls::Certificate(cert.0));
+        }
+
+        let (status, _, mut response) = request.send()?.split();
 
         if !status.is_success() {
             return Err(ArchiveError::HttpError(status));

--- a/crates/fetch/Cargo.toml
+++ b/crates/fetch/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fetch"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+attohttpc = { version = "0.23.1", default-features = false, features = ["json", "compress", "tls-rustls"] }
+rustls-native-certs = "0.6.2"
+rustls = "0.20.7"

--- a/crates/fetch/src/lib.rs
+++ b/crates/fetch/src/lib.rs
@@ -1,0 +1,15 @@
+use attohttpc::RequestBuilder;
+use rustls_native_certs::load_native_certs;
+use rustls::Certificate;
+
+pub fn fetch<U>(url: U) -> RequestBuilder where U: AsRef<str>, {
+    let mut request = attohttpc::get(url);
+
+    for cert in load_native_certs().expect("could not load platform certs") {
+        request = request.add_root_certificate(Certificate(cert.0));
+    }
+
+    return request;
+}
+
+pub use attohttpc;

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -45,7 +45,9 @@ once_cell = "1.15.0"
 dunce = "1.0.2"
 ci_info = "0.14.6"
 hyperx = "1.4.0"
-attohttpc = { version = "0.22.0", default-features = false, features = ["json", "compress", "tls-rustls"] }
+attohttpc = { version = "0.23.1", default-features = false, features = ["json", "compress", "tls-rustls"] }
+rustls-native-certs = "0.6.2"
+rustls = "0.20.7"
 chain-map = "0.1.0"
 indexmap = "1.9.1"
 retry = "2"

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -45,9 +45,7 @@ once_cell = "1.15.0"
 dunce = "1.0.2"
 ci_info = "0.14.6"
 hyperx = "1.4.0"
-attohttpc = { version = "0.23.1", default-features = false, features = ["json", "compress", "tls-rustls"] }
-rustls-native-certs = "0.6.2"
-rustls = "0.20.7"
+fetch = { path = "../fetch" }
 chain-map = "0.1.0"
 indexmap = "1.9.1"
 retry = "2"

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -17,7 +17,7 @@ mod fetch;
 mod metadata;
 mod resolve;
 
-pub use fetch::load_default_npm_version;
+pub use self::fetch::load_default_npm_version;
 pub use resolve::resolve;
 
 cfg_if! {

--- a/crates/volta-core/src/tool/registry.rs
+++ b/crates/volta-core/src/tool/registry.rs
@@ -6,8 +6,8 @@ use crate::error::{Context, ErrorKind, Fallible};
 use crate::fs::read_dir_eager;
 use crate::style::progress_spinner;
 use crate::version::{hashmap_version_serde, version_serde};
-use attohttpc::header::ACCEPT;
-use attohttpc::Response;
+use fetch::attohttpc::header::ACCEPT;
+use fetch::attohttpc::Response;
 use cfg_if::cfg_if;
 use semver::Version;
 use serde::Deserialize;
@@ -38,13 +38,7 @@ cfg_if! {
 pub fn fetch_npm_registry(url: String, name: &str) -> Fallible<(String, PackageIndex)> {
     let spinner = progress_spinner(format!("Fetching npm registry: {}", url));
 
-    let mut request = attohttpc::get(&url);
-
-    for cert in rustls_native_certs::load_native_certs().expect("could not load platform certs") {
-        request = request.add_root_certificate(rustls::Certificate(cert.0));
-    }
-
-    let metadata: RawPackageMetadata = request
+    let metadata: RawPackageMetadata = fetch::fetch(&url)
         .header(ACCEPT, NPM_ABBREVIATED_ACCEPT_HEADER)
         .send()
         .and_then(Response::error_for_status)


### PR DESCRIPTION
Hello,

I wanted to use Volta on my work computer. Like lot of developpers working for large enterprise, I'm behind a MITM Corporate Proxy. Because of that, all our network is decrypted by the proxy and reencrypted with another certificate, signed by a Corporate CA Authority. and the public certificate of the CA Authority is installed on all computers of the enterprise.

So after installing Volta, I ran `volta install node` and error `Io Error: invalid peer certificate contents: invalid peer certificate: UnknownIssuer` append.

I am used to this type of error. Native langages and ssl lib do not work well by default with private CA installed on windows. So I search if volta had a configuration or a variable environment to add CA files like Node.js have `NODE_EXTRA_CA_CERTS`. I don't find it.
I search at least something to disable SSL check (very insecure…). I don't find it either.

I search if ssl deps of volta (rustls, attohttpc) had a env variable for this. No, it doesn't exist.

I found `add_root_certificate` method in attohttpc, and `rustls-native-certs` crate.

So I used it in `archive` crate (only zip, wich is use by windows). and it seems working.

---

I'm not a rust developer. So don't hesitate to fix my code if you can do better (I'm not familliar with mut / borrow with rust).
Also, if you know how to load once the certificates store for all attohttpc call. It could be a great improvement.

---

Resources:
- https://github.com/rustls/rustls-native-certs/blob/HEAD/examples/google.rs#L9
- https://docs.rs/attohttpc/latest/attohttpc/struct.RequestBuilder.html#method.add_root_certificate