### PR TITLE
Configure `zip` not to use its `time` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,17 +1496,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi",
- "winapi",
-]
-
-[[package]]
 name = "typenum"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,5 +2063,4 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time",
 ]

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -7,7 +7,10 @@ edition = "2018"
 [dependencies]
 flate2 = "1.0"
 tar = "0.4.13"
-zip_rs = { version = "0.5", package = "zip" }
+# Set features manually to drop usage of `time` crate: we do not rely on that
+# set of capabilities, and it has a vulnerability. NOTE: this should be updated
+# to include the `aes-crypto` and `zstd` features when upgrading to v0.6+.
+zip_rs = { version = "0.5", package = "zip", default-features = false, features = ["deflate", "bzip2"] }
 tee = "0.1.0"
 fs-utils = { path = "../fs-utils" }
 progress-read = { path = "../progress-read" }


### PR DESCRIPTION
This is the second half of getting us out of the position of depending on the vulnerable version of `time`.