### PR TITLE
Fix clippy warnings and rust-toolchain.toml file

### DIFF
--- a/crates/volta-core/src/platform/tests.rs
+++ b/crates/volta-core/src/platform/tests.rs
@@ -112,7 +112,7 @@ fn test_image_path() {
     let node_npm_pnpm = Image {
         node: Sourced::with_default(v123.clone()),
         npm: Some(Sourced::with_default(v643.clone())),
-        pnpm: Some(Sourced::with_default(v771.clone())),
+        pnpm: Some(Sourced::with_default(v771)),
         yarn: None,
     };
 

--- a/crates/volta-core/src/tool/package/manager.rs
+++ b/crates/volta-core/src/tool/package/manager.rs
@@ -103,14 +103,14 @@ impl PackageManager {
 
         if let PackageManager::Yarn = self {
             command.env("npm_config_global_folder", self.source_root(package_root));
-        } else
-        // FIXME: Find out if there is a perfect way to intercept pnpm global
-        // installs by using environment variables or whatever.
-        // Using `--global-dir` and `--global-bin-dir` flags here is not enough,
-        // because pnpm generates _absolute path_ based symlinks, and this makes
-        // impossible to simply move installed packages from the staging directory
-        // to the final `image/packages/` destination.
-        if let PackageManager::Pnpm = self {
+        } else if let PackageManager::Pnpm = self {
+            // FIXME: Find out if there is a perfect way to intercept pnpm global
+            // installs by using environment variables or whatever.
+            // Using `--global-dir` and `--global-bin-dir` flags here is not enough,
+            // because pnpm generates _absolute path_ based symlinks, and this makes
+            // impossible to simply move installed packages from the staging directory
+            // to the final `image/packages/` destination.
+
             // Specify the staging directory to store global package,
             // see: https://pnpm.io/npmrc#global-dir
             command.arg("--global-dir").arg(&package_root);
@@ -125,8 +125,7 @@ impl PackageManager {
             // pass the check.
             // See: https://github.com/volta-cli/rfcs/pull/46#discussion_r861943740
             let mut new_path = global_bin_dir;
-            let mut command_envs = command.get_envs();
-            while let Some((name, value)) = command_envs.next() {
+            for (name, value) in command.get_envs() {
                 if name == "PATH" {
                     if let Some(old_path) = value {
                         #[cfg(unix)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.63"
+components = ["clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
Info
-----
* There are a couple of clippy warnings that I missed in the code review for the pnpm implementation.
* The `rust-toolchain.toml` file also doesn't contain the necessary components to let `rust-analyzer` work properly in local development environments.

Changes
-----
* Fixed the warnings with clippy's suggested fixes.
* Added `clippy` and `rustfmt` to the `components` in `rust-toolchain.toml`

Tested
-----
* Locally verified that there aren't any clippy warnings.
* Confirmed that local development works as expected.