### PR TITLE
Detect when the installer is running via Rosetta

### DIFF
--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -135,7 +135,8 @@ parse_os_info() {
       fi
       ;;
     Darwin)
-      if [ "$(uname -m)" == "arm64" ]; then
+      # If running via Rosetta, uname -m returns x86_64, but sysctl reports proc_translated=1
+      if [ "$(uname -m)" == "arm64" ] || [ "$(sysctl -n sysctl.proc_translated)" == "1" ]; then
         echo "macos-aarch64"
       else
         echo "macos"


### PR DESCRIPTION
This fixes an edge case where the installer itself runs under Rosetta on ARM64 macOS, for example when running the installer via a subprocess in another install script that uses an x86 binary, or if you run your terminal via Rosetta.

I'm not sure how to add a test given that it would have to run on an macOS ARM64 CI runner. Here's a manual verification:

```bash
#!/usr/bin/env bash
echo "uname: $(uname -m)"
echo "proc_translated: $(sysctl -n sysctl.proc_translated)"
```

Output:

```
$ ./test.sh
uname: arm64
proc_translated: 0

$ arch -x86_64 ./test.sh
uname: x86_64
proc_translated: 1
```

I don't have an x86_64 Mac to test it, but it returns `0` on native x86_64. This is the relevant information from Apple: https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment#3616845