### PR TITLE
v2.0.0

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -11,7 +11,7 @@ Volta currently tests against the following platforms, and will treat it as a br
 We compile release artifacts compatible with the following, and likewise will treat it as a breaking change to drop support for them:
 
 - macOS v11
-- RHEL and CentOS v6
+- RHEL and CentOS v7
 - Windows 10
 
 In general, Volta should build and run against any other modern hardware and operating system supported by stable Rust, and we will make a best effort not to break them. However, we do *not* include them in our SemVer guarantees or test against them.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1548,7 +1548,7 @@ checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 
 [[package]]
 name = "volta"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "cfg-if",
  "ci_info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "volta"
-version = "1.1.1"
+version = "2.0.0"
 authors = ["David Herman <david.herman@gmail.com>", "Charles Pierce <cpierce.grad@gmail.com>"]
 license = "BSD-2-Clause"
 repository = "https://github.com/volta-cli/volta"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,7 +8,7 @@
 - Volta will now use a universal binary on Mac, rather than separate Intel- & ARM-specific builds (#1635)
 - Switched to installing profile scripts into `.zshenv` by default, rather than `.zshrc` (#1657)
 - Added a default shim for the `yarnpkg` command, which is an alias of `yarn` (#1670)
-- Added a new `--very-verbose` flag to enable even more logging (#1815)
+- Added a new `--very-verbose` flag to enable even more logging (note: we haven't yet implemented much additional logging) (#1815)
 - Simplified the fetching process to remove an extra network request and resolve hangs (#1812)
 - Several dependency upgrades and clean-up refactors from @tottoto
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Version 2.0.0
 
-- 🚨 (BREAKING) 🚨 We upgraded the version of Rust used to build Volta, which drops support for older versions of glibc & Linux kernel. See [the Rust announcement](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html) for details about the supported versions. Notably, this means that we no longer support CentOS 6 (#1611)
+- 🚨 (BREAKING) 🚨 We upgraded the version of Rust used to build Volta, which drops support for older versions of glibc & Linux kernel. See [the Rust announcement from August 2022](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html) for details about the supported versions. Notably, this means that we no longer support CentOS 6 (#1611)
 - 🚨 (BREAKING) 🚨 Due to costs and changes in the code signing process, we have dropped the code signing for the Windows installer. We now recommend using `winget` to install Volta on Windows (#1650)
 - 🎉 (NEW) 🎉 We now ship a pre-built binary for ARM Linux & ARM Windows (#1696, #1801)
 - Volta no longer requires Developer Mode to be enabled on Windows (#1755)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,17 @@
+# Version 2.0.0
+
+- 🚨 (BREAKING) 🚨 We upgraded the version of Rust used to build Volta, which drops support for older versions of glibc & Linux kernel. See [the Rust announcement](https://blog.rust-lang.org/2022/08/01/Increasing-glibc-kernel-requirements.html) for details about the supported versions. Notably, this means that we no longer support CentOS 6 (#1611)
+- 🚨 (BREAKING) 🚨 Due to costs and changes in the code signing process, we have dropped the code signing for the Windows installer. We now recommend using `winget` to install Volta on Windows (#1650)
+- 🎉 (NEW) 🎉 We now ship a pre-built binary for ARM Linux & ARM Windows (#1696, #1801)
+- Volta no longer requires Developer Mode to be enabled on Windows (#1755)
+- `volta uninstall` now provides better help & error messages to describe its use and limitations (#1628, #1786)
+- Volta will now use a universal binary on Mac, rather than separate Intel- & ARM-specific builds (#1635)
+- Switched to installing profile scripts into `.zshenv` by default, rather than `.zshrc` (#1657)
+- Added a default shim for the `yarnpkg` command, which is an alias of `yarn` (#1670)
+- Added a new `--very-verbose` flag to enable even more logging (#1815)
+- Simplified the fetching process to remove an extra network request and resolve hangs (#1812)
+- Several dependency upgrades and clean-up refactors from @tottoto
+
 # Version 1.1.1
 
 - Experimental support for pnpm (requires `VOLTA_FEATURE_PNPM` environment variable) (#1273)


### PR DESCRIPTION
Updating Volta itself for the 2.0.0 release. Before merging and releasing, there are a few coordination steps needed:

- [x] Verify if we need to update `volta-cli/action` with the addition of the `yarnpkg` shim
- [x] Update `volta-cli/website` with changes to Windows recommendations (using `winget` for installer and removing the Developer Mode requirement)