### PR TITLE
chore: replace hyperx with headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "cfg-if",
  "flate2",
  "fs-utils",
- "hyperx",
+ "headers",
  "progress-read",
  "tar",
  "tee",
@@ -164,6 +164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +180,15 @@ name = "bitflags"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -362,12 +377,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -388,6 +422,16 @@ checksum = "9ae11867b75e44bacc8baf64be8abe6501c6571bbf33fed819a0a90623c82d1b"
 dependencies = [
  "lazy_static",
  "regex",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -529,6 +573,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +617,30 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -607,25 +685,9 @@ checksum = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
 
 [[package]]
 name = "httpdate"
-version = "0.3.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
-
-[[package]]
-name = "hyperx"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c"
-dependencies = [
- "base64",
- "bytes",
- "http",
- "httpdate",
- "language-tags",
- "mime",
- "percent-encoding",
- "unicase",
-]
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "iana-time-zone"
@@ -715,12 +777,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,12 +849,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.13"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
-dependencies = [
- "unicase",
-]
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1183,7 +1236,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -1296,6 +1349,17 @@ dependencies = [
  "itoa 0.4.4",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1435,13 +1499,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicase"
-version = "2.6.0"
+name = "typenum"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
@@ -1538,7 +1599,7 @@ dependencies = [
  "dirs",
  "envoy",
  "hamcrest2",
- "hyperx",
+ "headers",
  "lazy_static",
  "log",
  "mockito",
@@ -1572,7 +1633,7 @@ dependencies = [
  "envoy",
  "fs-utils",
  "fs2",
- "hyperx",
+ "headers",
  "indexmap 2.1.0",
  "indicatif",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,6 @@ winreg = "0.52.0"
 hamcrest2 = "0.3.0"
 envoy = "0.1.3"
 ci_info = "0.14.14"
-hyperx = "1.4.0"
+headers = "0.3"
 
 [workspace]

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -16,6 +16,6 @@ fs-utils = { path = "../fs-utils" }
 progress-read = { path = "../progress-read" }
 verbatim = "0.1"
 cfg-if = "1.0"
-hyperx = "1.0.0"
+headers = "0.3"
 thiserror = "1.0.16"
 attohttpc = { version = "0.26", default-features = false, features = ["json", "compress", "tls-rustls-native-roots"] }

--- a/crates/archive/src/tarball.rs
+++ b/crates/archive/src/tarball.rs
@@ -115,9 +115,11 @@ impl Archive for Tarball {
 /// more efficient than simply downloading the entire file up front.
 fn fetch_isize(url: &str, len: u64) -> Result<[u8; 4], ArchiveError> {
     let mut header_values = Vec::with_capacity(1);
-    Range::bytes(len - 4..=len - 1)
+    Range::bytes(len - 4..len)
         .unwrap()
         .encode(&mut header_values);
+    // We just pushed a header in with the `.encode` above, so there will always
+    // be a value at `.first()`.
     let range_header = header_values.first().unwrap();
 
     let (status, headers, mut response) = attohttpc::get(url)

--- a/crates/archive/src/tarball.rs
+++ b/crates/archive/src/tarball.rs
@@ -9,9 +9,7 @@ use super::{Archive, ArchiveError, Origin};
 use attohttpc::header::HeaderMap;
 use flate2::read::GzDecoder;
 use fs_utils::ensure_containing_dir_exists;
-use hyperx::header::{
-    AcceptRanges, ByteRangeSpec, ContentLength, Header, Range, RangeUnit, TypedHeaders,
-};
+use headers::{AcceptRanges, ContentLength, Header, HeaderMapExt, Range};
 use progress_read::ProgressRead;
 use tee::TeeReader;
 
@@ -31,8 +29,7 @@ pub struct Tarball {
 /// the HTTP `"Content-Length"` header.
 fn content_length(headers: &HeaderMap) -> Result<u64, ArchiveError> {
     headers
-        .decode::<ContentLength>()
-        .ok()
+        .typed_get::<ContentLength>()
         .map(|v| v.0)
         .ok_or_else(|| ArchiveError::MissingHeaderError(String::from("Content-Length")))
 }
@@ -117,9 +114,14 @@ impl Archive for Tarball {
 /// downloading the entire gzip file. For very small files it's unlikely to be
 /// more efficient than simply downloading the entire file up front.
 fn fetch_isize(url: &str, len: u64) -> Result<[u8; 4], ArchiveError> {
-    let range_header = Range::Bytes(vec![ByteRangeSpec::FromTo(len - 4, len - 1)]);
+    let mut header_values = Vec::with_capacity(1);
+    Range::bytes(len - 4..=len - 1)
+        .unwrap()
+        .encode(&mut header_values);
+    let range_header = header_values.first().unwrap();
+
     let (status, headers, mut response) = attohttpc::get(url)
-        .header(Range::header_name(), range_header.to_string())
+        .header(Range::name(), range_header)
         .send()?
         .split();
 
@@ -150,10 +152,8 @@ fn load_isize(file: &mut File) -> Result<[u8; 4], ArchiveError> {
 
 fn accepts_byte_ranges(headers: &HeaderMap) -> bool {
     headers
-        .decode::<AcceptRanges>()
-        .ok()
-        .map(|v| v.iter().any(|unit| *unit == RangeUnit::Bytes))
-        .unwrap_or(false)
+        .typed_get::<AcceptRanges>()
+        .map_or(false, |v| v == AcceptRanges::bytes())
 }
 
 /// Determines the uncompressed size of a gzip file hosted at the specified

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -47,7 +47,7 @@ volta-layout = { path = "../volta-layout" }
 once_cell = "1.19.0"
 dunce = "1.0.4"
 ci_info = "0.14.14"
-hyperx = "1.4.0"
+headers = "0.3"
 attohttpc = { version = "0.26", default-features = false, features = ["json", "compress", "tls-rustls-native-roots"] }
 chain-map = "0.1.0"
 indexmap = "2.1.0"

--- a/crates/volta-core/src/tool/node/resolve.rs
+++ b/crates/volta-core/src/tool/node/resolve.rs
@@ -258,6 +258,7 @@ fn resolve_node_versions(url: &str) -> Fallible<RawNodeIndex> {
 
             let mut header_values = Vec::with_capacity(1);
             expires.encode(&mut header_values);
+            // Since we just `.encode()`d into `header_values
             let encoded_expires = header_values.first().unwrap().to_str().unwrap();
 
             write!(expiry_file, "{}", encoded_expires).with_context(|| {

--- a/tests/acceptance/support/sandbox.rs
+++ b/tests/acceptance/support/sandbox.rs
@@ -52,6 +52,8 @@ impl CacheBuilder {
 
         let mut header_values = Vec::with_capacity(1);
         expiry_date.encode(&mut header_values);
+        // Since we just `.encode()`d into `header_values, it is guaranteed to
+        // have a `.first()`.
         let encoded_expiry_date = header_values.first().unwrap();
 
         let mut expiry_file = File::create(&self.expiry_path).unwrap_or_else(|e| {


### PR DESCRIPTION
Replaces `hyperx` crate with `headers` crate to modernize dependencies regarding to HTTP headers. `hyperx` was released as an extraction of the `hyper` 0.11 typed header module. Today, `hyper` community decoupled the header module as `headers` crate and maintains it.