### PR TITLE
Add colors back to help output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.111"
 lazy_static = "1.3.0"
 log = { version = "0.4", features = ["std"] }
 node-semver = "2"
-clap = { version = "4.4.16", features = ["derive"] }
+clap = { version = "4.4.16", features = ["color", "derive", "wrap_help"] }
 clap_complete = "4.4.6"
 cfg-if = "1.0"
 mockito = { version = "0.31.1", optional = true }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{builder::styling, ColorChoice, Parser};
 
 use crate::command::{self, Command};
 use volta_core::error::{ExitCode, Fallible};
@@ -12,8 +12,9 @@ use volta_core::session::Session;
 
     To install a tool in your toolchain, use `volta install`.
     To pin your project's runtime or package manager, use `volta pin`.",
-    color = clap::ColorChoice::Auto,
+    color = ColorChoice::Auto,
     disable_version_flag = true,
+    styles = styles()
 )]
 pub(crate) struct Volta {
     #[command(subcommand)]
@@ -130,4 +131,20 @@ impl Subcommand {
             Subcommand::Run(run) => run.run(session),
         }
     }
+}
+
+fn styles() -> styling::Styles {
+    styling::Styles::plain()
+        .header(
+            styling::AnsiColor::Yellow.on_default()
+                | styling::Effects::BOLD
+                | styling::Effects::ITALIC,
+        )
+        .usage(
+            styling::AnsiColor::Yellow.on_default()
+                | styling::Effects::BOLD
+                | styling::Effects::ITALIC,
+        )
+        .literal(styling::AnsiColor::Green.on_default() | styling::Effects::BOLD)
+        .placeholder(styling::AnsiColor::BrightBlue.on_default())
 }


### PR DESCRIPTION
We lost this with the Clap v4 upgrade, and it is a small nicety that users may miss. Happily, the capability exists, and is just opt-in rather than the default now.

<details><summary>Volta v1</summary>

![volta-v1](https://github.com/volta-cli/volta/assets/2403023/33d7deda-f9f9-4b98-9271-f28b575c75be)

</details>

<details><summary>Volta v2 <em>without</em> this change</summary>

![volta-v2-plain](https://github.com/volta-cli/volta/assets/2403023/ce0b21ac-7361-4f37-868b-72aca9994d8d)

</details>

<details><summary>Volta v2 <em>with</em> this change</summary>

![volta-v2](https://github.com/volta-cli/volta/assets/2403023/b3c9d8ca-3c14-41af-b9e7-52a59c3c9336)

</details>

Things to notice:

- The Clap output made a couple changes going to v4 (all of which already landed as part of #1649):
    - It now puts flags after commands.
    - It renamed "Subcommands" to "Commands".
    - It switched from all caps to title case.
    - It no longer prints `volta-completions` or similar as the name of subcommands (which is a behavior change we have wanted!).
- I made a couple design choices:
    - I restored the color choices we had before for the headers, options, and flags.
    - I added bright blue for the options and flags in the usage message.
    - I chose to italicize as well as bold the headings, but not to underline them.

Input welcome!