### PR TITLE
Move pin suggestion CTA to the project version message

### DIFF
--- a/crates/volta-core/src/tool/mod.rs
+++ b/crates/volta-core/src/tool/mod.rs
@@ -28,36 +28,31 @@ pub use pnpm::Pnpm;
 pub use registry::PackageDetails;
 pub use yarn::Yarn;
 
-#[inline]
-fn debug_already_fetched<T: Display + Sized>(tool: T) {
+fn debug_already_fetched<T: Display>(tool: T) {
     debug!("{} has already been fetched, skipping download", tool);
 }
 
-#[inline]
-fn info_installed<T: Display + Sized>(tool: T) {
+fn info_installed<T: Display>(tool: T) {
     info!("{} installed and set {tool} as default", success_prefix());
+}
+
+fn info_fetched<T: Display>(tool: T) {
+    info!("{} fetched {tool}", success_prefix());
+}
+
+fn info_pinned<T: Display>(tool: T) {
+    info!("{} pinned {tool} in package.json", success_prefix());
+}
+
+fn info_project_version<P, D>(project_version: P, default_version: D)
+where
+    P: Display,
+    D: Display,
+{
     info!(
-        "{} to use {tool} in this project run `volta pin {tool}`",
-        success_prefix()
-    );
-}
-
-#[inline]
-fn info_fetched<T: Display + Sized>(tool: T) {
-    info!("{} fetched {}", success_prefix(), tool);
-}
-
-#[inline]
-fn info_pinned<T: Display + Sized>(tool: T) {
-    info!("{} pinned {} in package.json", success_prefix(), tool);
-}
-
-#[inline]
-fn info_project_version<T: Display + Sized>(tool: T) {
-    info!(
-        "{} you are using {} in the current project",
-        note_prefix(),
-        tool
+        r#"{} you are using {project_version} in the current project; to
+         instead use {default_version}, run `volta pin {default_version}`"#,
+        note_prefix()
     );
 }
 

--- a/crates/volta-core/src/tool/node/mod.rs
+++ b/crates/volta-core/src/tool/node/mod.rs
@@ -229,7 +229,7 @@ impl Tool for Node {
         // Instead we should check if the bundled version is higher than the default and inform the user
         // Note: The previous line ensures that there will be a default platform
         if let Some(default_npm) = &default_toolchain.platform().unwrap().npm {
-            info_installed(self); // includes node version
+            info_installed(&self); // includes node version
 
             if node_version.npm > *default_npm {
                 info!("{} this version of Node includes {}, which is higher than your default version ({}).
@@ -246,7 +246,7 @@ impl Tool for Node {
         check_shim_reachable("node");
 
         if let Ok(Some(project)) = session.project_platform() {
-            info_project_version(tool_version("node", &project.node));
+            info_project_version(tool_version("node", &project.node), &self);
         }
 
         Ok(())

--- a/crates/volta-core/src/tool/npm/mod.rs
+++ b/crates/volta-core/src/tool/npm/mod.rs
@@ -63,12 +63,12 @@ impl Tool for Npm {
             .toolchain_mut()?
             .set_active_npm(Some(self.version.clone()))?;
 
-        info_installed(self);
+        info_installed(&self);
         check_shim_reachable("npm");
 
         if let Ok(Some(project)) = session.project_platform() {
             if let Some(npm) = &project.npm {
-                info_project_version(tool_version("npm", npm));
+                info_project_version(tool_version("npm", npm), &self);
             }
         }
         Ok(())

--- a/crates/volta-core/src/tool/pnpm/mod.rs
+++ b/crates/volta-core/src/tool/pnpm/mod.rs
@@ -8,8 +8,8 @@ use crate::style::tool_version;
 use crate::sync::VoltaLock;
 
 use super::{
-    check_fetched, debug_already_fetched, info_fetched, info_installed, info_pinned,
-    info_project_version, FetchStatus, Tool,
+    check_fetched, check_shim_reachable, debug_already_fetched, info_fetched, info_installed,
+    info_pinned, info_project_version, FetchStatus, Tool,
 };
 
 mod fetch;
@@ -63,11 +63,12 @@ impl Tool for Pnpm {
             .toolchain_mut()?
             .set_active_pnpm(Some(self.version.clone()))?;
 
-        info_installed(self);
+        info_installed(&self);
+        check_shim_reachable("pnpm");
 
         if let Ok(Some(project)) = session.project_platform() {
             if let Some(pnpm) = &project.pnpm {
-                info_project_version(tool_version("pnpm", pnpm));
+                info_project_version(tool_version("pnpm", pnpm), &self);
             }
         }
         Ok(())

--- a/crates/volta-core/src/tool/yarn/mod.rs
+++ b/crates/volta-core/src/tool/yarn/mod.rs
@@ -62,12 +62,12 @@ impl Tool for Yarn {
             .toolchain_mut()?
             .set_active_yarn(Some(self.version.clone()))?;
 
-        info_installed(self);
+        info_installed(&self);
         check_shim_reachable("yarn");
 
         if let Ok(Some(project)) = session.project_platform() {
             if let Some(yarn) = &project.yarn {
-                info_project_version(tool_version("yarn", yarn));
+                info_project_version(tool_version("yarn", yarn), &self);
             }
         }
         Ok(())


### PR DESCRIPTION
Closes #1847 

Info
-----
Currently, the call-to-action suggestion to use `volta pin` is printed as part of the "success" message on every call to `volta install`. However, that message is confusing when you aren't in a project. Additionally, it's only necessary if the current project itself has a pinned version of the tool.

We actually already have a message sent after installing if the project has an overlapping version: a note that the local version is different. This message seems like the ideal place to have the CTA, so that it lets users know what they can do to update the local version in case that's what they intended.

Changes
-----
* Removed the `volta pin` CTA from the `info_installed` message
* Updated the `info_project_version` message to include a `volta pin` CTA
* Updated calls to `info_project_version` to include the information about the newly-installed version as well.
* Cleaned up some of the generic requirements and removed some unnecessary `#[inline]` attributes.

Tested
-----
* Ran locally both in and out of a package to verify the messages make sense in all scenarios

Screenshots
-----
<details>
<summary>Outside of a package</summary>

<img alt="Volta message when run outside of a package" src="https://github.com/user-attachments/assets/e47215d2-b922-4ea1-ab2e-b6bcb101a910">
</details>

<details>
<summary>Inside a package with no pinned version</summary>

<img alt="Volta message when run in a package without a pinned version" src="https://github.com/user-attachments/assets/f1ef747c-1920-48c9-ad6c-6d1837f67192">
</details>

<details>
<summary>Inside a package with a pinned version</summary>

<img alt="Volta message when run in a package with a pinned version" src="https://github.com/user-attachments/assets/2bf602a4-8f49-405b-a34f-5e70dececae8">
</details>