### PR TITLE
chore: replace is-terminal crate with std::io::IsTerminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi",
  "libc",
  "winapi",
 ]
@@ -497,12 +497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
-
-[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,17 +608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
-dependencies = [
- "hermit-abi 0.3.3",
- "rustix",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1543,7 +1526,6 @@ dependencies = [
  "envoy",
  "hamcrest2",
  "hyperx",
- "is-terminal",
  "lazy_static",
  "log",
  "mockito",
@@ -1581,7 +1563,6 @@ dependencies = [
  "hyperx",
  "indexmap 2.1.0",
  "indicatif",
- "is-terminal",
  "lazy_static",
  "lazycell",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ name = "volta-migrate"
 path = "src/volta-migrate.rs"
 
 [dependencies]
-is-terminal = "0.4.10"
 volta-core = { path = "crates/volta-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.109"

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -40,7 +40,6 @@ dirs = "5.0.1"
 chrono = { version = "0.4.23", default-features = false, features = ["alloc", "std", "clock"] }
 validate-npm-package-name = { path = "../validate-npm-package-name" }
 textwrap = "0.16.0"
-is-terminal = "0.4.10"
 log = { version = "0.4", features = ["std"] }
 ctrlc = "3.4.2"
 walkdir = "2.4.0"

--- a/crates/volta-core/src/log.rs
+++ b/crates/volta-core/src/log.rs
@@ -1,9 +1,9 @@
 //! This module provides a custom Logger implementation for use with the `log` crate
 use console::style;
-use is_terminal::IsTerminal;
 use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use std::env;
 use std::fmt::Display;
+use std::io::IsTerminal;
 use textwrap::{fill, Options, WordSplitter};
 
 use crate::style::text_width;

--- a/src/command/list/mod.rs
+++ b/src/command/list/mod.rs
@@ -2,9 +2,9 @@ mod human;
 mod plain;
 mod toolchain;
 
+use std::io::IsTerminal as _;
 use std::{fmt, path::PathBuf, str::FromStr};
 
-use is_terminal::IsTerminal as _;
 use node_semver::Version;
 use structopt::StructOpt;
 


### PR DESCRIPTION
As the Rust version used by `volta` has been updated to 1.75, `volta` can use `std::io::IsTerminal`.