### PR TITLE
Update logger config to support all internal crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,7 +1566,7 @@ dependencies = [
  "textwrap",
  "volta-core",
  "volta-migrate",
- "which 6.0.1",
+ "which",
  "winreg",
 ]
 
@@ -1610,7 +1610,7 @@ dependencies = [
  "validate-npm-package-name",
  "volta-layout",
  "walkdir",
- "which 4.4.2",
+ "which",
  "winreg",
 ]
 
@@ -1713,18 +1713,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
 
 [[package]]
 name = "which"

--- a/crates/volta-core/src/log.rs
+++ b/crates/volta-core/src/log.rs
@@ -15,7 +15,13 @@ const SHIM_WARNING_PREFIX: &str = "Volta warning:";
 const MIGRATION_ERROR_PREFIX: &str = "Volta update error:";
 const MIGRATION_WARNING_PREFIX: &str = "Volta update warning:";
 const VOLTA_LOGLEVEL: &str = "VOLTA_LOGLEVEL";
-const ALLOWED_PREFIX: &str = "volta";
+const ALLOWED_PREFIXES: [&str; 5] = [
+    "volta",
+    "archive",
+    "fs-utils",
+    "progress-read",
+    "validate-npm-package-name",
+];
 const WRAP_INDENT: &str = "    ";
 
 /// Represents the context from which the logger was created
@@ -48,7 +54,13 @@ impl Log for Logger {
     }
 
     fn log(&self, record: &Record) {
-        if self.enabled(record.metadata()) && record.target().starts_with(ALLOWED_PREFIX) {
+        let level_allowed = self.enabled(record.metadata());
+
+        let is_valid_target = ALLOWED_PREFIXES
+            .iter()
+            .any(|prefix| record.target().starts_with(prefix));
+
+        if level_allowed && is_valid_target {
             match record.level() {
                 Level::Error => self.log_error(record.args()),
                 Level::Warn => self.log_warning(record.args()),


### PR DESCRIPTION
Discovered while debugging #1784: we assume a prefix of `"volta"` for all the crates in the repo, but that is simply not reflective of reality!

This raises the question of whether we *want* to standardize on that (which I think would be fine and dandy) or whether we want to collapse some of these smaller crates together, seeing as they are fairly stable and shouldn’t particularly affect our build times (which I *also* think would be fine and dandy), but I think we can defer those for later.