### PR TITLE
Describe Volta's SemVer commitments (COMPATIBILITY.md)

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,17 @@
+# Compatibility
+
+Volta currently tests against the following platforms, and will treat it as a breaking change to drop support for them:
+
+- macOS
+    - x86-64
+    - Apple Silicon
+- Linux x86-64
+- Windows x86-64
+
+We compile release artifacts compatible with the following, and likewise will treat it as a breaking change to drop support for them:
+
+- macOS v11
+- RHEL and CentOS v6
+- Windows 10
+
+In general, Volta should build and run against any other modern hardware and operating system supported by stable Rust, and we will make a best effort not to break them. However, we do *not* include them in our SemVer guarantees or test against them.


### PR DESCRIPTION
While discussing #1611, @rwjblue and I noticed that we do not have any explicit documentation of our SemVer/compatibility policy. We should specify what versions of our main targeted operating systems we support.

Additionally, this proposes that dropping support for a currently-supported version will be a major version bump for Volta—so, e.g. when #1611 itself lands, we should release 2.0 afterwards, since it will drop support for the EOL'd RHEL 6 line. As an alternative, we could consider treating operating system support similar to the way most crates treat Rust support and the way most JS packages treat Node versions: non-breaking to drop support for EOL versions.