### PR TITLE
chore: Update deprecated actions

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
       - name: Set up cargo

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -15,11 +15,9 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up cargo
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.63
-          override: true
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Build docs

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -21,10 +21,8 @@ jobs:
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Build docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --all --features cross-platform-docs --no-deps --document-private-items
+        run: |
+          cargo doc --all --features cross-platform-docs --no-deps --document-private-items
       - name: Prepare docs for publication
         run: |
           mkdir -p publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up docker image
         run: docker build -t volta .
         working-directory: ./ci/docker
@@ -31,7 +31,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rs/toolchain@v1
         with:
@@ -53,7 +53,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rs/toolchain@v1
         with:
@@ -76,7 +76,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rs/toolchain@v1
         with:
@@ -138,7 +138,7 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Determine release version
         id: release_info
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Compile and package Volta
         run: docker run --volume ${PWD}:/root/workspace --workdir /root/workspace --rm --init --tty volta /root/workspace/ci/build-linux.sh volta-linux
       - name: Upload release artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: linux
           path: target/release/volta-linux.tar.gz
@@ -41,7 +41,7 @@ jobs:
       - name: Compile and package Volta
         run: ./ci/build-macos-x86_64.sh volta-macos
       - name: Upload release artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macos
           path: target/release/volta-macos.tar.gz
@@ -62,7 +62,7 @@ jobs:
       - name: Compile and package Volta
         run: ./ci/build-macos-arm.sh volta-macos-aarch64
       - name: Upload release artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: macos-aarch64
           path: target/aarch64-apple-darwin/release/volta-macos-aarch64.tar.gz
@@ -111,12 +111,12 @@ jobs:
         run: powershell Compress-Archive volta*.exe volta-windows.zip
         working-directory: ./target/release
       - name: Upload installer
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-installer
           path: target/wix/volta-windows.msi
       - name: Upload zip
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: windows-zip
           path: target/release/volta-windows.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
         id: release_info
         env:
           TAG: ${{ github.ref }}
-        run: echo "::set-output name=version::${TAG:11}"
+        run: echo "version=${TAG:11}" >> $GITHUB_OUTPUT
       - name: Fetch Linux artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,15 +80,10 @@ jobs:
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Add cargo-wix subcommand
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-wix
+        run: cargo install cargo-wix
       - name: Compile and package installer
-        uses: actions-rs/cargo@v1
-        with:
-          command: wix
-          args: --nocapture --package volta --output target\wix\volta-windows.msi
+        run: |
+          cargo wix --nocapture --package volta --output target\wix\volta-windows.msi
       - name: Load Certificate File
         id: certificate_file
         if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.63
-          override: true
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Compile and package Volta
@@ -55,12 +53,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.63
           target: aarch64-apple-darwin
-          override: true
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Compile and package Volta
@@ -78,11 +74,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.63
-          override: true
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Add cargo-wix subcommand

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rs/toolchain@v1
         with:
@@ -54,7 +54,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rs/toolchain@v1
         with:
@@ -76,7 +76,7 @@ jobs:
       - name: Setup BATS
         run: sudo npm install -g bats
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run tests
         run: bats dev/unix/tests/
 
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,19 +31,13 @@ jobs:
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --features mock-network
+        run: |
+          cargo test --all --features mock-network
       - name: Lint with clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
+        run: cargo clippy
       - name: Lint tests with clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --tests --features mock-network
+        run: |
+          cargo clippy --tests --features mock-network
 
   smoke-tests:
     name: Smoke Tests
@@ -60,10 +54,8 @@ jobs:
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --test smoke --features smoke-tests -- --test-threads 1
+        run: |
+          cargo test --test smoke --features smoke-tests -- --test-threads 1
 
   shell-tests:
     name: Shell Script Tests
@@ -90,7 +82,5 @@ jobs:
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Run check
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all --quiet -- --check
+        run: |
+          cargo fmt --all --quiet -- --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.63
-          override: true
           components: clippy
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
@@ -56,11 +54,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.63
-          override: true
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Run tests
@@ -87,11 +83,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: 1.63
-          override: true
           components: rustfmt
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
There are a lot of deprecation warnings in our recent workflow runs (for ex. [1](https://github.com/volta-cli/volta/actions/runs/3383641697), [2](https://github.com/volta-cli/volta/actions/runs/3387570392), [3](https://github.com/volta-cli/volta/actions/runs/3387570396)).

All of these contain multiple instances of the same three things:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions-rs/toolchain, actions/upload-artifact, actions/checkout
```
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions-rs/cargo
```
```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

This change updates some actions to fix these:

* `actions/checkout` to v3, which [uses node16](https://github.com/actions/checkout/releases/tag/v3.0.0)
* `actions/upload-artifact` to v3, which [uses node16](https://github.com/actions/upload-artifact/releases/tag/v3.0.0)
* `actions/rs-toolchain` to `dtolnay/rust-toolchain`, since `rs-toolchain` [seems to be unmaintained](https://github.com/actions-rs/toolchain/issues/216)
* `actions-rs/cargo` was removed, since [it has not been updated](https://github.com/actions-rs/cargo/issues/216), and instead the workflows run `cargo` directly

And one usage of `set-output` was changed to [use environment files instead](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

## workflows for this PR

https://github.com/volta-cli/volta/actions/runs/3398423871 - no more deprecations
https://github.com/volta-cli/volta/actions/runs/3398423872 - no more deprecations