### PR TITLE
Update 'zip' to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "archive"
 version = "0.1.0"
 dependencies = [
@@ -159,21 +168,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytecount"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e5f035d16fc623ae5f74981db80a439803888314e3a555fd6f04acd51a3205"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -362,12 +365,18 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -387,6 +396,17 @@ checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
 dependencies = [
  "nix",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -428,6 +448,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -500,9 +531,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -762,6 +793,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,9 +818,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miette"
@@ -822,9 +859,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -1319,6 +1356,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "similar"
@@ -1941,13 +1984,32 @@ checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "2.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "40dd8c92efc296286ce1fbd16657c5dbefff44f1b4ca01cc5f517d8b7b3d3e2e"
 dependencies = [
- "byteorder",
+ "arbitrary",
  "bzip2",
  "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
  "flate2",
+ "indexmap 2.3.0",
+ "memchr",
  "thiserror",
+ "zopfli",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
 ]

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -8,9 +8,10 @@ edition = "2018"
 flate2 = "1.0"
 tar = "0.4.13"
 # Set features manually to drop usage of `time` crate: we do not rely on that
-# set of capabilities, and it has a vulnerability. NOTE: this should be updated
-# to include the `aes-crypto` and `zstd` features when upgrading to v0.6+.
-zip_rs = { version = "0.5", package = "zip", default-features = false, features = ["deflate", "bzip2"] }
+# set of capabilities, and it has a vulnerability. We also don't need to use
+# every single compression algorithm feature since we are only downloading
+# Node as a zip file
+zip_rs = { version = "=2.1.6", package = "zip", default-features = false, features = ["deflate", "bzip2"] }
 tee = "0.1.0"
 fs-utils = { path = "../fs-utils" }
 progress-read = { path = "../progress-read" }

--- a/crates/archive/src/lib.rs
+++ b/crates/archive/src/lib.rs
@@ -3,6 +3,8 @@
 use std::fs::File;
 use std::path::Path;
 
+use attohttpc::header::HeaderMap;
+use headers::{ContentLength, Header, HeaderMapExt};
 use thiserror::Error;
 
 mod tarball;
@@ -91,4 +93,13 @@ cfg_if::cfg_if! {
     } else {
         compile_error!("Unsupported OS (expected 'unix' or 'windows').");
     }
+}
+
+/// Determines the length of an HTTP response's content in bytes, using
+/// the HTTP `"Content-Length"` header.
+fn content_length(headers: &HeaderMap) -> Result<u64, ArchiveError> {
+    headers
+        .typed_get::<ContentLength>()
+        .map(|v| v.0)
+        .ok_or_else(|| ArchiveError::MissingHeaderError(ContentLength::name()))
 }

--- a/crates/archive/src/tarball.rs
+++ b/crates/archive/src/tarball.rs
@@ -5,11 +5,9 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
-use super::{Archive, ArchiveError, Origin};
-use attohttpc::header::HeaderMap;
+use super::{content_length, Archive, ArchiveError, Origin};
 use flate2::read::GzDecoder;
 use fs_utils::ensure_containing_dir_exists;
-use headers::{ContentLength, Header, HeaderMapExt};
 use progress_read::ProgressRead;
 use tee::TeeReader;
 
@@ -18,15 +16,6 @@ pub struct Tarball {
     compressed_size: u64,
     data: Box<dyn Read>,
     origin: Origin,
-}
-
-/// Determines the length of an HTTP response's content in bytes, using
-/// the HTTP `"Content-Length"` header.
-fn content_length(headers: &HeaderMap) -> Result<u64, ArchiveError> {
-    headers
-        .typed_get::<ContentLength>()
-        .map(|v| v.0)
-        .ok_or_else(|| ArchiveError::MissingHeaderError(ContentLength::name()))
 }
 
 impl Tarball {


### PR DESCRIPTION
Info
-----
* With the bump to our MSRV, we can now take advantage of the latest version of `zip`
* Additionally, we can take advantage of `ZipStreamReader`, which is an implementation of a streamed Zip extractor. It's marked as `unstable` so the crate authors recommend that we pin to a specific `zip` version when using it.
* The `ZipStreamReader` lets us greatly simplify the code for fetching & extracting a Zip file, making it much more analogous to the `tarball` code.

Changes
-----
* Updated the version of `zip`, keeping the same features enabled.
* Altered the implementation of `Zip` to take advantage of `ZipStreamReader`

Tested
-----
* Ran Volta locally on Windows and verified that fetching a Node version still works as expected.