### PR TITLE
Update to the latest version of Chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,11 +221,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-integer",
  "num-traits",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1500,9 +1497,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi",
@@ -1693,7 +1690,7 @@ dependencies = [
  "validate-npm-package-name",
  "volta-layout",
  "walkdir",
- "winreg 0.50.0",
+ "winreg 0.52.0",
 ]
 
 [[package]]
@@ -2050,9 +2047,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -33,7 +33,11 @@ envoy = "0.1.3"
 mockito = { version = "0.31.1", optional = true }
 regex = "1.7.1"
 dirs = "5.0.1"
-chrono = "0.4.23"
+# We manually configure the feature list here because 0.4.16 includes the
+# `oldtime` feature by default to avoid a breaking change. Additionally, using
+# the feature list explicitly lets us drop the `wasmbind` feature, which we do
+# not need.
+chrono = { version = "0.4.23", default-features = false, features = ["alloc", "std", "clock"] }
 validate-npm-package-name = { path = "../validate-npm-package-name" }
 textwrap = "0.16.0"
 is-terminal = "0.4.7"


### PR DESCRIPTION
This does not *fully* resolve our issue with our dependency on vulnerable versions of `time`, but it gets us closer. (We also need to get from zip 0.5 to 0.6!)