### PR TITLE
Correctly (locally) test Node architecture fallback

### DIFF
--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -259,18 +259,42 @@ mod tests {
     #[test]
     fn test_node_archive_basename() {
         assert_eq!(
-            Node::archive_basename(&Version::parse("1.2.3").unwrap()),
-            format!("node-v1.2.3-{}-{}", NODE_DISTRO_OS, NODE_DISTRO_ARCH)
+            Node::archive_basename(&Version::parse("16.2.3").unwrap()),
+            format!("node-v16.2.3-{}-{}", NODE_DISTRO_OS, NODE_DISTRO_ARCH)
         );
     }
 
     #[test]
     fn test_node_archive_filename() {
         assert_eq!(
+            Node::archive_filename(&Version::parse("16.2.3").unwrap()),
+            format!(
+                "node-v16.2.3-{}-{}.{}",
+                NODE_DISTRO_OS, NODE_DISTRO_ARCH, NODE_DISTRO_EXTENSION
+            )
+        );
+    }
+
+    #[test]
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    fn test_fallback_node_archive_basename() {
+        assert_eq!(
+            Node::archive_basename(&Version::parse("1.2.3").unwrap()),
+            format!(
+                "node-v1.2.3-{}-{}",
+                NODE_DISTRO_OS, NODE_DISTRO_ARCH_FALLBACK
+            )
+        );
+    }
+
+    #[test]
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    fn test_fallback_node_archive_filename() {
+        assert_eq!(
             Node::archive_filename(&Version::parse("1.2.3").unwrap()),
             format!(
                 "node-v1.2.3-{}-{}.{}",
-                NODE_DISTRO_OS, NODE_DISTRO_ARCH, NODE_DISTRO_EXTENSION
+                NODE_DISTRO_OS, NODE_DISTRO_ARCH_FALLBACK, NODE_DISTRO_EXTENSION
             )
         );
     }


### PR DESCRIPTION
Previously, since we were testing against a version spec of `1.2.3`, we were failing on local Apple Silicon builds because our test expectations looked for the correct (`arm64`) string, but the version check we use to avoid incorrectly trying to install non-Apple Silicon-compatible Node versions without Rosetta meant we ended up in the fallback path. Update the existing tests to use versions which will get `arm64` when run on an Apple Silicon machine, and add additional tests behind a `#[cfg(...)]` check for `macos-aarch64` to confirm the fallback works correctly.

Note that these new tests will *only* run locally at present, since we do not yet have Apple Silicon runners on GitHub, but if/when we can add those, they will run automatically there. This path should also become less important over time as more and more of the mac ecosystem moves to Apple Silicon, but is valuable for as long as we support Intel Macs.