### PR TITLE
chore: replace term_size with terminal_size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1352,13 +1352,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
+name = "terminal_size"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+checksum = "21bebf2b7c9e0a515f6e0f8c51dc0f8e4696391e6f1ff30379559f8365fb0df7"
 dependencies = [
- "libc",
- "winapi",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1576,7 +1576,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "term_size",
+ "terminal_size",
  "textwrap 0.16.0",
  "validate-npm-package-name",
  "volta-layout",

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -13,7 +13,7 @@ mock-network = ["mockito"]
 cross-platform-docs = []
 
 [dependencies]
-term_size = "0.3.2"
+terminal_size = "0.3.0"
 indicatif = "0.17.7"
 console = ">=0.11.3, <1.0.0"
 readext = "0.1.0"

--- a/crates/volta-core/src/style.rs
+++ b/crates/volta-core/src/style.rs
@@ -7,6 +7,7 @@ use archive::Origin;
 use cfg_if::cfg_if;
 use console::{style, StyledObject};
 use indicatif::{ProgressBar, ProgressStyle};
+use terminal_size::{terminal_size, Width};
 
 pub const MAX_WIDTH: usize = 100;
 const MAX_PROGRESS_WIDTH: usize = 40;
@@ -49,8 +50,7 @@ where
 
 /// Get the width of the terminal, limited to a maximum of MAX_WIDTH
 pub fn text_width() -> Option<usize> {
-    use terminal_size::Width;
-    terminal_size::terminal_size().map(|(Width(w), _)| (w as usize).min(MAX_WIDTH))
+    terminal_size().map(|(Width(w), _)| (w as usize).min(MAX_WIDTH))
 }
 
 /// Constructs a command-line progress bar based on the specified Origin enum

--- a/crates/volta-core/src/style.rs
+++ b/crates/volta-core/src/style.rs
@@ -49,7 +49,8 @@ where
 
 /// Get the width of the terminal, limited to a maximum of MAX_WIDTH
 pub fn text_width() -> Option<usize> {
-    term_size::dimensions().map(|(w, _)| w.min(MAX_WIDTH))
+    use terminal_size::Width;
+    terminal_size::terminal_size().map(|(Width(w), _)| (w as usize).min(MAX_WIDTH))
 }
 
 /// Constructs a command-line progress bar based on the specified Origin enum


### PR DESCRIPTION
`term_size` announces that it is not maintained although it works fine, and proposes using `terminal_size` crate instead.

https://github.com/clap-rs/term_size-rs/pull/31