### PR TITLE
Use lockfile when installing cargo-wix in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           rustflags: ""
       - name: Add cargo-wix subcommand
-        run: cargo install cargo-wix
+        run: cargo install --locked cargo-wix
       - name: Compile and package installer
         run: |
           cargo wix --nocapture --package volta --output target\wix\volta-windows.msi
@@ -114,7 +114,7 @@ jobs:
           target: aarch64-pc-windows-msvc
           rustflags: ""
       - name: Add cargo-wix subcommand
-        run: cargo install cargo-wix
+        run: cargo install --locked cargo-wix
       - name: Compile and package installer
         run: |
           cargo wix --nocapture --package volta --target aarch64-pc-windows-msvc --output target\wix\volta-windows-arm.msi


### PR DESCRIPTION
Info
-----

When installing a package using `cargo install`, by default it ignores the lockfile for that package and installs the latest relevant dependency versions. This can be overridden by using the `--locked` flag.

Using an unlocked install is causing issues in CI, because we have our Rust version pinned to a version that is older than the MSRV for some of `cargo-wix`'s dependencies. Switching to a locked install means that the dependency versions will be repeatable and so we shouldn't have issues with Rust version mismatches.

Changes
-----
* Updated the CI task that installs `cargo wix` to use the `--locked` flag

Tested
-----
* Validating in CI

Notes
-----
* See [the Cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile) for more info about the `--locked` flag.