### PR TITLE
Update Rust version to 1.75

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up cargo
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63
+          toolchain: 1.75
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Build docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up cargo
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63
+          toolchain: 1.75
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Compile and package Volta
@@ -63,7 +63,7 @@ jobs:
       - name: Set up cargo
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63
+          toolchain: 1.75
           target: aarch64-apple-darwin
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
@@ -84,7 +84,7 @@ jobs:
       - name: Set up cargo
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63
+          toolchain: 1.75
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Add cargo-wix subcommand

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up cargo
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63
+          toolchain: 1.75
           components: clippy
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
@@ -50,7 +50,7 @@ jobs:
       - name: Set up cargo
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63
+          toolchain: 1.75
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Run tests
@@ -77,7 +77,7 @@ jobs:
       - name: Set up cargo
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.63
+          toolchain: 1.75
           components: rustfmt
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2

--- a/ci/build-linux.sh
+++ b/ci/build-linux.sh
@@ -3,7 +3,8 @@
 set -e
 
 # Activate the upgraded versions of GCC and binutils
-source /opt/rh/devtoolset-2/enable
+# See https://linux.web.cern.ch/centos7/docs/softwarecollections/#inst
+source /opt/rh/devtoolset-8/enable
 
 echo "Building Volta"
 

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -1,19 +1,16 @@
-FROM cern/slc6-base
+FROM cern/cc7-base
 
 # This repo file references a URL that is no longer valid. It also isn't used by the build
 # toolchain, so we can safely remove it entirely
 RUN rm /etc/yum.repos.d/epel.repo
 
+# https://linux.web.cern.ch/centos7/docs/softwarecollections/#inst
 # Tools needed for the build and setup process
 RUN yum -y install wget tar
 # Fetch the repo information for the devtoolset repo
-RUN wget -O /etc/yum.repos.d/slc6-devtoolset.repo http://linuxsoft.cern.ch/cern/devtoolset/slc6-devtoolset.repo
-# Install more recent GCC and binutils, to allow us to compile 
-RUN yum -y install devtoolset-2-gcc devtoolset-2-binutils
+RUN yum install -y centos-release-scl
+# Install more recent GCC and binutils, to allow us to compile
+RUN yum install -y devtoolset-8
 
-# Install Rust toolchain (need to do this manually since current rustup requires a more recent
-# glibc version than is available on RHEL/CentOS 6)
-RUN curl https://static.rust-lang.org/rustup/archive/1.25.1/x86_64-unknown-linux-gnu/rustup-init -sSf -o ~/rustup-init
-RUN chmod +x ~/rustup-init
-RUN ~/rustup-init -y --default-toolchain 1.63
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.63"
+channel = "1.75"
 components = ["clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
We originally pinned to 1.63 because that was the last version before Rust dropped support for older versions of `glibc` [in Rust 1.64][blog]. However, the relevant operating systems we were maintaining support for at that time (CentOS/RHEL 6) have now been end-of-life for three full years, so it seems reasonable to update to a more current version. Since no other changes to the `glibc` support have happened in the interval, we can safely update to the most current version of Rust.

[blog]: https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html

As part of this, update the RHEL 7 Dockerfile setup for building on Rust 1.74, including using updated versions of gcc and binutils.

---

**For discussion:** is this breaking? I do not think we have written down our SemVer contract for things like this anywhere. It *will* break anyone who tries to update to what will presumably be Volta 1.2.0, so it may be appropriate (and is certainly simplest) to make it a 2.0.0 release, while noting that the only breakage is support for older versions.