### PR TITLE
Use published version of detect-indent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,7 +297,8 @@ dependencies = [
 [[package]]
 name = "detect-indent"
 version = "0.1.0"
-source = "git+https://github.com/stefanpenner/detect-indent-rs?branch=master#f645bcc81bfb1f9745c4a4dec7c7f6faf3f84ec5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae11867b75e44bacc8baf64be8abe6501c6571bbf33fed819a0a90623c82d1b"
 dependencies = [
  "lazy_static",
  "regex",

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -28,7 +28,7 @@ fs-utils = { path = "../fs-utils" }
 cfg-if = "1.0"
 tempfile = "3.8.1"
 os_info = "3.7.0"
-detect-indent = { git = "https://github.com/stefanpenner/detect-indent-rs", branch = "master" }
+detect-indent = "0.1"
 envoy = "0.1.3"
 mockito = { version = "0.31.1", optional = true }
 regex = "1.7.1"


### PR DESCRIPTION
Just what it says on the tin. Zero functional changes, but some minor clean-up in the implementation.