### PR TITLE
feat: support yarnpkg as an alias for yarn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,7 +1584,7 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 
 [[package]]
 name = "volta"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "cfg-if",
  "ci_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volta"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["David Herman <david.herman@gmail.com>", "Charles Pierce <cpierce.grad@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/volta-cli/volta"

--- a/crates/volta-core/src/run/mod.rs
+++ b/crates/volta-core/src/run/mod.rs
@@ -96,7 +96,8 @@ fn get_executor(
                     binary::command(exe, args, session)
                 }
             }
-            Some("yarn") => yarn::command(args, session),
+            Some("yarn") => yarn::command(args, session, "yarn"),
+            Some("yarnpkg") => yarn::command(args, session, "yarnpkg"),
             _ => binary::command(exe, args, session),
         }
     }

--- a/crates/volta-core/src/run/yarn.rs
+++ b/crates/volta-core/src/run/yarn.rs
@@ -16,7 +16,7 @@ use crate::session::{ActivityKind, Session};
 ///
 /// If the command is _not_ a global add / remove or we don't have a default platform, then
 /// we will allow Yarn to execute the command as usual.
-pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Executor> {
+pub(super) fn command(args: &[OsString], session: &mut Session, yarn_executable: &str) -> Fallible<Executor> {
     session.add_event_start(ActivityKind::Yarn);
     // Don't re-evaluate the context or global install interception if this is a recursive call
     let platform = match env::var_os(RECURSION_ENV_VAR) {
@@ -32,8 +32,8 @@ pub(super) fn command(args: &[OsString], session: &mut Session) -> Fallible<Exec
             Platform::current(session)?
         }
     };
-
-    Ok(ToolCommand::new("yarn", args, platform, ToolKind::Yarn).into())
+    
+    Ok(ToolCommand::new(yarn_executable, args, platform, ToolKind::Yarn).into())
 }
 
 /// Determine the execution context (PATH and failure error message) for Yarn

--- a/crates/volta-core/src/shim.rs
+++ b/crates/volta-core/src/shim.rs
@@ -36,6 +36,7 @@ fn get_shim_list_deduped(dir: &Path) -> Fallible<HashSet<String>> {
         shims.insert("npx".into());
         shims.insert("pnpm".into());
         shims.insert("yarn".into());
+        shims.insert("yarnpkg".into());
         Ok(shims)
     }
 


### PR DESCRIPTION
My attempt at implementing #1391. This is my first Rust code aside from a helloworld example, so you know, it mightn't be perfect yet.

I tested (and wrote) this on macOS Sonoma 14.3 by switching between the 1.1.1 release and this dev build, and it seems to work, but I'm not 100% sure on how to reliably verify it. I bumped the version to 1.1.2 so that the dev install script would let me switch, not sure if I was supposed to do that. :) 