### PR TITLE
Add a step to CI that validates the installer checksum

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,14 @@ jobs:
       - name: Run check
         run: |
           cargo fmt --all --quiet -- --check
+
+  validate-installer-checksum:
+    name: Validate installer checksum
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Run check
+        run: |
+          cd dev/unix
+          sha256sum --check SHASUMS256.txt


### PR DESCRIPTION
Info
-----
* Noted in #1861, we need to update the SHASUMS256.txt file for the installer script whenever we make changes to the installer.
* This adds a simple CI check that verifies the checksum to run on PRs, so that we can't forget to update the hash.

Changes
-----
* Added a new CI job that validates the checksum

Tested
-----
* Tested in this PR that the job passes when there are no changes to `volta-install.sh` and fails when there are changes that don't also update the `SHASUMS256.txt` file.