### PR TITLE
Remove early-exit check_architecture function from installer

### DIFF
--- a/dev/unix/tests/install-script.bats
+++ b/dev/unix/tests/install-script.bats
@@ -116,39 +116,4 @@ END_CARGO_TOML
   [ "$status" -eq 1 ]
 }
 
-@test "check_architecture" {
-  # Succeeds for local-release and supported arch
-  run check_architecture "local-release" "x86_64"
-  [ "$status" -eq 0 ]
-
-  # Succeeds for local-release and unsupported arch
-  run check_architecture "local-release" "i686"
-  [ "$status" -eq 0 ]
-
-  # Succeeds for local-dev and supported arch
-  run check_architecture "local-dev" "x86_64"
-  [ "$status" -eq 0 ]
-
-  # Succeeds for local-dev and unsupported arch
-  run check_architecture "local-dev" "i686"
-  [ "$status" -eq 0 ]
-
-  # Succeeds for latest and supported arch
-  run check_architecture "latest" "x86_64"
-  [ "$status" -eq 0 ]
-
-  # Fails for latest and unsupported arch
-  run check_architecture "latest" "i686"
-  [ "$status" -ne 0 ]
-
-  # Succeeds for version and supported arch
-  run check_architecture "0.5.0" "x86_64"
-  [ "$status" -eq 0 ]
-
-  # Fails for version and unsupported arch
-  run check_architecture "0.5.0" "i686"
-  [ "$status" -ne 0 ]
-}
-
-
 # TODO: test creating symlinks

--- a/dev/unix/volta-install.sh
+++ b/dev/unix/volta-install.sh
@@ -345,28 +345,6 @@ install_from_file() {
   tar -xf "$archive" -C "$install_dir"/bin
 }
 
-check_architecture() {
-  local version="$1"
-  local arch="$2"
-
-  if [[ "$version" != "local"* ]]; then
-    case "$arch" in
-      x86_64)
-        return 0
-        ;;
-      arm64)
-        if [ "$(uname -s)" = "Darwin" ]; then
-          return 0
-        fi
-        ;;
-    esac
-
-    error "Sorry! Volta currently only provides pre-built binaries for x86_64 architectures."
-    return 1
-  fi
-}
-
-
 # return if sourced (for testing the functions above)
 return 0 2>/dev/null
 
@@ -413,7 +391,5 @@ do
       ;;
   esac
 done
-
-check_architecture "$version_to_install" "$(uname -m)" || exit 1
 
 install_version "$version_to_install" "$install_dir" "$should_run_setup"


### PR DESCRIPTION
Closes #1834 

Info
-----
Early on, we added a fast-fail function `check_architecture` to the installer. This allowed us to detect an unsupported architecture and fail early, rather than continuing and appearing to succeed only for the app to fail.

As of 2.0.0, however, we now support both x64 & ARM on all platforms, so we check the architecture as part of the normal install process. This means that the early exit is no longer necessary—an unsupported architecture will still be caught by the `parse_os_info` function before any download occurs.

Changes
-----
* Removed the `check_architecture` function and any calls to it from the installer
* Removed the tests of `check_architecture`

Tested
-----
* Ran the script locally and verified that it still downloaded the appropriate version of Volta.