### PR TITLE
chore: use once_cell crate uniformly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,12 +783,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1565,7 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 name = "validate-npm-package-name"
 version = "0.1.0"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "percent-encoding",
  "regex",
 ]
@@ -1600,10 +1594,10 @@ dependencies = [
  "envoy",
  "hamcrest2",
  "headers",
- "lazy_static",
  "log",
  "mockito",
  "node-semver",
+ "once_cell",
  "serde",
  "serde_json",
  "test-support",
@@ -1636,8 +1630,6 @@ dependencies = [
  "headers",
  "indexmap 2.1.0",
  "indicatif",
- "lazy_static",
- "lazycell",
  "log",
  "mockito",
  "node-semver",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ path = "src/volta-migrate.rs"
 volta-core = { path = "crates/volta-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.111"
-lazy_static = "1.3.0"
+once_cell = "1.19.0"
 log = { version = "0.4", features = ["std"] }
 node-semver = "2"
 clap = { version = "4.4.18", features = ["color", "derive", "wrap_help"] }

--- a/crates/validate-npm-package-name/Cargo.toml
+++ b/crates/validate-npm-package-name/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 [lib]
 
 [dependencies]
-lazy_static = "1.3.0"
+once_cell = "1.19.0"
 percent-encoding = "2.1.0"
 regex = "1.1.6"

--- a/crates/validate-npm-package-name/src/lib.rs
+++ b/crates/validate-npm-package-name/src/lib.rs
@@ -1,7 +1,7 @@
 //! A Rust implementation of the validation rules from the core JS package
 //! [`validate-npm-package-name`](https://github.com/npm/validate-npm-package-name/).
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use regex::Regex;
 
@@ -18,56 +18,54 @@ static ENCODE_URI_SET: &AsciiSet = &NON_ALPHANUMERIC
     .remove(b'(')
     .remove(b')');
 
-lazy_static! {
-    static ref SCOPED_PACKAGE: Regex =
-        Regex::new(r"^(?:@([^/]+?)[/])?([^/]+?)$").expect("regex is valid");
-    static ref SPECIAL_CHARS: Regex = Regex::new(r"[~'!()*]").expect("regex is valid");
-    static ref BLACKLIST: Vec<&'static str> = vec!["node_modules", "favicon.ico"];
+static SCOPED_PACKAGE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^(?:@([^/]+?)[/])?([^/]+?)$").expect("regex is valid"));
+static SPECIAL_CHARS: Lazy<Regex> = Lazy::new(|| Regex::new(r"[~'!()*]").expect("regex is valid"));
+const BLACKLIST: [&str; 2] = ["node_modules", "favicon.ico"];
 
-    // Borrowed from https://github.com/juliangruber/builtins
-    static ref BUILTINS: Vec<&'static str> = vec![
-        "assert",
-        "buffer",
-        "child_process",
-        "cluster",
-        "console",
-        "constants",
-        "crypto",
-        "dgram",
-        "dns",
-        "domain",
-        "events",
-        "fs",
-        "http",
-        "https",
-        "module",
-        "net",
-        "os",
-        "path",
-        "punycode",
-        "querystring",
-        "readline",
-        "repl",
-        "stream",
-        "string_decoder",
-        "sys",
-        "timers",
-        "tls",
-        "tty",
-        "url",
-        "util",
-        "vm",
-        "zlib",
-        "freelist",
-        // excluded only in some versions
-        "freelist",
-        "v8",
-        "process",
-        "async_hooks",
-        "http2",
-        "perf_hooks",
-    ];
-}
+// Borrowed from https://github.com/juliangruber/builtins
+const BUILTINS: [&str; 39] = [
+    "assert",
+    "buffer",
+    "child_process",
+    "cluster",
+    "console",
+    "constants",
+    "crypto",
+    "dgram",
+    "dns",
+    "domain",
+    "events",
+    "fs",
+    "http",
+    "https",
+    "module",
+    "net",
+    "os",
+    "path",
+    "punycode",
+    "querystring",
+    "readline",
+    "repl",
+    "stream",
+    "string_decoder",
+    "sys",
+    "timers",
+    "tls",
+    "tty",
+    "url",
+    "util",
+    "vm",
+    "zlib",
+    "freelist",
+    // excluded only in some versions
+    "freelist",
+    "v8",
+    "process",
+    "async_hooks",
+    "http2",
+    "perf_hooks",
+];
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Validity {

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -20,8 +20,6 @@ readext = "0.1.0"
 serde_json = { version = "1.0.111", features = ["preserve_order"] }
 serde = { version = "1.0.193", features = ["derive"] }
 archive = { path = "../archive" }
-lazycell = "1.3.0"
-lazy_static = "1.3.0"
 node-semver = "2"
 cmdline_words_parser = "0.2.1"
 fs-utils = { path = "../fs-utils" }

--- a/crates/volta-core/src/hook/mod.rs
+++ b/crates/volta-core/src/hook/mod.rs
@@ -10,8 +10,8 @@ use crate::error::{Context, ErrorKind, Fallible};
 use crate::layout::volta_home;
 use crate::project::Project;
 use crate::tool::{Node, Npm, Pnpm, Tool};
-use lazycell::LazyCell;
 use log::debug;
+use once_cell::unsync::OnceCell;
 
 pub(crate) mod serial;
 pub mod tool;
@@ -28,21 +28,21 @@ pub enum Publish {
 
 /// Lazily loaded Volta hook configuration
 pub struct LazyHookConfig {
-    settings: LazyCell<HookConfig>,
+    settings: OnceCell<HookConfig>,
 }
 
 impl LazyHookConfig {
     /// Constructs a new `LazyHookConfig`
     pub fn init() -> LazyHookConfig {
         LazyHookConfig {
-            settings: LazyCell::new(),
+            settings: OnceCell::new(),
         }
     }
 
     /// Forces the loading of the hook configuration from both project-local and user-default hooks
     pub fn get(&self, project: Option<&Project>) -> Fallible<&HookConfig> {
         self.settings
-            .try_borrow_with(|| HookConfig::current(project))
+            .get_or_try_init(|| HookConfig::current(project))
     }
 }
 

--- a/crates/volta-core/src/hook/tool.rs
+++ b/crates/volta-core/src/hook/tool.rs
@@ -10,9 +10,9 @@ use crate::hook::RegistryFormat;
 use crate::tool::{NODE_DISTRO_ARCH, NODE_DISTRO_OS};
 use cmdline_words_parser::parse_posix;
 use dunce::canonicalize;
-use lazy_static::lazy_static;
 use log::debug;
 use node_semver::Version;
+use once_cell::sync::Lazy;
 
 const ARCH_TEMPLATE: &str = "{{arch}}";
 const OS_TEMPLATE: &str = "{{os}}";
@@ -20,10 +20,8 @@ const VERSION_TEMPLATE: &str = "{{version}}";
 const EXTENSION_TEMPLATE: &str = "{{ext}}";
 const FILENAME_TEMPLATE: &str = "{{filename}}";
 
-lazy_static! {
-    static ref REL_PATH: String = format!(".{}", std::path::MAIN_SEPARATOR);
-    static ref REL_PATH_PARENT: String = format!("..{}", std::path::MAIN_SEPARATOR);
-}
+static REL_PATH: Lazy<String> = Lazy::new(|| format!(".{}", std::path::MAIN_SEPARATOR));
+static REL_PATH_PARENT: Lazy<String> = Lazy::new(|| format!("..{}", std::path::MAIN_SEPARATOR));
 
 /// A hook for resolving the distro URL for a given tool version
 #[derive(PartialEq, Eq, Debug)]

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 use crate::error::{Context, ErrorKind, Fallible};
 use cfg_if::cfg_if;
 use dunce::canonicalize;
-use lazy_static::lazy_static;
 use once_cell::sync::OnceCell;
 use volta_layout::v3::{VoltaHome, VoltaInstall};
 
@@ -18,10 +17,8 @@ cfg_if! {
     }
 }
 
-lazy_static! {
-    static ref VOLTA_HOME: OnceCell<VoltaHome> = OnceCell::new();
-    static ref VOLTA_INSTALL: OnceCell<VoltaInstall> = OnceCell::new();
-}
+static VOLTA_HOME: OnceCell<VoltaHome> = OnceCell::new();
+static VOLTA_INSTALL: OnceCell<VoltaInstall> = OnceCell::new();
 
 pub fn volta_home<'a>() -> Fallible<&'a VoltaHome> {
     VOLTA_HOME.get_or_try_init(|| {

--- a/crates/volta-core/src/platform/tests.rs
+++ b/crates/volta-core/src/platform/tests.rs
@@ -214,14 +214,12 @@ mod inherit_option {
 }
 
 mod cli_platform {
-    use lazy_static::lazy_static;
     use node_semver::Version;
+    use once_cell::unsync::Lazy;
 
-    lazy_static! {
-        static ref NODE_VERSION: Version = Version::from((12, 14, 1));
-        static ref NPM_VERSION: Version = Version::from((6, 13, 2));
-        static ref YARN_VERSION: Version = Version::from((1, 17, 0));
-    }
+    const NODE_VERSION: Lazy<Version> = Lazy::new(|| Version::from((12, 14, 1)));
+    const NPM_VERSION: Lazy<Version> = Lazy::new(|| Version::from((6, 13, 2)));
+    const YARN_VERSION: Lazy<Version> = Lazy::new(|| Version::from((1, 17, 0)));
 
     mod merge {
         use super::super::super::*;

--- a/crates/volta-core/src/run/npx.rs
+++ b/crates/volta-core/src/run/npx.rs
@@ -6,19 +6,16 @@ use super::{debug_active_image, debug_no_platform, RECURSION_ENV_VAR};
 use crate::error::{ErrorKind, Fallible};
 use crate::platform::{Platform, System};
 use crate::session::{ActivityKind, Session};
-use lazy_static::lazy_static;
 use node_semver::Version;
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    /// The minimum required npm version that includes npx (5.2.0)
-    static ref REQUIRED_NPM_VERSION: Version = Version {
-        major: 5,
-        minor: 2,
-        patch: 0,
-        build: vec![],
-        pre_release: vec![]
-    };
-}
+static REQUIRED_NPM_VERSION: Lazy<Version> = Lazy::new(|| Version {
+    major: 5,
+    minor: 2,
+    patch: 0,
+    build: vec![],
+    pre_release: vec![],
+});
 
 /// Build a `ToolCommand` for npx
 pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {

--- a/crates/volta-core/src/sync.rs
+++ b/crates/volta-core/src/sync.rs
@@ -30,12 +30,10 @@ use crate::error::{Context, ErrorKind, Fallible};
 use crate::layout::volta_home;
 use crate::style::progress_spinner;
 use fs2::FileExt;
-use lazy_static::lazy_static;
 use log::debug;
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    static ref LOCK_STATE: Mutex<Option<LockState>> = Mutex::new(None);
-}
+static LOCK_STATE: Lazy<Mutex<Option<LockState>>> = Lazy::new(|| Mutex::new(None));
 
 /// The current state of locks for this process.
 ///

--- a/crates/volta-core/src/tool/serial.rs
+++ b/crates/volta-core/src/tool/serial.rs
@@ -3,16 +3,14 @@ use std::cmp::Ordering;
 use super::Spec;
 use crate::error::{ErrorKind, Fallible};
 use crate::version::{VersionSpec, VersionTag};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use regex::Regex;
 use validate_npm_package_name::{validate, Validity};
 
-lazy_static! {
-    static ref TOOL_SPEC_PATTERN: Regex =
-        Regex::new("^(?P<name>(?:@([^/]+?)[/])?([^/]+?))(@(?P<version>.+))?$")
-            .expect("regex is valid");
-    static ref HAS_VERSION: Regex = Regex::new(r"^[^\s]+@").expect("regex is valid");
-}
+static TOOL_SPEC_PATTERN: Lazy<Regex> = Lazy::new(|| {
+    Regex::new("^(?P<name>(?:@([^/]+?)[/])?([^/]+?))(@(?P<version>.+))?$").expect("regex is valid")
+});
+static HAS_VERSION: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[^\s]+@").expect("regex is valid"));
 
 /// Methods for parsing a Spec out of string values
 impl Spec {

--- a/crates/volta-core/src/toolchain/mod.rs
+++ b/crates/volta-core/src/toolchain/mod.rs
@@ -5,34 +5,35 @@ use crate::error::{Context, ErrorKind, Fallible};
 use crate::fs::touch;
 use crate::layout::volta_home;
 use crate::platform::PlatformSpec;
-use lazycell::LazyCell;
 use log::debug;
 use node_semver::Version;
+use once_cell::unsync::OnceCell;
 use readext::ReadExt;
 
 pub mod serial;
 
 /// Lazily loaded toolchain
 pub struct LazyToolchain {
-    toolchain: LazyCell<Toolchain>,
+    toolchain: OnceCell<Toolchain>,
 }
 
 impl LazyToolchain {
     /// Creates a new `LazyToolchain`
     pub fn init() -> Self {
         LazyToolchain {
-            toolchain: LazyCell::new(),
+            toolchain: OnceCell::new(),
         }
     }
 
     /// Forces loading of the toolchain and returns an immutable reference to it
     pub fn get(&self) -> Fallible<&Toolchain> {
-        self.toolchain.try_borrow_with(Toolchain::current)
+        self.toolchain.get_or_try_init(Toolchain::current)
     }
 
     /// Forces loading of the toolchain and returns a mutable reference to it
     pub fn get_mut(&mut self) -> Fallible<&mut Toolchain> {
-        self.toolchain.try_borrow_mut_with(Toolchain::current)
+        let _ = self.toolchain.get_or_try_init(Toolchain::current)?;
+        Ok(self.toolchain.get_mut().unwrap())
     }
 }
 

--- a/src/command/list/human.rs
+++ b/src/command/list/human.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use super::{Node, Package, PackageManager, PackageManagerKind, Toolchain};
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use textwrap::{fill, Options};
 use volta_core::style::{text_width, tool_version, MAX_WIDTH};
 
@@ -13,9 +13,7 @@ static NO_RUNTIME: &str = "⚡️ No Node runtimes installed!
     You can install a runtime by running `volta install node`. See `volta help install` for
     details and more options.";
 
-lazy_static! {
-    static ref TEXT_WIDTH: usize = text_width().unwrap_or(MAX_WIDTH);
-}
+static TEXT_WIDTH: Lazy<usize> = Lazy::new(|| text_width().unwrap_or(MAX_WIDTH));
 
 #[allow(clippy::unnecessary_wraps)] // Needs to match the API of `plain::format`
 pub(super) fn format(toolchain: &Toolchain) -> Option<String> {
@@ -400,19 +398,17 @@ where
 mod tests {
     use std::path::PathBuf;
 
-    use lazy_static::lazy_static;
     use node_semver::Version;
+    use once_cell::sync::Lazy;
 
     use super::*;
 
-    lazy_static! {
-        static ref NODE_12: Version = Version::from((12, 2, 0));
-        static ref NODE_11: Version = Version::from((11, 9, 0));
-        static ref NODE_10: Version = Version::from((10, 15, 3));
-        static ref YARN_VERSION: Version = Version::from((1, 16, 0));
-        static ref NPM_VERSION: Version = Version::from((6, 13, 1));
-        static ref PROJECT_PATH: PathBuf = PathBuf::from("~/path/to/project.json");
-    }
+    static NODE_12: Lazy<Version> = Lazy::new(|| Version::from((12, 2, 0)));
+    static NODE_11: Lazy<Version> = Lazy::new(|| Version::from((11, 9, 0)));
+    static NODE_10: Lazy<Version> = Lazy::new(|| Version::from((10, 15, 3)));
+    static YARN_VERSION: Lazy<Version> = Lazy::new(|| Version::from((1, 16, 0)));
+    static NPM_VERSION: Lazy<Version> = Lazy::new(|| Version::from((6, 13, 1)));
+    static PROJECT_PATH: Lazy<PathBuf> = Lazy::new(|| PathBuf::from("~/path/to/project.json"));
 
     mod active {
         use super::*;

--- a/src/command/list/plain.rs
+++ b/src/command/list/plain.rs
@@ -203,18 +203,16 @@ fn display_tool(name: &str, host: &Package) -> Option<String> {
 mod tests {
     use std::path::PathBuf;
 
-    use lazy_static::lazy_static;
     use node_semver::Version;
+    use once_cell::sync::Lazy;
 
     use crate::command::list::PackageDetails;
 
-    lazy_static! {
-        static ref NODE_VERSION: Version = Version::from((12, 4, 0));
-        static ref TYPESCRIPT_VERSION: Version = Version::from((3, 4, 1));
-        static ref NPM_VERSION: Version = Version::from((6, 13, 4));
-        static ref YARN_VERSION: Version = Version::from((1, 16, 0));
-        static ref PROJECT_PATH: PathBuf = PathBuf::from("/a/b/c");
-    }
+    static NODE_VERSION: Lazy<Version> = Lazy::new(|| Version::from((12, 4, 0)));
+    static TYPESCRIPT_VERSION: Lazy<Version> = Lazy::new(|| Version::from((3, 4, 1)));
+    static NPM_VERSION: Lazy<Version> = Lazy::new(|| Version::from((6, 13, 4)));
+    static YARN_VERSION: Lazy<Version> = Lazy::new(|| Version::from((1, 16, 0)));
+    static PROJECT_PATH: Lazy<PathBuf> = Lazy::new(|| PathBuf::from("/a/b/c"));
 
     mod node {
         use super::super::*;


### PR DESCRIPTION
`once_cell`, `lazycell`, and `lazy_static` crates have been used in the `volta` project. The crates provides similar functionality. As parts of `once_cell`'s API is stabilized at the standard library and the other parts are going on, replaces `lazycell` and `lazy_static` with `once_cell` crate.