### PR TITLE
infra: enable tracing-level logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "flate2",
  "fs-utils",
  "headers",
+ "log",
  "progress-read",
  "tar",
  "tee",

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -19,3 +19,4 @@ cfg-if = "1.0"
 headers = "0.4"
 thiserror = "1.0.16"
 attohttpc = { version = "0.28", default-features = false, features = ["json", "compress", "tls-rustls-native-roots"] }
+log = { version = "0.4", features = ["std"] }

--- a/crates/volta-core/src/log.rs
+++ b/crates/volta-core/src/log.rs
@@ -1,6 +1,6 @@
 //! This module provides a custom Logger implementation for use with the `log` crate
 use console::style;
-use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
+use log::{trace, Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use std::env;
 use std::fmt::Display;
 use std::io::IsTerminal;
@@ -37,10 +37,12 @@ pub enum LogContext {
 }
 
 /// Represents the level of verbosity that was requested by the user
+#[derive(Debug, Copy, Clone)]
 pub enum LogVerbosity {
     Quiet,
     Default,
     Verbose,
+    VeryVerbose,
 }
 
 pub struct Logger {
@@ -64,9 +66,11 @@ impl Log for Logger {
             match record.level() {
                 Level::Error => self.log_error(record.args()),
                 Level::Warn => self.log_warning(record.args()),
-                Level::Debug => eprintln!("[verbose] {}", record.args()),
                 // all info-level messages go to stdout
-                _ => println!("{}", record.args()),
+                Level::Info => println!("{}", record.args()),
+                // all debug- and trace-level messages go to stderr
+                Level::Debug => eprintln!("[verbose] {}", record.args()),
+                Level::Trace => eprintln!("[trace] {}", record.args()),
             }
         }
     }
@@ -90,6 +94,7 @@ impl Logger {
             LogVerbosity::Quiet => LevelFilter::Error,
             LogVerbosity::Default => level_from_env(),
             LogVerbosity::Verbose => LevelFilter::Debug,
+            LogVerbosity::VeryVerbose => LevelFilter::Trace,
         };
 
         Logger { context, level }
@@ -159,6 +164,7 @@ fn level_from_env() -> LevelFilter {
         .and_then(|level| level.to_uppercase().parse().ok())
         .unwrap_or_else(|| {
             if std::io::stdout().is_terminal() {
+                trace!("using fallback log level (info)");
                 LevelFilter::Info
             } else {
                 LevelFilter::Error

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,6 +25,10 @@ pub(crate) struct Volta {
     #[arg(long, global = true)]
     pub(crate) verbose: bool,
 
+    /// Enables trace-level diagnostics.
+    #[arg(long, global = true, requires = "verbose")]
+    pub(crate) very_verbose: bool,
+
     /// Prevents unnecessary output
     #[arg(
         long,

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,20 @@ pub fn main() {
     let volta = cli::Volta::parse();
     let verbosity = match (&volta.verbose, &volta.quiet) {
         (false, false) => LogVerbosity::Default,
-        (true, false) => LogVerbosity::Verbose,
+        (true, false) => {
+            if volta.very_verbose {
+                LogVerbosity::VeryVerbose
+            } else {
+                LogVerbosity::Verbose
+            }
+        }
         (false, true) => LogVerbosity::Quiet,
         (true, true) => {
             unreachable!("Clap should prevent the user from providing both --verbose and --quiet")
         }
     };
     Logger::init(LogContext::Volta, verbosity).expect("Only a single logger should be initialized");
+    log::trace!("log level: {verbosity:?}");
 
     let mut session = Session::init();
     session.add_event_start(ActivityKind::Volta);


### PR DESCRIPTION
The previous work on this in #1793 made it *possible* to use more log levels; this actually *uses* that new possibility. There is only a single tracing message at present, used to indicate that tracing itself is turned on, but we can use it for any future debugging work. Extracted from #1784, where we used it to help diagnose the issues underlying #1744.