### PR TITLE
Update publish job to depend on all build jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - linux
+      - linux-arm
       - macos
       - windows
       - windows-arm


### PR DESCRIPTION
Info
-----
- When we added the ability to build for ARM Linux, we missed a step of updating the `needs` section for the publish CI job.
- This means that the job can potentially start before the ARM Linux build completes, which could then cause it to fail because it tries to download an artifact that hasn't been built yet.

Changes
-----
- Updated the `needs` section to include the `linux-arm` job as well.