### PR TITLE
Switch to actions-rust-lang/setup-rust-toolchain

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -15,9 +15,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.75
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Build docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.75
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Compile and package Volta
@@ -61,9 +59,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@master
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.75
           target: aarch64-apple-darwin
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
@@ -82,9 +79,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.75
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Add cargo-wix subcommand

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.75
-          components: clippy
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Run tests
@@ -48,9 +45,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.75
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Run tests
@@ -75,10 +70,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up cargo
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.75
-          components: rustfmt
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Cargo Cache
         uses: Swatinem/rust-cache@v2
       - name: Run check

--- a/tests/acceptance/volta_bypass.rs
+++ b/tests/acceptance/volta_bypass.rs
@@ -25,7 +25,7 @@ fn shim_skips_platform_checks_on_bypass() {
 
     #[cfg(windows)]
     assert_that!(
-        s.process(&shim_exe()),
+        s.process(shim_exe()),
         execs()
             .with_status(ExitCode::UnknownError as i32)
             .with_stderr_contains("[..]is not recognized as an internal or external command[..]")


### PR DESCRIPTION
This lets us use `rust-toolchain.toml` for our single source of truth for our targeted Rust version. Resolves #1618.