### PR TITLE
chore: fix Cargo.lock file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,7 +1646,7 @@ dependencies = [
  "volta-core",
  "volta-migrate",
  "which",
- "winreg 0.52.0",
+ "winreg",
 ]
 
 [[package]]
@@ -1690,7 +1690,7 @@ dependencies = [
  "volta-layout",
  "walkdir",
  "which",
- "winreg 0.53.0",
+ "winreg",
 ]
 
 [[package]]
@@ -1993,26 +1993,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47b489f8fc5b949477e89dca4d1617f162c6c53fbcbefde553ab17b342ff9"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "winreg"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a47b489f8fc5b949477e89dca4d1617f162c6c53fbcbefde553ab17b342ff9"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "winreg"


### PR DESCRIPTION
Fixes the `Cargo.lock` file.

```
error: failed to parse lock file at: /Users/runner/work/volta/volta/Cargo.lock

Caused by:
  package `winreg` is specified twice in the lockfile
```