### PR TITLE
fix(yarn) pnp workspace support

### DIFF
--- a/crates/volta-core/src/project/mod.rs
+++ b/crates/volta-core/src/project/mod.rs
@@ -177,9 +177,18 @@ impl Project {
         self.platform()
             .map_or(false, |platform| platform.yarn.is_some())
             && self.manifest_file.parent().map_or(false, |base_dir| {
+<<<<<<< HEAD
                 base_dir.join(".yarnrc.yml").exists()
                     || base_dir.join(".pnp.js").exists()
                     || base_dir.join(".pnp.cjs").exists()
+=======
+                base_dir.join(".yarnrc.yml").exists()
+		    && (base_dir.join(".pnp.js").exists()
+                    || base_dir.join(".pnp.cjs").exists()
+                    || self
+                        .workspace_roots()
+                        .any(|x| x.join(".pnp.cjs").exists() || x.join(".pnp.js").exists()))
+>>>>>>> 44a13678 (fix(yarn) pnp workspace support)
             })
     }
 

--- a/crates/volta-core/src/project/mod.rs
+++ b/crates/volta-core/src/project/mod.rs
@@ -176,19 +176,10 @@ impl Project {
     pub fn needs_yarn_run(&self) -> bool {
         self.platform()
             .map_or(false, |platform| platform.yarn.is_some())
-            && self.manifest_file.parent().map_or(false, |base_dir| {
-<<<<<<< HEAD
-                base_dir.join(".yarnrc.yml").exists()
-                    || base_dir.join(".pnp.js").exists()
-                    || base_dir.join(".pnp.cjs").exists()
-=======
-                base_dir.join(".yarnrc.yml").exists()
-		    && (base_dir.join(".pnp.js").exists()
-                    || base_dir.join(".pnp.cjs").exists()
-                    || self
-                        .workspace_roots()
-                        .any(|x| x.join(".pnp.cjs").exists() || x.join(".pnp.js").exists()))
->>>>>>> 44a13678 (fix(yarn) pnp workspace support)
+            && self.workspace_roots().any(|x| {
+                x.join(".yarnrc.yml").exists()
+                    || x.join(".pnp.cjs").exists()
+                    || x.join(".pnp.js").exists()
             })
     }
 


### PR DESCRIPTION
Yarn berry works great with single mode, but does not works if inside workspace directory. I found that this line does not respect root monorepo:
https://github.com/volta-cli/volta/blob/7827adefcb57ffe3beb7896c7ed483b24e619556/crates/volta-core/src/project/mod.rs#L176

as it expect `.pnp.js` on same level as root dir. But workspace dir does not have `.pnp.js` hence it works fine with yarn berry. like `yarn why packagename`