### PR TITLE
chore: update GHA `checkout` and `upload-artifact`

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Set up cargo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up docker buildx
         uses: docker/setup-buildx-action@v2
       - name: Build docker image
@@ -29,7 +29,7 @@ jobs:
       - name: Compile and package Volta
         run: docker run --volume ${PWD}:/root/workspace --workdir /root/workspace --rm --init --tty volta /root/workspace/ci/build-linux.sh volta-linux
       - name: Upload release artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux
           path: target/release/volta-linux.tar.gz
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install cross-rs
         uses: taiki-e/install-action@v2
         with:
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd target/aarch64-unknown-linux-gnu/release && tar -zcvf "volta-linux-arm.tar.gz" volta volta-shim volta-migrate
       - name: Upload release artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-arm
           path: target/aarch64-unknown-linux-gnu/release/volta-linux-arm.tar.gz
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -68,7 +68,7 @@ jobs:
       - name: Compile and package Volta
         run: ./ci/build-macos.sh volta-macos
       - name: Upload release artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: macos
           path: target/universal-apple-darwin/release/volta-macos.tar.gz
@@ -78,7 +78,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Add cargo-wix subcommand
@@ -90,12 +90,12 @@ jobs:
         run: powershell Compress-Archive volta*.exe volta-windows.zip
         working-directory: ./target/release
       - name: Upload installer
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-installer
           path: target/wix/volta-windows.msi
       - name: Upload zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: windows-zip
           path: target/release/volta-windows.zip
@@ -110,7 +110,7 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Determine release version
         id: release_info
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Run tests
@@ -41,7 +41,7 @@ jobs:
       RUST_BACKTRACE: full
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Run tests
@@ -55,7 +55,7 @@ jobs:
       - name: Setup BATS
         run: sudo npm install -g bats
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Run tests
         run: bats dev/unix/tests/
 
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Run check


### PR DESCRIPTION
Both of these were on versions using Node 16; update to the current fixes that *and* gets us some performance improvements and bug fixes.