### PR TITLE
chore: fixed typo in run.rs

### DIFF
--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -24,7 +24,7 @@ pub(crate) struct Run {
     #[arg(long, conflicts_with = "npm")]
     bundled_npm: bool,
 
-    /// Set the custon pnpm version
+    /// Set the custom pnpm version
     #[arg(long, value_name = "version", conflicts_with = "no_pnpm")]
     pnpm: Option<String>,
 


### PR DESCRIPTION
The typo exists in the completions output.