### PR TITLE
chore: remove legacy numeric constant import

### DIFF
--- a/crates/test-support/src/matchers.rs
+++ b/crates/test-support/src/matchers.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::process::Output;
 use std::str;
-use std::usize;
 
 use crate::process::ProcessBuilder;
 


### PR DESCRIPTION
Removes the legacy numeric constant import.