### PR TITLE
debugging: add a bunch of tracing around `archive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "flate2",
  "fs-utils",
  "hyperx",
+ "log",
  "progress-read",
  "tar",
  "tee",

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 flate2 = "1.0"
+log = { version = "0.4", features = ["std"] }
 tar = "0.4.13"
 zip_rs = { version = "0.2.6", package = "zip" }
 tee = "0.1.0"

--- a/crates/volta-core/src/log.rs
+++ b/crates/volta-core/src/log.rs
@@ -31,10 +31,12 @@ pub enum LogContext {
 }
 
 /// Represents the level of verbosity that was requested by the user
+#[derive(Debug, Copy, Clone)]
 pub enum LogVerbosity {
     Quiet,
     Default,
     Verbose,
+    VeryVerbose,
 }
 
 pub struct Logger {
@@ -52,9 +54,10 @@ impl Log for Logger {
             match record.level() {
                 Level::Error => self.log_error(record.args()),
                 Level::Warn => self.log_warning(record.args()),
-                Level::Debug => eprintln!("[verbose] {}", record.args()),
                 // all info-level messages go to stdout
-                _ => println!("{}", record.args()),
+                Level::Info => println!("{}", record.args()),
+                Level::Debug => eprintln!("[verbose] {}", record.args()),
+                Level::Trace => eprintln!("[very verbose] {}", record.args()),
             }
         }
     }
@@ -78,6 +81,7 @@ impl Logger {
             LogVerbosity::Quiet => LevelFilter::Error,
             LogVerbosity::Default => level_from_env(),
             LogVerbosity::Verbose => LevelFilter::Debug,
+            LogVerbosity::VeryVerbose => LevelFilter::max(),
         };
 
         Logger { context, level }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,14 @@ pub(crate) struct Volta {
     pub(crate) verbose: bool,
 
     #[structopt(
+        long = "very-verbose",
+        help = "Enables maximally verbose diagnostics. Requires `--verbose`",
+        global = true,
+        requires = "verbose"
+    )]
+    pub(crate) very_verbose: bool,
+
+    #[structopt(
         long = "quiet",
         help = "Prevents unnecessary output",
         global = true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,20 @@ pub fn main() {
     let volta = cli::Volta::from_args();
     let verbosity = match (&volta.verbose, &volta.quiet) {
         (false, false) => LogVerbosity::Default,
-        (true, false) => LogVerbosity::Verbose,
+        (true, false) => {
+            if volta.very_verbose {
+                LogVerbosity::VeryVerbose
+            } else {
+                LogVerbosity::Verbose
+            }
+        }
         (false, true) => LogVerbosity::Quiet,
         (true, true) => unreachable!(
             "StructOpt should prevent the user from providing both --verbose and --quiet"
         ),
     };
     Logger::init(LogContext::Volta, verbosity).expect("Only a single logger should be initialized");
+    log::trace!("log level: {verbosity:?}");
 
     let mut session = Session::init();
     session.add_event_start(ActivityKind::Volta);


### PR DESCRIPTION
## Background/Notes

This is not really intended to be merged as is, but it should allow folks to do some testing and see if we can get more info for #1744.

In the interest of *possibly* being able to build on this for merging it if we find that useful in the future, I used `trace!` rather than `debug!` for this extreme level of output, and added a `--very-verbose` flag for this mode.

**Note:** This is based on v1.1.1, *not* on the latest `main`, and I have intentionally marked it as a draft until we get more info from #1744.

## To Test


```sh
git clone https://github.com/volta-cli/volta.git
cd volta
git switch chriskrycho/debug-1744
cargo build --release
mv $HOME/.volta/bin/volta $HOME/.volta/bin/volta-backup
cp ./target/release/volta $HOME/.volta/bin/volta
volta --verbose --very-verbose
```

That final line should print the normal help output *preceded* by this line:

```
[very verbose] log level: VeryVerbose
```

(If you have a non-standard installation location, you will want to figure out where it is with `which volta` and do the same basic thing for the final two steps, but with the appropriate directory changes.)

Once you have that set up, you should be able to get much more info about where in the archive/unpacking process things are going wrong.