### PR TITLE
Replace Windows symlinks with `volta run` scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,6 +780,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "junction"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9c415a9b7b1e86cd5738f39d34c9e78c765da7fb1756dbd7d31b3b0d2e7afa"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1274,6 +1284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1646,7 @@ dependencies = [
  "httpdate",
  "indexmap 2.2.6",
  "indicatif",
+ "junction",
  "log",
  "mockito",
  "node-semver",

--- a/crates/volta-core/Cargo.toml
+++ b/crates/volta-core/Cargo.toml
@@ -55,3 +55,4 @@ fs2 = "0.4.3"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.52.0"
+junction = "1.1.0"

--- a/crates/volta-core/src/fs.rs
+++ b/crates/volta-core/src/fs.rs
@@ -138,7 +138,7 @@ where
     D: AsRef<Path>,
 {
     #[cfg(windows)]
-    return std::os::windows::fs::symlink_dir(src, dest);
+    return junction::create(src, dest);
 
     #[cfg(unix)]
     return std::os::unix::fs::symlink(src, dest);

--- a/crates/volta-core/src/layout/mod.rs
+++ b/crates/volta-core/src/layout/mod.rs
@@ -5,7 +5,7 @@ use crate::error::{Context, ErrorKind, Fallible};
 use cfg_if::cfg_if;
 use dunce::canonicalize;
 use once_cell::sync::OnceCell;
-use volta_layout::v3::{VoltaHome, VoltaInstall};
+use volta_layout::v4::{VoltaHome, VoltaInstall};
 
 cfg_if! {
     if #[cfg(unix)] {

--- a/crates/volta-layout/src/lib.rs
+++ b/crates/volta-layout/src/lib.rs
@@ -5,6 +5,7 @@ pub mod v0;
 pub mod v1;
 pub mod v2;
 pub mod v3;
+pub mod v4;
 
 fn executable(name: &str) -> String {
     format!("{}{}", name, std::env::consts::EXE_SUFFIX)

--- a/crates/volta-layout/src/v4.rs
+++ b/crates/volta-layout/src/v4.rs
@@ -1,0 +1,125 @@
+use std::path::PathBuf;
+
+use volta_layout_macro::layout;
+
+pub use crate::v1::VoltaInstall;
+
+layout! {
+    pub struct VoltaHome {
+        "cache": cache_dir {
+            "node": node_cache_dir {
+                "index.json": node_index_file;
+                "index.json.expires": node_index_expiry_file;
+            }
+        }
+        "bin": shim_dir {}
+        "log": log_dir {}
+        "tools": tools_dir {
+            "inventory": inventory_dir {
+                "node": node_inventory_dir {}
+                "npm": npm_inventory_dir {}
+                "pnpm": pnpm_inventory_dir {}
+                "yarn": yarn_inventory_dir {}
+            }
+            "image": image_dir {
+                "node": node_image_root_dir {}
+                "npm": npm_image_root_dir {}
+                "pnpm": pnpm_image_root_dir {}
+                "yarn": yarn_image_root_dir {}
+                "packages": package_image_root_dir {}
+            }
+            "shared": shared_lib_root {}
+            "user": default_toolchain_dir {
+                "bins": default_bin_dir {}
+                "packages": default_package_dir {}
+                "platform.json": default_platform_file;
+            }
+        }
+        "tmp": tmp_dir {}
+        "hooks.json": default_hooks_file;
+        "layout.v4": layout_file;
+    }
+}
+
+impl VoltaHome {
+    pub fn node_image_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_root_dir.clone(), node)
+    }
+
+    pub fn npm_image_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_root_dir.clone(), npm)
+    }
+
+    pub fn npm_image_bin_dir(&self, npm: &str) -> PathBuf {
+        path_buf!(self.npm_image_dir(npm), "bin")
+    }
+
+    pub fn pnpm_image_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.pnpm_image_root_dir.clone(), version)
+    }
+
+    pub fn pnpm_image_bin_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.pnpm_image_dir(version), "bin")
+    }
+
+    pub fn yarn_image_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_root_dir.clone(), version)
+    }
+
+    pub fn yarn_image_bin_dir(&self, version: &str) -> PathBuf {
+        path_buf!(self.yarn_image_dir(version), "bin")
+    }
+
+    pub fn package_image_dir(&self, name: &str) -> PathBuf {
+        path_buf!(self.package_image_root_dir.clone(), name)
+    }
+
+    pub fn default_package_config_file(&self, package_name: &str) -> PathBuf {
+        path_buf!(
+            self.default_package_dir.clone(),
+            format!("{}.json", package_name)
+        )
+    }
+
+    pub fn default_tool_bin_config(&self, bin_name: &str) -> PathBuf {
+        path_buf!(self.default_bin_dir.clone(), format!("{}.json", bin_name))
+    }
+
+    pub fn node_npm_version_file(&self, version: &str) -> PathBuf {
+        path_buf!(
+            self.node_inventory_dir.clone(),
+            format!("node-v{}-npm", version)
+        )
+    }
+
+    pub fn shim_file(&self, toolname: &str) -> PathBuf {
+        // On Windows, shims are created as `<name>.cmd` since they
+        // are thin scripts that use `volta run` to execute the command
+        #[cfg(windows)]
+        let toolname = format!("{}{}", toolname, ".cmd");
+
+        path_buf!(self.shim_dir.clone(), toolname)
+    }
+
+    pub fn shared_lib_dir(&self, library: &str) -> PathBuf {
+        path_buf!(self.shared_lib_root.clone(), library)
+    }
+}
+
+#[cfg(windows)]
+impl VoltaHome {
+    pub fn shim_git_bash_script_file(&self, toolname: &str) -> PathBuf {
+        path_buf!(self.shim_dir.clone(), toolname)
+    }
+
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        self.node_image_dir(node)
+    }
+}
+
+#[cfg(unix)]
+impl VoltaHome {
+    pub fn node_image_bin_dir(&self, node: &str) -> PathBuf {
+        path_buf!(self.node_image_dir(node), "bin")
+    }
+}

--- a/crates/volta-migrate/src/lib.rs
+++ b/crates/volta-migrate/src/lib.rs
@@ -16,11 +16,13 @@ mod v0;
 mod v1;
 mod v2;
 mod v3;
+mod v4;
 
 use v0::V0;
 use v1::V1;
 use v2::V2;
 use v3::V3;
+use v4::V4;
 
 use log::{debug, info};
 use volta_core::error::Fallible;
@@ -40,6 +42,7 @@ enum MigrationState {
     V1(Box<V1>),
     V2(Box<V2>),
     V3(Box<V3>),
+    V4(Box<V4>),
 }
 
 /// Macro to simplify the boilerplate associated with detecting a tagged state.
@@ -79,7 +82,7 @@ macro_rules! detect_tagged {
     }
 }
 
-detect_tagged!((v3, V3, V3), (v2, V2, V2), (v1, V1, V1));
+detect_tagged!((v4, V4, V4), (v3, V3, V3), (v2, V2, V2), (v1, V1, V1));
 
 impl MigrationState {
     fn current() -> Fallible<Self> {
@@ -164,7 +167,8 @@ fn detect_and_migrate() -> Fallible<()> {
             MigrationState::V0(zero) => MigrationState::V1(Box::new((*zero).try_into()?)),
             MigrationState::V1(one) => MigrationState::V2(Box::new((*one).try_into()?)),
             MigrationState::V2(two) => MigrationState::V3(Box::new((*two).try_into()?)),
-            MigrationState::V3(_) => {
+            MigrationState::V3(three) => MigrationState::V4(Box::new((*three).try_into()?)),
+            MigrationState::V4(_) => {
                 break;
             }
         };

--- a/crates/volta-migrate/src/v4.rs
+++ b/crates/volta-migrate/src/v4.rs
@@ -1,0 +1,148 @@
+use std::convert::TryFrom;
+use std::fs::File;
+use std::path::PathBuf;
+
+use super::empty::Empty;
+use super::v3::V3;
+use log::debug;
+use volta_core::error::{Context, ErrorKind, Fallible, VoltaError};
+#[cfg(windows)]
+use volta_core::fs::read_dir_eager;
+use volta_core::fs::remove_file_if_exists;
+use volta_layout::v4;
+
+/// Represents a V4 Volta Layout (used by Volta v2.0.0 and above)
+///
+/// Holds a reference to the V4 layout struct to support potential future migrations
+pub struct V4 {
+    pub home: v4::VoltaHome,
+}
+
+impl V4 {
+    pub fn new(home: PathBuf) -> Self {
+        V4 {
+            home: v4::VoltaHome::new(home),
+        }
+    }
+
+    /// Write the layout file to mark migration to V4 as complete
+    ///
+    /// Should only be called once all other migration steps are finished, so that we don't
+    /// accidentally mark an incomplete migration as completed
+    fn complete_migration(home: v4::VoltaHome) -> Fallible<Self> {
+        debug!("Writing layout marker file");
+        File::create(home.layout_file()).with_context(|| ErrorKind::CreateLayoutFileError {
+            file: home.layout_file().to_owned(),
+        })?;
+
+        Ok(V4 { home })
+    }
+}
+
+impl TryFrom<Empty> for V4 {
+    type Error = VoltaError;
+
+    fn try_from(old: Empty) -> Fallible<V4> {
+        debug!("New Volta installation detected, creating fresh layout");
+
+        let home = v4::VoltaHome::new(old.home);
+        home.create().with_context(|| ErrorKind::CreateDirError {
+            dir: home.root().to_owned(),
+        })?;
+
+        V4::complete_migration(home)
+    }
+}
+
+impl TryFrom<V3> for V4 {
+    type Error = VoltaError;
+
+    fn try_from(old: V3) -> Fallible<V4> {
+        debug!("Migrating from V3 layout");
+
+        let new_home = v4::VoltaHome::new(old.home.root().to_owned());
+        new_home
+            .create()
+            .with_context(|| ErrorKind::CreateDirError {
+                dir: new_home.root().to_owned(),
+            })?;
+
+        // Perform the core of the migration
+        #[cfg(windows)]
+        {
+            migrate_shims(&new_home)?;
+            migrate_shared_directory(&new_home)?;
+        }
+
+        // Complete the migration, writing the V4 layout file
+        let layout = V4::complete_migration(new_home)?;
+
+        // Remove the V3 layout file, since we're now on V4 (do this after writing the V4 so that we know the migration succeeded)
+        let old_layout_file = old.home.layout_file();
+        remove_file_if_exists(old_layout_file)?;
+        Ok(layout)
+    }
+}
+
+/// Migrate Windows shims to use the new non-symlink approach. Previously, shims were created in
+/// the same way as on Unix: With symlinks to the `volta-shim` executable. Now, we use scripts that
+/// call `volta run` to execute the underlying tool. This allows us to avoid needing developer
+/// mode, making Volta more broadly usable for Windows devs.
+///
+/// To migrate the shims, we read the shim directory looking for symlinks, remove those, and then
+/// file stem (name without extension) to generate new shims.
+#[cfg(windows)]
+fn migrate_shims(new_home: &v4::VoltaHome) -> Fallible<()> {
+    use std::ffi::OsStr;
+
+    let entries = read_dir_eager(new_home.shim_dir()).with_context(|| ErrorKind::ReadDirError {
+        dir: new_home.shim_dir().to_owned(),
+    })?;
+
+    for (entry, metadata) in entries {
+        if metadata.is_symlink() {
+            let path = entry.path();
+            remove_file_if_exists(&path)?;
+
+            if let Some(shim_name) = path.file_stem().and_then(OsStr::to_str) {
+                volta_core::shim::create(shim_name)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Migrate Windows shared directory to use junctions rather than directory symlinks. Similar to
+/// the shims, we previously used symlinks to create the shared global package directory, which
+/// requires developer mode. By using junctions, we can avoid that requirement entirely.
+///
+/// To migrate the directories, we read the shim directory, determine the target of each symlink,
+/// delete the link, and then create a junction (using volta_core::fs::symlink_dir which delegates
+/// to `junction` internally)
+#[cfg(windows)]
+fn migrate_shared_directory(new_home: &v4::VoltaHome) -> Fallible<()> {
+    use std::fs::read_link;
+    use volta_core::fs::{remove_dir_if_exists, symlink_dir};
+
+    let entries =
+        read_dir_eager(new_home.shared_lib_root()).with_context(|| ErrorKind::ReadDirError {
+            dir: new_home.shared_lib_root().to_owned(),
+        })?;
+
+    for (entry, metadata) in entries {
+        if metadata.is_symlink() {
+            let path = entry.path();
+            let source = read_link(&path).with_context(|| ErrorKind::ReadDirError {
+                dir: new_home.shared_lib_root().to_owned(),
+            })?;
+
+            remove_dir_if_exists(&path)?;
+            symlink_dir(source, path).with_context(|| ErrorKind::CreateSharedLinkError {
+                name: entry.file_name().to_string_lossy().to_string(),
+            })?;
+        }
+    }
+
+    Ok(())
+}

--- a/tests/acceptance/migrations.rs
+++ b/tests/acceptance/migrations.rs
@@ -30,7 +30,7 @@ fn empty_volta_home_is_created() {
     assert!(Sandbox::path_exists(".volta/tools/user"));
 
     // Layout file should now exist
-    assert!(Sandbox::path_exists(".volta/layout.v3"));
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -58,6 +58,7 @@ fn legacy_v0_volta_home_is_upgraded() {
     // Layout file is not there
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
     assert!(!Sandbox::path_exists(".volta/layout.v2"));
+    assert!(!Sandbox::path_exists(".volta/layout.v3"));
 
     // running volta should not create anything else
     assert_that!(s.volta("--version"), execs().with_status(0));
@@ -73,7 +74,8 @@ fn legacy_v0_volta_home_is_upgraded() {
     // Most recent layout file should exist, others should not
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
     assert!(!Sandbox::path_exists(".volta/layout.v2"));
-    assert!(Sandbox::path_exists(".volta/layout.v3"));
+    assert!(!Sandbox::path_exists(".volta/layout.v3"));
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -141,7 +143,8 @@ fn tagged_v1_volta_home_is_upgraded() {
     // Most recent layout file should exist, others should not
     assert!(!Sandbox::path_exists(".volta/layout.v1"));
     assert!(!Sandbox::path_exists(".volta/layout.v2"));
-    assert!(Sandbox::path_exists(".volta/layout.v3"));
+    assert!(!Sandbox::path_exists(".volta/layout.v3"));
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
 
     // shims should all be created
     // NOTE: this doesn't work in Windows, because the default shims are stored separately
@@ -206,12 +209,12 @@ fn tagged_v1_to_v2_keeps_migrated_node_images() {
 }
 
 #[test]
-fn current_v3_volta_home_is_unchanged() {
-    let s = sandbox().layout_file("v3").build();
+fn current_v4_volta_home_is_unchanged() {
+    let s = sandbox().layout_file("v4").build();
 
     // directories that are already created by the test framework
     assert!(Sandbox::path_exists(".volta"));
-    assert!(Sandbox::path_exists(".volta/layout.v3"));
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));
@@ -222,7 +225,7 @@ fn current_v3_volta_home_is_unchanged() {
 
     // everything should be the same as before running the command
     assert!(Sandbox::path_exists(".volta"));
-    assert!(Sandbox::path_exists(".volta/layout.v3"));
+    assert!(Sandbox::path_exists(".volta/layout.v4"));
     assert!(Sandbox::path_exists(".volta/cache/node"));
     assert!(Sandbox::path_exists(".volta/tmp"));
     assert!(Sandbox::path_exists(".volta/tools/inventory/node"));


### PR DESCRIPTION
Closes #1397 

Info
-----
* Huge kudos to @rcsilva83 and @Xstoudi for a bunch of iteration in #1552 on removing symlinks for Windows, to allow dropping the requirement for Developer Mode.
* Based on discussions in that PR, we had a new idea for replacing symlink shims on Windows by using scripts that call `volta run <package>`.
* This is a first-pass implementation of creating simple script-based shims for executing 3rd-party binaries on Windows.
* This should be a no-op for Unix.

Changes
-----
* Used `junction` to create NTFS junctions instead of directory symlinks (this part is directly copied from #1552)
* Updated the `shim` module to have different implementations of `create` for Unix and Windows.
    * The Unix implementation is the same as it was before.
    * The Windows implementation creates a very simple `.cmd` script that calls `volta run` for the shim. It also continues to create a custom Git Bash script, though that script is updated to now call `volta run` directly, instead of calling the existing shim via `cmd.exe`
* Create a new `v4` layout since the shim file on Windows is now `<binary>.cmd` instead of `<binary>.exe`.
* Created a migration to `v4` that removes and regenerates the shims, making sure that the old symlinks are removed. The migration also updates any existing directory symlinks to use junctions as well.

Tested
-----
* Installed packages using the current Volta version (i.e. with symlinks).
* Installed a new version of Volta based on these changes.
* Verified that running the existing packages still works and that the shims were properly migrated.
* Turned off developer mode.
* Verified that even without developer mode, I could install and run new packages 🎉 
* Did some very basic performance tests, on my local machine I wasn't seeing any statistically significant differences between the symlink-based approach and the `volta run` approach ⚡ 