### PR TITLE
Use docker buildx to cache docker image in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: ./ci/docker
-          push: true
+          push: false
+          load: true
           tags: volta
       - name: Compile and package Volta
         run: docker run --volume ${PWD}:/root/workspace --workdir /root/workspace --rm --init --tty volta /root/workspace/ci/build-linux.sh volta-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Set up docker image
-        run: docker build -t volta .
-        working-directory: ./ci/docker
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Build docker image
+        uses: docker/build-push-action@v3
+        with:
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          context: ./ci/docker
+          push: true
+          tags: volta
       - name: Compile and package Volta
         run: docker run --volume ${PWD}:/root/workspace --workdir /root/workspace --rm --init --tty volta /root/workspace/ci/build-linux.sh volta-linux
       - name: Upload release artifact


### PR DESCRIPTION
Info
-----
* The docker CI build takes a long time to complete and can sometimes fail when building the docker image.
* However, the docker image itself shouldn't be changing often, we rarely make changes to the CI environment.
* We should be able to cache the docker image and re-use it on subsequent runs for both performance and stability.

Changes
-----
* Added the `docker/setup-buildx-action` and `docker/build-push-action` CI steps to build and cache the docker image on GitHub actions, instead of manually calling `docker build` each time.

Tested
-----
* This PR will be the testing ground, to verify that the build completes and that the cache works across runs.
* Update: Tested rerunning the build after it completed and can confirm that it loads from cache. The initial run took ~5:30 to complete, the re-run took < 1 minute and clearly shows that each step in the Docker build is cached and doesn't need to be re-run :tada: