### PR TITLE
Re-add 'Header' import to tarball module

### DIFF
--- a/crates/archive/src/tarball.rs
+++ b/crates/archive/src/tarball.rs
@@ -9,7 +9,7 @@ use super::{Archive, ArchiveError, Origin};
 use attohttpc::header::HeaderMap;
 use flate2::read::GzDecoder;
 use fs_utils::ensure_containing_dir_exists;
-use headers::{AcceptRanges, ContentLength, HeaderMapExt, Range};
+use headers::{AcceptRanges, ContentLength, Header, HeaderMapExt, Range};
 use progress_read::ProgressRead;
 use tee::TeeReader;
 


### PR DESCRIPTION
I merged two PRs recently that had conflicting imports. The net result was that 'main' isn't currently building because one PR removed an import that the other PR relied on.