### PR TITLE
Manually fetch older version of Rustup on Linux production build

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -11,6 +11,9 @@ RUN wget -O /etc/yum.repos.d/slc6-devtoolset.repo http://linuxsoft.cern.ch/cern/
 # Install more recent GCC and binutils, to allow us to compile 
 RUN yum -y install devtoolset-2-gcc devtoolset-2-binutils
 
-# Install Rust toolchain
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.63
+# Install Rust toolchain (need to do this manually since current rustup requires a more recent
+# glibc version than is available on RHEL/CentOS 6)
+RUN curl https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-unknown-linux-gnu/rustup-init -sSf -o ~/rustup-init
+RUN chmod +x ~/rustup-init
+RUN ~/rustup-init -y --default-toolchain 1.63
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
## Info
* The most recent version of Rustup depends on a newer version of `glibc` than is available in the CentOS 6-based Docker image we are using to compile the Linux version of Volta.
* This is causing CI to fail as it's not able to install the Rust compiler.
* We're intentionally using an older version of glibc to maintain compatibility with those older versions.
* Luckily, older Rustup versions are available for download.

## Changes
* Updated the Dockerfile to directly fetch an older version of `rustup-init` and use that to install Rust.