### PR TITLE
Prevent GitHub Action from overriding RUSTFLAGS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up cargo
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          rustflags: ""
       - name: Add cargo-wix subcommand
         run: cargo install cargo-wix
       - name: Compile and package installer
@@ -110,6 +112,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: aarch64-pc-windows-msvc
+          rustflags: ""
       - name: Add cargo-wix subcommand
         run: cargo install cargo-wix
       - name: Compile and package installer


### PR DESCRIPTION
Info
-----
* When trying to publish v2.0.1 to Winget, there was an automated message about the install failing because it didn't have the Visual C Runtime.
* However, we should have fixed that in #1844 
* It turns out that the `setup-rust-toolchain` action we use will, by default, set a `RUSTFLAGS` environment variable.
* Then, per [the docs](https://github.com/actions-rust-lang/setup-rust-toolchain?tab=readme-ov-file#rustflags), that variable will override any `.cargo/config.toml` setting we have, which is how we set the app to statically link.
* As a result, the CI-built version of Volta actually _isn't_ currently statically linked to the C Runtime.

Changes
-----
* Updated the CI job following the suggestion in `setup-rust-toolchain` to set `rustflags` to an empty string, which prevents the job from overriding it.

Tested
-----
* Downloaded the built version from this PR locally and validated that it does _not_ depend on the Visual C Runtime any more.