### PR TITLE
Enable fat link-time optimizations in release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ path = "src/volta-shim.rs"
 name = "volta-migrate"
 path = "src/volta-migrate.rs"
 
+[profile.release]
+lto = "fat"
+codegen-units = 1
+
 [dependencies]
 volta-core = { path = "crates/volta-core" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Info
-----
* Despite putting a large focus on performance (and to some extent, binary size), we haven't taken advantage of Rust's ability to enable link-time optimizations (LTO).
* These optimizations can improve performance and reduce binary size, at the cost of taking longer at compilation.

Changes
-----
* Updated `Cargo.toml` to enable fat LTO in release builds of Volta
* Also added `codegen-units = 1`, which is another setting which increases final performance at the cost of compile time (see [the Rust Performance Book](https://nnethercote.github.io/perf-book/build-configuration.html) for more details).

Tested
-----
* On Windows, this results in an ~10% reduction in binary size. I didn't see any significant performance difference.
* On macOS (M2 Max), I see ~25% reduction in binary size (!) and ~5% faster performance for a simple test.
* The CI builds take slightly longer, but not massively so to the point where running them with full optimizations would impact PRs.