### PR TITLE
Remove Swatinem/rust-cache from CI configs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: aarch64-apple-darwin,x86_64-apple-darwin
-      - name: Cargo Cache
-        uses: Swatinem/rust-cache@v2
       - name: Compile and package Volta
         run: ./ci/build-macos.sh volta-macos
       - name: Upload release artifact
@@ -62,8 +60,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Cargo Cache
-        uses: Swatinem/rust-cache@v2
       - name: Add cargo-wix subcommand
         run: cargo install cargo-wix
       - name: Compile and package installer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Cargo Cache
-        uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: |
           cargo test --all --features mock-network
@@ -46,8 +44,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Cargo Cache
-        uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: |
           cargo test --test smoke --features smoke-tests -- --test-threads 1
@@ -71,8 +67,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
-      - name: Cargo Cache
-        uses: Swatinem/rust-cache@v2
       - name: Run check
         run: |
           cargo fmt --all --quiet -- --check


### PR DESCRIPTION
We get this transitively via actions-rust-lang/setup-rust-toolchain@v1 now, and we are not using any of its configuration options, so we can simply drop it for now.

I am opening this on top of #1635 to see if it resolves the build issue there; I do not expect it to, as I think the underlying caching issue there may be a bit more finicky than this, but it is worth checking.