### PR TITLE
Update cli_platform tests to use 'const' correctly

### DIFF
--- a/crates/volta-core/src/platform/tests.rs
+++ b/crates/volta-core/src/platform/tests.rs
@@ -215,11 +215,28 @@ mod inherit_option {
 
 mod cli_platform {
     use node_semver::Version;
-    use once_cell::unsync::Lazy;
 
-    const NODE_VERSION: Lazy<Version> = Lazy::new(|| Version::from((12, 14, 1)));
-    const NPM_VERSION: Lazy<Version> = Lazy::new(|| Version::from((6, 13, 2)));
-    const YARN_VERSION: Lazy<Version> = Lazy::new(|| Version::from((1, 17, 0)));
+    const NODE_VERSION: Version = Version {
+        major: 12,
+        minor: 14,
+        patch: 1,
+        build: Vec::new(),
+        pre_release: Vec::new(),
+    };
+    const NPM_VERSION: Version = Version {
+        major: 6,
+        minor: 13,
+        patch: 2,
+        build: Vec::new(),
+        pre_release: Vec::new(),
+    };
+    const YARN_VERSION: Version = Version {
+        major: 1,
+        minor: 17,
+        patch: 0,
+        build: Vec::new(),
+        pre_release: Vec::new(),
+    };
 
     mod merge {
         use super::super::super::*;
@@ -228,7 +245,7 @@ mod cli_platform {
         #[test]
         fn uses_node() {
             let test = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::default(),
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
@@ -243,7 +260,7 @@ mod cli_platform {
 
             let merged = test.merge(base);
 
-            assert_eq!(merged.node.value, NODE_VERSION.clone());
+            assert_eq!(merged.node.value, NODE_VERSION);
             assert_eq!(merged.node.source, Source::CommandLine);
         }
 
@@ -257,7 +274,7 @@ mod cli_platform {
             };
 
             let base = Platform {
-                node: Sourced::with_default(NODE_VERSION.clone()),
+                node: Sourced::with_default(NODE_VERSION),
                 npm: None,
                 pnpm: None,
                 yarn: None,
@@ -265,15 +282,15 @@ mod cli_platform {
 
             let merged = test.merge(base);
 
-            assert_eq!(merged.node.value, NODE_VERSION.clone());
+            assert_eq!(merged.node.value, NODE_VERSION);
             assert_eq!(merged.node.source, Source::Default);
         }
 
         #[test]
         fn uses_npm() {
             let test = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
-                npm: InheritOption::Some(NPM_VERSION.clone()),
+                node: Some(NODE_VERSION),
+                npm: InheritOption::Some(NPM_VERSION),
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
@@ -288,14 +305,14 @@ mod cli_platform {
             let merged = test.merge(base);
 
             let merged_npm = merged.npm.unwrap();
-            assert_eq!(merged_npm.value, NPM_VERSION.clone());
+            assert_eq!(merged_npm.value, NPM_VERSION);
             assert_eq!(merged_npm.source, Source::CommandLine);
         }
 
         #[test]
         fn inherits_npm() {
             let test = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::Inherit,
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
@@ -303,7 +320,7 @@ mod cli_platform {
 
             let base = Platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
-                npm: Some(Sourced::with_default(NPM_VERSION.clone())),
+                npm: Some(Sourced::with_default(NPM_VERSION)),
                 pnpm: None,
                 yarn: None,
             };
@@ -311,14 +328,14 @@ mod cli_platform {
             let merged = test.merge(base);
 
             let merged_npm = merged.npm.unwrap();
-            assert_eq!(merged_npm.value, NPM_VERSION.clone());
+            assert_eq!(merged_npm.value, NPM_VERSION);
             assert_eq!(merged_npm.source, Source::Default);
         }
 
         #[test]
         fn none_does_not_inherit_npm() {
             let test = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::None,
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
@@ -326,7 +343,7 @@ mod cli_platform {
 
             let base = Platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
-                npm: Some(Sourced::with_default(NPM_VERSION.clone())),
+                npm: Some(Sourced::with_default(NPM_VERSION)),
                 pnpm: None,
                 yarn: None,
             };
@@ -339,10 +356,10 @@ mod cli_platform {
         #[test]
         fn uses_yarn() {
             let test = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::default(),
                 pnpm: InheritOption::default(),
-                yarn: InheritOption::Some(YARN_VERSION.clone()),
+                yarn: InheritOption::Some(YARN_VERSION),
             };
 
             let base = Platform {
@@ -355,14 +372,14 @@ mod cli_platform {
             let merged = test.merge(base);
 
             let merged_yarn = merged.yarn.unwrap();
-            assert_eq!(merged_yarn.value, YARN_VERSION.clone());
+            assert_eq!(merged_yarn.value, YARN_VERSION);
             assert_eq!(merged_yarn.source, Source::CommandLine);
         }
 
         #[test]
         fn inherits_yarn() {
             let test = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::default(),
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::Inherit,
@@ -372,20 +389,20 @@ mod cli_platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
                 npm: None,
                 pnpm: None,
-                yarn: Some(Sourced::with_default(YARN_VERSION.clone())),
+                yarn: Some(Sourced::with_default(YARN_VERSION)),
             };
 
             let merged = test.merge(base);
 
             let merged_yarn = merged.yarn.unwrap();
-            assert_eq!(merged_yarn.value, YARN_VERSION.clone());
+            assert_eq!(merged_yarn.value, YARN_VERSION);
             assert_eq!(merged_yarn.source, Source::Default);
         }
 
         #[test]
         fn none_does_not_inherit_yarn() {
             let test = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::default(),
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::None,
@@ -395,7 +412,7 @@ mod cli_platform {
                 node: Sourced::with_default(Version::from((10, 10, 10))),
                 npm: None,
                 pnpm: None,
-                yarn: Some(Sourced::with_default(YARN_VERSION.clone())),
+                yarn: Some(Sourced::with_default(YARN_VERSION)),
             };
 
             let merged = test.merge(base);
@@ -425,7 +442,7 @@ mod cli_platform {
         #[test]
         fn uses_cli_node() {
             let cli = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::default(),
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
@@ -434,15 +451,15 @@ mod cli_platform {
             let transformed: Option<Platform> = cli.into();
 
             let node = transformed.unwrap().node;
-            assert_eq!(node.value, NODE_VERSION.clone());
+            assert_eq!(node.value, NODE_VERSION);
             assert_eq!(node.source, Source::CommandLine);
         }
 
         #[test]
         fn uses_cli_npm() {
             let cli = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
-                npm: InheritOption::Some(NPM_VERSION.clone()),
+                node: Some(NODE_VERSION),
+                npm: InheritOption::Some(NPM_VERSION),
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
             };
@@ -450,14 +467,14 @@ mod cli_platform {
             let transformed: Option<Platform> = cli.into();
 
             let npm = transformed.unwrap().npm.unwrap();
-            assert_eq!(npm.value, NPM_VERSION.clone());
+            assert_eq!(npm.value, NPM_VERSION);
             assert_eq!(npm.source, Source::CommandLine);
         }
 
         #[test]
         fn no_npm() {
             let cli = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::None,
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
@@ -471,7 +488,7 @@ mod cli_platform {
         #[test]
         fn inherit_npm_becomes_none() {
             let cli = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::Inherit,
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::default(),
@@ -485,23 +502,23 @@ mod cli_platform {
         #[test]
         fn uses_cli_yarn() {
             let cli = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::default(),
                 pnpm: InheritOption::default(),
-                yarn: InheritOption::Some(YARN_VERSION.clone()),
+                yarn: InheritOption::Some(YARN_VERSION),
             };
 
             let transformed: Option<Platform> = cli.into();
 
             let yarn = transformed.unwrap().yarn.unwrap();
-            assert_eq!(yarn.value, YARN_VERSION.clone());
+            assert_eq!(yarn.value, YARN_VERSION);
             assert_eq!(yarn.source, Source::CommandLine);
         }
 
         #[test]
         fn no_yarn() {
             let cli = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::default(),
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::None,
@@ -515,7 +532,7 @@ mod cli_platform {
         #[test]
         fn inherit_yarn_becomes_none() {
             let cli = CliPlatform {
-                node: Some(NODE_VERSION.clone()),
+                node: Some(NODE_VERSION),
                 npm: InheritOption::default(),
                 pnpm: InheritOption::default(),
                 yarn: InheritOption::Inherit,


### PR DESCRIPTION
Info
-----
The tests of the platform resolution for the various 'volta run' scenarios were using a lazily-loaded 'const' value. Clippy raised some warnings about those, as 'const' values are actually duplicated for each location they are used, so the interior mutability wasn't helpful.

It seems that the `Lazy` behavior was actually a way to work around the fact that `Version` doesn't have a 'const' constructor, however all of the fields are `pub`, so we can construct the values directly. This allows us to have a true `const` value and use it in each test without needing extra interior mutability or cloning.

Changes
-----
* Updated the `NODE_VERSION`, `NPM_VERSION`, and `YARN_VERSION` constants used in the `cli_platform` tests to be directly defined, rather than lazy loaded.
* Changed all call sites to use the constants directly, instead of cloning.

Tested
-----
* Ran the affected tests and verified that they still pass as expected.