### PR TITLE
Switch to stable node-semver crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,37 +131,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
-dependencies = [
- "byte-tools",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
-name = "byte-tools"
-version = "0.3.1"
+name = "bytecount"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
+checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
 
 [[package]]
 name = "byteorder"
@@ -325,15 +304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,12 +375,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -475,15 +439,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e87827efaf94c7a44b562ff57de06930712fe21b530c3797cdede26e6377eb"
 dependencies = [
  "dunce",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -713,12 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "maplit"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
-
-[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,6 +686,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "miette-derive",
+ "once_cell",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.31",
+ "syn 2.0.27",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,6 +716,12 @@ checksum = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 dependencies = [
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -782,6 +760,29 @@ dependencies = [
  "cfg-if",
  "libc",
  "static_assertions",
+]
+
+[[package]]
+name = "node-semver"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f390c1756333538f2aed01cf280a56bc683e199b9804a504df6e7320d40116"
+dependencies = [
+ "bytecount",
+ "miette",
+ "nom",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -874,12 +875,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
-name = "opaque-debug"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,49 +902,6 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
-name = "pest"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "933085deae3f32071f135d799d75667b63c8dc1f4537159756e3d4ceab41868c"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63120576c4efd69615b5537d3d052257328a4ca82876771d6944424ccfd9f646"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2 0.4.30",
- "quote 0.6.12",
- "syn 0.15.36",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249ea6de7c7b7aba92b4ff4376a994c6dbd98fd2166c89d5c4947397ecb574d"
-dependencies = [
- "maplit",
- "pest",
- "sha-1",
-]
 
 [[package]]
 name = "pkg-config"
@@ -1239,23 +1191,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "git+https://github.com/mikrostew/semver?branch=new-parser#7583eb352dc181ccd09978fd2b16461c1b1669c1"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.0"
-source = "git+https://github.com/mikrostew/semver-parser?branch=rewrite#f5c74268a09eef16a289a667ca7b4925e690fe13"
-dependencies = [
- "pest",
- "pest_derive",
-]
-
-[[package]]
 name = "serde"
 version = "1.0.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,18 +1232,6 @@ dependencies = [
  "itoa 0.4.4",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "sha-1"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
-dependencies = [
- "block-buffer",
- "digest",
- "fake-simd",
- "opaque-debug",
 ]
 
 [[package]]
@@ -1496,18 +1419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
-
-[[package]]
 name = "unicase"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1626,7 +1537,7 @@ dependencies = [
  "lazy_static",
  "log",
  "mockito",
- "semver",
+ "node-semver",
  "serde",
  "serde_json",
  "structopt",
@@ -1665,12 +1576,12 @@ dependencies = [
  "lazycell",
  "log",
  "mockito",
+ "node-semver",
  "once_cell",
  "os_info",
  "readext",
  "regex",
  "retry",
- "semver",
  "serde",
  "serde_json",
  "tempfile",
@@ -1703,7 +1614,7 @@ name = "volta-migrate"
 version = "0.1.0"
 dependencies = [
  "log",
- "semver",
+ "node-semver",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.96"
 lazy_static = "1.3.0"
 log = { version = "0.4", features = ["std"] }
-semver = { git = "https://github.com/mikrostew/semver", branch = "new-parser" }
+node-semver = "2"
 structopt = "0.2.14"
 cfg-if = "1.0"
 mockito = { version = "0.31.1", optional = true }

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.174", features = ["derive"] }
 archive = { path = "../archive" }
 lazycell = "1.3.0"
 lazy_static = "1.3.0"
-semver = { git = "https://github.com/mikrostew/semver", branch = "new-parser" }
+node-semver = "2"
 cmdline_words_parser = "0.2.1"
 fs-utils = { path = "../fs-utils" }
 cfg-if = "1.0"

--- a/crates/volta-core/src/hook/tool.rs
+++ b/crates/volta-core/src/hook/tool.rs
@@ -12,7 +12,7 @@ use cmdline_words_parser::parse_posix;
 use dunce::canonicalize;
 use lazy_static::lazy_static;
 use log::debug;
-use semver::Version;
+use node_semver::Version;
 
 const ARCH_TEMPLATE: &str = "{{arch}}";
 const OS_TEMPLATE: &str = "{{os}}";
@@ -182,14 +182,14 @@ fn execute_binary(bin: &str, base_path: &Path, extra_arg: Option<String>) -> Fal
 pub mod tests {
     use super::{calculate_extension, DistroHook, MetadataHook};
     use crate::tool::{NODE_DISTRO_ARCH, NODE_DISTRO_OS};
-    use semver::Version;
+    use node_semver::Version;
 
     #[test]
     fn test_distro_prefix_resolve() {
         let prefix = "http://localhost/node/distro/";
         let filename = "node.tar.gz";
         let hook = DistroHook::Prefix(prefix.to_string());
-        let version = Version::new(1, 0, 0);
+        let version = Version::parse("1.0.0").unwrap();
 
         assert_eq!(
             hook.resolve(&version, filename)
@@ -203,7 +203,7 @@ pub mod tests {
         let hook = DistroHook::Template(
             "http://localhost/node/{{os}}/{{arch}}/{{version}}/{{ext}}/{{filename}}".to_string(),
         );
-        let version = Version::new(1, 0, 0);
+        let version = Version::parse("1.0.0").unwrap();
 
         // tar.gz format has extra handling, to support a multi-part extension
         let expected = format!(

--- a/crates/volta-core/src/inventory.rs
+++ b/crates/volta-core/src/inventory.rs
@@ -11,7 +11,7 @@ use crate::layout::volta_home;
 use crate::tool::PackageConfig;
 use crate::version::parse_version;
 use log::debug;
-use semver::Version;
+use node_semver::Version;
 use walkdir::WalkDir;
 
 /// Checks if a given Node version image is available on the local machine

--- a/crates/volta-core/src/platform/image.rs
+++ b/crates/volta-core/src/platform/image.rs
@@ -5,7 +5,7 @@ use super::{build_path_error, Sourced};
 use crate::error::{Context, Fallible};
 use crate::layout::volta_home;
 use crate::tool::load_default_npm_version;
-use semver::Version;
+use node_semver::Version;
 
 /// A platform image.
 pub struct Image {

--- a/crates/volta-core/src/platform/mod.rs
+++ b/crates/volta-core/src/platform/mod.rs
@@ -5,7 +5,7 @@ use crate::error::{ErrorKind, Fallible};
 use crate::session::Session;
 use crate::tool::{Node, Npm, Pnpm, Yarn};
 use crate::VOLTA_FEATURE_PNPM;
-use semver::Version;
+use node_semver::Version;
 
 mod image;
 mod system;

--- a/crates/volta-core/src/platform/tests.rs
+++ b/crates/volta-core/src/platform/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::layout::volta_home;
 #[cfg(windows)]
 use crate::layout::volta_install;
-use semver::Version;
+use node_semver::Version;
 #[cfg(windows)]
 use std::path::PathBuf;
 
@@ -215,7 +215,7 @@ mod inherit_option {
 
 mod cli_platform {
     use lazy_static::lazy_static;
-    use semver::Version;
+    use node_semver::Version;
 
     lazy_static! {
         static ref NODE_VERSION: Version = Version::from((12, 14, 1));

--- a/crates/volta-core/src/project/mod.rs
+++ b/crates/volta-core/src/project/mod.rs
@@ -8,7 +8,7 @@ use std::iter::once;
 use std::path::{Path, PathBuf};
 
 use lazycell::LazyCell;
-use semver::Version;
+use node_semver::Version;
 
 use crate::error::{Context, ErrorKind, Fallible, VoltaError};
 use crate::layout::volta_home;

--- a/crates/volta-core/src/project/serial.rs
+++ b/crates/volta-core/src/project/serial.rs
@@ -8,7 +8,7 @@ use super::PartialPlatform;
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::version::parse_version;
 use dunce::canonicalize;
-use semver::Version;
+use node_semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -9,7 +9,7 @@ use crate::platform::{CliPlatform, Image, Sourced};
 use crate::session::Session;
 use crate::VOLTA_FEATURE_PNPM;
 use log::debug;
-use semver::Version;
+use node_semver::Version;
 
 pub mod binary;
 mod executor;

--- a/crates/volta-core/src/run/npx.rs
+++ b/crates/volta-core/src/run/npx.rs
@@ -7,11 +7,17 @@ use crate::error::{ErrorKind, Fallible};
 use crate::platform::{Platform, System};
 use crate::session::{ActivityKind, Session};
 use lazy_static::lazy_static;
-use semver::Version;
+use node_semver::Version;
 
 lazy_static! {
     /// The minimum required npm version that includes npx (5.2.0)
-    static ref REQUIRED_NPM_VERSION: Version = Version::new(5, 2, 0);
+    static ref REQUIRED_NPM_VERSION: Version = Version {
+        major: 5,
+        minor: 2,
+        patch: 0,
+        build: vec![],
+        pre_release: vec![]
+    };
 }
 
 /// Build a `ToolCommand` for npx

--- a/crates/volta-core/src/tool/node/fetch.rs
+++ b/crates/volta-core/src/tool/node/fetch.rs
@@ -15,7 +15,7 @@ use archive::{self, Archive};
 use cfg_if::cfg_if;
 use fs_utils::ensure_containing_dir_exists;
 use log::debug;
-use semver::Version;
+use node_semver::Version;
 use serde::Deserialize;
 
 cfg_if! {

--- a/crates/volta-core/src/tool/node/metadata.rs
+++ b/crates/volta-core/src/tool/node/metadata.rs
@@ -4,7 +4,7 @@ use super::NODE_DISTRO_IDENTIFIER;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 use super::NODE_DISTRO_IDENTIFIER_FALLBACK;
 use crate::version::{option_version_serde, version_serde};
-use semver::Version;
+use node_semver::Version;
 use serde::{Deserialize, Deserializer};
 
 /// The index of the public Node server.

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -11,7 +11,7 @@ use crate::style::{note_prefix, tool_version};
 use crate::sync::VoltaLock;
 use cfg_if::cfg_if;
 use log::info;
-use semver::Version;
+use node_semver::Version;
 
 mod fetch;
 mod metadata;
@@ -259,7 +259,7 @@ mod tests {
     #[test]
     fn test_node_archive_basename() {
         assert_eq!(
-            Node::archive_basename(&Version::new(1, 2, 3)),
+            Node::archive_basename(&Version::parse("1.2.3").unwrap()),
             format!("node-v1.2.3-{}-{}", NODE_DISTRO_OS, NODE_DISTRO_ARCH)
         );
     }
@@ -267,7 +267,7 @@ mod tests {
     #[test]
     fn test_node_archive_filename() {
         assert_eq!(
-            Node::archive_filename(&Version::new(1, 2, 3)),
+            Node::archive_filename(&Version::parse("1.2.3").unwrap()),
             format!(
                 "node-v1.2.3-{}-{}.{}",
                 NODE_DISTRO_OS, NODE_DISTRO_ARCH, NODE_DISTRO_EXTENSION

--- a/crates/volta-core/src/tool/npm/fetch.rs
+++ b/crates/volta-core/src/tool/npm/fetch.rs
@@ -15,7 +15,7 @@ use crate::version::VersionSpec;
 use archive::{Archive, Tarball};
 use fs_utils::ensure_containing_dir_exists;
 use log::debug;
-use semver::Version;
+use node_semver::Version;
 
 pub fn fetch(version: &Version, hooks: Option<&ToolHooks<Npm>>) -> Fallible<()> {
     let npm_dir = volta_home()?.npm_inventory_dir();

--- a/crates/volta-core/src/tool/npm/mod.rs
+++ b/crates/volta-core/src/tool/npm/mod.rs
@@ -11,7 +11,7 @@ use crate::session::Session;
 use crate::style::{success_prefix, tool_version};
 use crate::sync::VoltaLock;
 use log::info;
-use semver::Version;
+use node_semver::Version;
 
 mod fetch;
 mod resolve;

--- a/crates/volta-core/src/tool/npm/resolve.rs
+++ b/crates/volta-core/src/tool/npm/resolve.rs
@@ -9,7 +9,7 @@ use crate::session::Session;
 use crate::tool::Npm;
 use crate::version::{VersionSpec, VersionTag};
 use log::debug;
-use semver::{Version, VersionReq};
+use node_semver::{Range, Version};
 
 pub fn resolve(matching: VersionSpec, session: &mut Session) -> Fallible<Option<Version>> {
     let hooks = session.hooks()?.npm();
@@ -54,13 +54,13 @@ fn resolve_tag(tag: &str, hooks: Option<&ToolHooks<Npm>>) -> Fallible<Version> {
     }
 }
 
-fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Npm>>) -> Fallible<Version> {
+fn resolve_semver(matching: Range, hooks: Option<&ToolHooks<Npm>>) -> Fallible<Version> {
     let (url, index) = fetch_npm_index(hooks)?;
 
     let details_opt = index
         .entries
         .into_iter()
-        .find(|PackageDetails { version, .. }| matching.matches(version));
+        .find(|PackageDetails { version, .. }| matching.satisfies(version));
 
     match details_opt {
         Some(details) => {

--- a/crates/volta-core/src/tool/package/metadata.rs
+++ b/crates/volta-core/src/tool/package/metadata.rs
@@ -9,7 +9,7 @@ use crate::layout::volta_home;
 use crate::platform::PlatformSpec;
 use crate::version::{option_version_serde, version_serde};
 use fs_utils::ensure_containing_dir_exists;
-use semver::Version;
+use node_semver::Version;
 
 /// Configuration information about an installed package
 ///

--- a/crates/volta-core/src/tool/pnpm/fetch.rs
+++ b/crates/volta-core/src/tool/pnpm/fetch.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use archive::{Archive, Tarball};
 use fs_utils::ensure_containing_dir_exists;
 use log::debug;
-use semver::Version;
+use node_semver::Version;
 
 use crate::error::{Context, ErrorKind, Fallible};
 use crate::fs::{create_staging_dir, create_staging_file, rename, set_executable};

--- a/crates/volta-core/src/tool/pnpm/mod.rs
+++ b/crates/volta-core/src/tool/pnpm/mod.rs
@@ -1,4 +1,4 @@
-use semver::Version;
+use node_semver::Version;
 use std::fmt::{self, Display};
 
 use crate::error::{ErrorKind, Fallible};

--- a/crates/volta-core/src/tool/pnpm/resolve.rs
+++ b/crates/volta-core/src/tool/pnpm/resolve.rs
@@ -1,5 +1,5 @@
 use log::debug;
-use semver::{Version, VersionReq};
+use node_semver::{Range, Version};
 
 use crate::error::{ErrorKind, Fallible};
 use crate::hook::ToolHooks;
@@ -33,13 +33,13 @@ fn resolve_tag(tag: &str, hooks: Option<&ToolHooks<Pnpm>>) -> Fallible<Version> 
     }
 }
 
-fn resolve_semver(matching: VersionReq, hooks: Option<&ToolHooks<Pnpm>>) -> Fallible<Version> {
+fn resolve_semver(matching: Range, hooks: Option<&ToolHooks<Pnpm>>) -> Fallible<Version> {
     let (url, index) = fetch_pnpm_index(hooks)?;
 
     let details_opt = index
         .entries
         .into_iter()
-        .find(|PackageDetails { version, .. }| matching.matches(version));
+        .find(|PackageDetails { version, .. }| matching.satisfies(version));
 
     match details_opt {
         Some(details) => {

--- a/crates/volta-core/src/tool/registry.rs
+++ b/crates/volta-core/src/tool/registry.rs
@@ -9,7 +9,7 @@ use crate::version::{hashmap_version_serde, version_serde};
 use attohttpc::header::ACCEPT;
 use attohttpc::Response;
 use cfg_if::cfg_if;
-use semver::Version;
+use node_semver::Version;
 use serde::Deserialize;
 
 // Accept header needed to request the abbreviated metadata from the npm registry

--- a/crates/volta-core/src/tool/yarn/fetch.rs
+++ b/crates/volta-core/src/tool/yarn/fetch.rs
@@ -17,7 +17,7 @@ use crate::version::VersionSpec;
 use archive::{Archive, Tarball};
 use fs_utils::ensure_containing_dir_exists;
 use log::debug;
-use semver::Version;
+use node_semver::Version;
 
 pub fn fetch(version: &Version, hooks: Option<&YarnHooks>) -> Fallible<()> {
     let yarn_dir = volta_home()?.yarn_inventory_dir();

--- a/crates/volta-core/src/tool/yarn/metadata.rs
+++ b/crates/volta-core/src/tool/yarn/metadata.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use crate::version::version_serde;
-use semver::Version;
+use node_semver::Version;
 use serde::Deserialize;
 
 /// The public Yarn index.

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -9,7 +9,7 @@ use crate::inventory::yarn_available;
 use crate::session::Session;
 use crate::style::tool_version;
 use crate::sync::VoltaLock;
-use semver::Version;
+use node_semver::Version;
 
 mod fetch;
 mod metadata;

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -7,8 +7,8 @@ use crate::layout::volta_home;
 use crate::platform::PlatformSpec;
 use lazycell::LazyCell;
 use log::debug;
+use node_semver::Version;
 use readext::ReadExt;
-use semver::Version;
 
 pub mod serial;
 

--- a/crates/volta-core/src/toolchain/serial.rs
+++ b/crates/volta-core/src/toolchain/serial.rs
@@ -1,7 +1,7 @@
 use crate::error::{Context, ErrorKind, Fallible, VoltaError};
 use crate::platform::PlatformSpec;
 use crate::version::{option_version_serde, version_serde};
-use semver::Version;
+use node_semver::Version;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
@@ -74,7 +74,7 @@ pub mod tests {
 
     use super::*;
     use crate::platform;
-    use semver::Version;
+    use node_semver::Version;
 
     // NOTE: serde_json is required with the "preserve_order" feature in Cargo.toml,
     // so these tests will serialized/deserialize in a predictable order

--- a/crates/volta-core/src/version/mod.rs
+++ b/crates/volta-core/src/version/mod.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use crate::error::{Context, ErrorKind, Fallible, VoltaError};
-use semver::{Version, VersionReq};
+use node_semver::{Range, Version};
 
 mod serial;
 
@@ -12,8 +12,8 @@ pub enum VersionSpec {
     /// No version specified (default)
     None,
 
-    /// Semver Range
-    Semver(VersionReq),
+    /// SemVer Range
+    Semver(Range),
 
     /// Exact Version
     Exact(Version),
@@ -90,7 +90,7 @@ impl FromStr for VersionTag {
     }
 }
 
-pub fn parse_requirements(s: impl AsRef<str>) -> Fallible<VersionReq> {
+pub fn parse_requirements(s: impl AsRef<str>) -> Fallible<Range> {
     let s = s.as_ref();
     serial::parse_requirements(s)
         .with_context(|| ErrorKind::VersionParseError { version: s.into() })
@@ -114,7 +114,7 @@ fn trim_version(s: &str) -> &str {
 // custom serialization and de-serialization for Version
 // because Version doesn't work with serde out of the box
 pub mod version_serde {
-    use semver::Version;
+    use node_semver::Version;
     use serde::de::{Error, Visitor};
     use serde::{self, Deserializer, Serializer};
     use std::fmt;
@@ -155,7 +155,7 @@ pub mod version_serde {
 // custom serialization and de-serialization for Option<Version>
 // because Version doesn't work with serde out of the box
 pub mod option_version_serde {
-    use semver::Version;
+    use node_semver::Version;
     use serde::de::Error;
     use serde::{self, Deserialize, Deserializer, Serializer};
 
@@ -187,7 +187,7 @@ pub mod option_version_serde {
 // because Version doesn't work with serde out of the box
 pub mod hashmap_version_serde {
     use super::version_serde;
-    use semver::Version;
+    use node_semver::Version;
     use serde::{self, Deserialize, Deserializer};
     use std::collections::HashMap;
 

--- a/crates/volta-core/src/version/serial.rs
+++ b/crates/volta-core/src/version/serial.rs
@@ -1,4 +1,4 @@
-use semver::{Compat, ReqParseError, VersionReq};
+use node_semver::{Range, SemverError};
 
 // NOTE: using `parse_compat` here because the semver crate defaults to
 // parsing in a cargo-compatible way. This is normally fine, except for
@@ -11,43 +11,43 @@ use semver::{Compat, ReqParseError, VersionReq};
 // Because we are parsing the version requirements from the command line,
 // then serializing them to pass to `npm view`, they need to be handled in
 // a Node-compatible way (or we get the wrong version info returned).
-pub fn parse_requirements(src: &str) -> Result<VersionReq, ReqParseError> {
+pub fn parse_requirements(src: &str) -> Result<Range, SemverError> {
     let src = src.trim().trim_start_matches('v');
 
-    VersionReq::parse_compat(src, Compat::Node)
+    Range::parse(src)
 }
 
 #[cfg(test)]
 pub mod tests {
 
     use crate::version::serial::parse_requirements;
-    use semver::{Compat, VersionReq};
+    use node_semver::Range;
 
     #[test]
     fn test_parse_requirements() {
         assert_eq!(
             parse_requirements("1.2.3").unwrap(),
-            VersionReq::parse_compat("=1.2.3", Compat::Node).unwrap()
+            Range::parse("=1.2.3").unwrap()
         );
         assert_eq!(
             parse_requirements("v1.5").unwrap(),
-            VersionReq::parse_compat("=1.5", Compat::Node).unwrap()
+            Range::parse("=1.5").unwrap()
         );
         assert_eq!(
             parse_requirements("=1.2.3").unwrap(),
-            VersionReq::parse_compat("=1.2.3", Compat::Node).unwrap()
+            Range::parse("=1.2.3").unwrap()
         );
         assert_eq!(
             parse_requirements("^1.2").unwrap(),
-            VersionReq::parse_compat("^1.2", Compat::Node).unwrap()
+            Range::parse("^1.2").unwrap()
         );
         assert_eq!(
             parse_requirements(">=1.4").unwrap(),
-            VersionReq::parse_compat(">=1.4", Compat::Node).unwrap()
+            Range::parse(">=1.4").unwrap()
         );
         assert_eq!(
             parse_requirements("8.11 - 8.17 || 10.* || >= 12").unwrap(),
-            VersionReq::parse_compat("8.11 - 8.17 || 10.* || >= 12", Compat::Node).unwrap()
+            Range::parse("8.11 - 8.17 || 10.* || >= 12").unwrap()
         );
     }
 }

--- a/crates/volta-migrate/Cargo.toml
+++ b/crates/volta-migrate/Cargo.toml
@@ -9,7 +9,7 @@ volta-core = { path = "../volta-core" }
 volta-layout = { path = "../volta-layout" }
 log = { version = "0.4", features = ["std"] }
 tempfile = "3.8.1"
-semver = { git = "https://github.com/mikrostew/semver", branch = "new-parser" }
+node-semver = "2"
 serde_json = { version = "1.0.96", features = ["preserve_order"] }
 serde = { version = "1.0.174", features = ["derive"] }
 walkdir = "2.4.0"

--- a/crates/volta-migrate/src/v2.rs
+++ b/crates/volta-migrate/src/v2.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use super::empty::Empty;
 use super::v1::V1;
 use log::debug;
-use semver::Version;
+use node_semver::Version;
 use tempfile::tempdir_in;
 use volta_core::error::{Context, ErrorKind, Fallible, VoltaError};
 use volta_core::fs::{read_dir_eager, remove_dir_if_exists, remove_file_if_exists, rename};

--- a/crates/volta-migrate/src/v3/config.rs
+++ b/crates/volta-migrate/src/v3/config.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::path::Path;
 
-use semver::Version;
+use node_semver::Version;
 use volta_core::platform::PlatformSpec;
 use volta_core::version::{option_version_serde, version_serde};
 

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -401,7 +401,7 @@ mod tests {
     use std::path::PathBuf;
 
     use lazy_static::lazy_static;
-    use semver::Version;
+    use node_semver::Version;
 
     use super::*;
 
@@ -1136,7 +1136,7 @@ See `volta help install` for details and more options.";
     mod packages {
         use super::*;
         use crate::command::list::{Package, PackageDetails};
-        use semver::Version;
+        use node_semver::Version;
 
         #[test]
         fn none() {
@@ -1262,7 +1262,7 @@ See `volta help install` for details and more options.";
     mod tools {
         use super::*;
         use crate::command::list::{Package, PackageDetails};
-        use semver::Version;
+        use node_semver::Version;
 
         #[test]
         fn none() {

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -5,7 +5,7 @@ mod toolchain;
 use std::{fmt, path::PathBuf, str::FromStr};
 
 use is_terminal::IsTerminal as _;
-use semver::Version;
+use node_semver::Version;
 use structopt::StructOpt;
 
 use crate::command::Command;

--- a/src/command/list/plain.rs
+++ b/src/command/list/plain.rs
@@ -1,6 +1,6 @@
 //! Define the "plain" format style for list commands.
 
-use semver::Version;
+use node_semver::Version;
 
 use volta_core::style::tool_version;
 
@@ -204,7 +204,7 @@ mod tests {
     use std::path::PathBuf;
 
     use lazy_static::lazy_static;
-    use semver::Version;
+    use node_semver::Version;
 
     use crate::command::list::PackageDetails;
 

--- a/src/command/list/toolchain.rs
+++ b/src/command/list/toolchain.rs
@@ -1,6 +1,6 @@
 use super::{Filter, Node, Package, PackageManager, Source};
 use crate::command::list::PackageManagerKind;
-use semver::Version;
+use node_semver::Version;
 use volta_core::error::Fallible;
 use volta_core::inventory::{
     node_versions, npm_versions, package_configs, pnpm_versions, yarn_versions,

--- a/tests/acceptance/corrupted_download.rs
+++ b/tests/acceptance/corrupted_download.rs
@@ -1,7 +1,7 @@
 use crate::support::sandbox::{sandbox, DistroMetadata, NodeFixture, PnpmFixture, Yarn1Fixture};
 use hamcrest2::assert_that;
 use hamcrest2::prelude::*;
-use semver::Version;
+use node_semver::Version;
 use test_support::matchers::execs;
 
 use volta_core::error::ExitCode;
@@ -83,7 +83,7 @@ fn install_corrupted_node_leaves_inventory_unchanged() {
         execs().with_status(ExitCode::UnknownError as i32)
     );
 
-    assert!(!s.node_inventory_archive_exists(&Version::new(0, 0, 1)));
+    assert!(!s.node_inventory_archive_exists(&Version::parse("0.0.1").unwrap()));
 }
 
 #[test]
@@ -98,7 +98,7 @@ fn install_valid_node_saves_to_inventory() {
         execs().with_status(ExitCode::Success as i32)
     );
 
-    assert!(s.node_inventory_archive_exists(&Version::new(10, 99, 1040)));
+    assert!(s.node_inventory_archive_exists(&Version::parse("10.99.1040").unwrap()));
 }
 
 #[test]

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime};
 use cfg_if::cfg_if;
 use hyperx::header::HttpDate;
 use mockito::{self, mock, Matcher};
-use semver::Version;
+use node_semver::Version;
 use test_support::{self, ok_or_panic, paths, paths::PathExt, process::ProcessBuilder};
 use volta_core::fs::{set_executable, symlink_file};
 use volta_core::tool::{Node, Pnpm, Yarn, NODE_DISTRO_ARCH, NODE_DISTRO_EXTENSION, NODE_DISTRO_OS};


### PR DESCRIPTION
This implements the same set of features that @mikrostew's fork of `semver` did originally. `node-semver` exists to implement the Node version of SemVer, which is distinct in a few key ways from Cargo's implementation.